### PR TITLE
fix(dev): use worker to invalidate esm cache

### DIFF
--- a/build/server-worker.js
+++ b/build/server-worker.js
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { parentPort, workerData } from "node:worker_threads";
+
+import "source-map-support/register.js";
+
+/** @type {import("./types.js").WorkerData} */
+const { reqPath, page, compliationStats } = workerData;
+
+const ssrStats = compliationStats.find((x) => x.name === "ssr");
+if (!ssrStats) {
+  throw new Error(
+    "cannot find the ssr rspack config, did you change its name?",
+  );
+}
+const { outputPath, entrypoints } = ssrStats;
+const outputName = entrypoints?.index?.assets?.find(
+  ({ name }) => name.startsWith("index.") && name.endsWith(".js"),
+)?.name;
+const indexModulePath =
+  outputPath && outputName && path.join(outputPath, outputName);
+if (!indexModulePath) {
+  throw new Error(
+    "cannot find ssr entrypoint, did you change output.path or output.name in the rspack config?",
+  );
+}
+
+try {
+  /** @type {import("../entry.ssr.js")} */
+  const indexModule = await import(indexModulePath);
+  const html = await indexModule?.render(reqPath, page, compliationStats);
+  parentPort?.postMessage({ html });
+} catch (error) {
+  parentPort?.postMessage({ error });
+}

--- a/build/types.d.ts
+++ b/build/types.d.ts
@@ -1,0 +1,8 @@
+import { BuiltPage } from "@mdn/rari";
+import { StatsCompilation } from "@rspack/core";
+
+export interface WorkerData {
+  reqPath: string;
+  page: BuiltPage;
+  compliationStats: StatsCompilation[];
+}

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -114,7 +114,7 @@ export default [
     ],
     output: {
       path: path.resolve(__dirname, "dist/ssr"),
-      filename: isProd ? "[name].js" : "[name].[contenthash].js",
+      filename: "[name].js",
       // use proper file names in sourcemaps:
       devtoolModuleFilenameTemplate: (info) =>
         path.resolve(info.absoluteResourcePath),


### PR DESCRIPTION
should fix weird bugs with undoing changes locally
should also fix bugs where the global js state gets into a weird state
