### PR TITLE
feat(components): add Specifications list

### DIFF
--- a/components/content/index.js
+++ b/components/content/index.js
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { Heading } from "../heading-anchor/index.js";
+import { SpecificationsList } from "../specifications-list/index.js";
 
 import "./index.css";
 
@@ -23,8 +24,10 @@ export function Section({ type, value }) {
     case "browser_compatibility": {
       return BCD(value);
     }
+    case "specifications": {
+      return SpecificationsSection(value);
+    }
     default: {
-      // @ts-ignore
       return Prose(value);
     }
   }
@@ -50,5 +53,16 @@ function BCD({ id, title, query, isH3 }) {
   return html`<section aria-labelledby=${id}>
     ${Heading(level, id ? String(id) : null, String(title))}
     <lazy-compat-table locale="en-US" query=${query}></lazy-compat-table>
+  </section>`;
+}
+
+/**
+ * @param {import("@mdn/rari").SpecificationSection} section
+ */
+function SpecificationsSection({ id, title, specifications, isH3 }) {
+  const level = isH3 ? 3 : 2;
+  return html`<section aria-labelledby=${id}>
+    ${Heading(level, id ? String(id) : null, String(title))}
+    ${SpecificationsList(specifications)}
   </section>`;
 }

--- a/components/specifications-list/index.js
+++ b/components/specifications-list/index.js
@@ -1,0 +1,28 @@
+import { html } from "lit";
+
+/**
+ * @param {import("@mdn/rari").Specification[]} specifications
+ */
+export function SpecificationsList(specifications) {
+  if (specifications.length === 0) {
+    return html`This feature does not appear to be defined in any specification.`;
+  }
+
+  return html`This feature is defined in the following
+    <a href="/en-US/docs/Glossary/Specification">specifications</a>:
+    <ul>
+      ${specifications.map(
+        (spec) =>
+          html`<li>
+            <a
+              class="external"
+              href=${spec.bcdSpecificationURL}
+              rel="noopener"
+              target="_blank"
+              >${spec.title}<br />
+              <small># ${spec.bcdSpecificationURL.split("#")[1]}</small></a
+            >
+          </li>`,
+      )}
+    </ul>`;
+}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds a server-side `SpecificationsList()` component.

### Motivation

Implements the Specifications section.

### Additional details

| Yari | Fred |
|--------|--------|
| <img width="643" alt="image" src="https://github.com/user-attachments/assets/df031053-aa2a-48b6-90d4-ecc9d2933b92" /> | <img width="643" alt="image" src="https://github.com/user-attachments/assets/3fc3997b-0626-4a64-9c1e-1a2dad0fa4ad" /> | 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

