### PR TITLE
Ignore local .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out/
 .eslintcache
 .stylelintcache
 .DS_Store
+.env


### PR DESCRIPTION
### Description

Given the instruction in the readme:

> 1. Copy `.env-dist` to `.env` and update

It would be right to ignore the local copy.