### PR TITLE
Breadcrumb styling & greys

### DIFF
--- a/components/breadcrumbs/index.css
+++ b/components/breadcrumbs/index.css
@@ -3,18 +3,30 @@
 .breadcrumbs {
   --breadcrumbs-side-padding: 1rem;
 
+  /* these colors should go globally - these are the greys */
+  --color-grey-light-super: hsl(212deg 7% 98%);
+  --color-grey-light: hsl(212deg 7% 93%);
+  --color-grey-mid-light: hsl(212deg 7% 80%);
+  --color-grey-mid-dark: hsl(212deg 7% 26%);
+  --color-grey-dark: hsl(212deg 7% 16%);
+  --color-grey-dark-super: hsl(212deg 7% 12%);
+
   display: grid;
 
-  grid-template-columns: 1fr min-content min-content;
+  grid-template-columns: 1fr repeat(4, max-content);
 
   column-gap: 1rem;
   align-items: center;
 
-  padding-block: 0.5rem;
+  padding-block: 0.2rem;
   padding-inline: var(--breadcrumbs-side-padding);
 
-  background-color: var(--color-background-secondary);
-  border-block-end: 1px solid var(--color-text-secondary);
+  background-color: light-dark(
+    var(--color-grey-light-super),
+    var(--color-grey-dark-super)
+  );
+  border-block-end: 1px solid
+    light-dark(var(--color-grey-mid-light), var(--color-grey-mid-dark));
 
   @media (width > 1440px) {
     padding-inline: calc(
@@ -47,8 +59,62 @@
       }
 
       svg {
-        color: var(--color-text-secondary);
+        color: light-dark(
+          var(--color-grey-mid-light),
+          var(--color-grey-mid-dark)
+        );
       }
     }
+  }
+
+  /* right side 'buttons' these are styled the same as the color-theme component */
+  div[class^="breadcrumbs__"] {
+    display: flex;
+
+    column-gap: 0.25rem;
+    align-items: center;
+
+    padding: 0 0.5rem;
+
+    background-color: transparent;
+    border-radius: 2px;
+
+    &:hover {
+      background-color: light-dark(
+        var(--color-grey-mid-light),
+        var(--color-grey-mid-dark)
+      );
+    }
+  }
+}
+
+.mdn-search {
+  position: relative;
+
+  display: flex;
+
+  flex-direction: row-reverse;
+
+  align-items: center;
+
+  width: 5rem;
+
+  padding: 0.5rem;
+
+  border: 1px solid
+    light-dark(var(--color-grey-mid-dark), var(--color-grey-mid-light));
+  border-radius: 2rem;
+
+  &::before {
+    position: absolute;
+    right: 64%;
+    bottom: 0.5rem;
+    left: 14%;
+
+    height: 2px;
+
+    content: "";
+
+    background-color: var(--color-text-blue);
   }
 }

--- a/components/breadcrumbs/index.js
+++ b/components/breadcrumbs/index.js
@@ -35,7 +35,81 @@ export function BreadCrumbs(context) {
     <ul>
       ${items}
     </ul>
-    <div class="breadcrumbs__collection">Collection</div>
-    <div class="breadcrumbs__language">Language</div>
+    <button class="mdn-search" title="Search the site">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="6.5"
+          cy="6.5"
+          r="5.75"
+          stroke="#4E4E4E"
+          stroke-width="1.5"
+        />
+        <line
+          x1="11.0607"
+          y1="11"
+          x2="15"
+          y2="14.9393"
+          stroke="#4E4E4E"
+          stroke-width="1.5"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
+    <mdn-color-theme></mdn-color-theme>
+    <div class="breadcrumbs__collection">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.41603 11.376L8 11.0986L7.58397 11.376L2.75 14.5986V2C2.75 1.30964 3.30964 0.75 4 0.75H12C12.6904 0.75 13.25 1.30964 13.25 2V14.5986L8.41603 11.376Z"
+          stroke="#4E4E4E"
+          stroke-width="1.5"
+        />
+      </svg>
+      Save
+    </div>
+    <div class="breadcrumbs__language">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="8" cy="8" r="7.25" stroke="#4E4E4E" stroke-width="1.5" />
+        <path
+          d="M8 15.25C7.7649 15.25 7.48181 15.1442 7.15894 14.8321C6.83246 14.5165 6.50419 14.0235 6.21224 13.3562C5.62932 12.0239 5.25 10.1307 5.25 8C5.25 5.86928 5.62932 3.97615 6.21224 2.64376C6.50419 1.97645 6.83246 1.48352 7.15894 1.16789C7.48181 0.855751 7.7649 0.75 8 0.75C8.2351 0.75 8.51819 0.855751 8.84106 1.16789C9.16754 1.48352 9.49581 1.97645 9.78776 2.64376C10.3707 3.97615 10.75 5.86928 10.75 8C10.75 10.1307 10.3707 12.0239 9.78776 13.3562C9.49581 14.0235 9.16754 14.5165 8.84106 14.8321C8.51819 15.1442 8.2351 15.25 8 15.25Z"
+          stroke="#4E4E4E"
+          stroke-width="1.5"
+        />
+        <line
+          x1="1"
+          y1="5.75"
+          x2="15"
+          y2="5.75"
+          stroke="#4E4E4E"
+          stroke-width="1.5"
+        />
+        <line
+          x1="1"
+          y1="10.25"
+          x2="15"
+          y2="10.25"
+          stroke="#4E4E4E"
+          stroke-width="1.5"
+        />
+      </svg>
+      English (US)
+    </div>
   </div>`;
 }

--- a/components/color-theme/index.css
+++ b/components/color-theme/index.css
@@ -8,7 +8,7 @@
   column-gap: 0.25rem;
   align-items: center;
 
-  padding: 0.5rem;
+  padding: 0 0.5rem;
   margin: 0;
 
   font: inherit;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

First pass at styling the breadcrumb bar - notable things
- Reviewed the site for greys and suggested 6 greys which should be global are in the component
- Styled a button for search use - agreed to keep the input but move the button code to the search component commented out incase we change our mind - `mdn-search`
- Search should stay in top part of header and removed from breadcrumb bar - theme, save & language in breadcrumb bar
- We will show breadcrumbs on every page

