### PR TITLE
fix: clean up TODOs from server components work

### DIFF
--- a/build/server-worker.js
+++ b/build/server-worker.js
@@ -24,10 +24,17 @@ if (!indexModulePath) {
   );
 }
 
+const clientStats = compliationStats.find((x) => x.name === "client");
+if (!clientStats) {
+  throw new Error(
+    "cannot find the client rspack config, did you change its name?",
+  );
+}
+
 try {
   /** @type {import("../entry.ssr.js")} */
   const indexModule = await import(indexModulePath);
-  const html = await indexModule?.render(reqPath, page, compliationStats);
+  const html = await indexModule?.render(reqPath, page, clientStats);
   parentPort?.postMessage({ html });
 } catch (error) {
   parentPort?.postMessage({ error });

--- a/build/ssr.js
+++ b/build/ssr.js
@@ -7,11 +7,7 @@ import { render } from "../dist/ssr/index.js";
 const BUILD_OUT_ROOT = "./out";
 
 /** @type {import("@rspack/core").StatsCompilation} */
-const ssrStats = JSON.parse(await readFile("./dist/ssr/stats.json", "utf8"));
-/** @type {import("@rspack/core").StatsCompilation} */
-const clientStats = JSON.parse(
-  await readFile("./dist/client/stats.json", "utf8"),
-);
+const manifest = JSON.parse(await readFile("./dist/client/stats.json", "utf8"));
 
 /**
  * @template T
@@ -85,16 +81,7 @@ async function ssrSingleDocument(file) {
     return;
   }
   try {
-    const html = await render(context.url, context, [
-      {
-        name: "ssr",
-        ...ssrStats,
-      },
-      {
-        name: "client",
-        ...clientStats,
-      },
-    ]);
+    const html = await render(context.url, context, manifest);
     const outputFile = file.replace(/.json$/, ".html");
     await writeFile(outputFile, html);
     return outputFile;

--- a/components/article-footer/index.js
+++ b/components/article-footer/index.js
@@ -1,6 +1,6 @@
 import { html } from "lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 import svg from "./article-footer.svg?lit";
 

--- a/components/banner/index.js
+++ b/components/banner/index.js
@@ -1,6 +1,6 @@
 import { html } from "lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Banner extends ServerComponent {
   render() {

--- a/components/baseline-indicator/index.js
+++ b/components/baseline-indicator/index.js
@@ -1,6 +1,6 @@
 import { html, nothing } from "lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 /**
  * @type {{ name: string, browsers: Baseline.BrowserGroup[] }[]}

--- a/components/blog-index/index.js
+++ b/components/blog-index/index.js
@@ -3,7 +3,7 @@ import { html, nothing } from "lit";
 import { AuthorDateReadTime, BlogContainer } from "../blog/index.js";
 import { Button } from "../button/index.js";
 import { PageLayout } from "../page-layout/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 /**
  * @param {Fred.Context} _context

--- a/components/blog-post/index.js
+++ b/components/blog-post/index.js
@@ -5,7 +5,7 @@ import { PageLayout } from "../../components/page-layout/index.js";
 import { ReferenceToc } from "../../components/reference-toc/index.js";
 import { AuthorDateReadTime, BlogContainer } from "../blog/index.js";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 /**
  * @param {Fred.Context} _context

--- a/components/breadcrumbs/index.js
+++ b/components/breadcrumbs/index.js
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 
 import bookmarkSvg from "../icon/bookmark.svg?lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 import dividerSvg from "./divider.svg?lit";
 

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -1,4 +1,4 @@
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 import PureButton from "./pure.js";
 

--- a/components/content/index.js
+++ b/components/content/index.js
@@ -5,7 +5,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { ArticleFooter } from "../article-footer/index.js";
 import { BaselineIndicator } from "../baseline-indicator/index.js";
 import { HeadingAnchor } from "../heading-anchor/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 import { SpecificationsList } from "../specifications-list/index.js";
 
 export class Content extends ServerComponent {

--- a/components/contributor-spotlight/index.js
+++ b/components/contributor-spotlight/index.js
@@ -2,7 +2,7 @@ import { html } from "lit";
 
 import { Section } from "../../components/content/index.js";
 import { PageLayout } from "../../components/page-layout/index.js";
-import { ServerComponent } from "../../components/server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class ContributorSpotlight extends ServerComponent {
   /**

--- a/components/curriculum/index.js
+++ b/components/curriculum/index.js
@@ -2,7 +2,7 @@ import { html } from "lit";
 
 import { Section } from "../../components/content/index.js";
 import { PageLayout } from "../../components/page-layout/index.js";
-import { ServerComponent } from "../../components/server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Curriculum extends ServerComponent {
   /**

--- a/components/doc/index.js
+++ b/components/doc/index.js
@@ -1,6 +1,6 @@
 import { PageLayout } from "../../components/page-layout/index.js";
 import { ReferenceLayout } from "../../components/reference-layout/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Doc extends ServerComponent {
   /**

--- a/components/footer/index.js
+++ b/components/footer/index.js
@@ -6,7 +6,7 @@ import mastodon from "../icon/mastodon.svg?lit";
 import rss from "../icon/rss.svg?lit";
 import x from "../icon/x.svg?lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 import mdn from "./mdn.svg?lit";
 import mozilla from "./mozilla.svg?lit";

--- a/components/generic/index.js
+++ b/components/generic/index.js
@@ -2,7 +2,7 @@ import { html } from "lit";
 
 import { Section } from "../../components/content/index.js";
 import { PageLayout } from "../../components/page-layout/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Generic extends ServerComponent {
   /**

--- a/components/heading-anchor/index.js
+++ b/components/heading-anchor/index.js
@@ -2,7 +2,7 @@ import { nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { html as hh, unsafeStatic } from "lit/static-html.js";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class HeadingAnchor extends ServerComponent {
   /**

--- a/components/home-page/index.js
+++ b/components/home-page/index.js
@@ -1,7 +1,7 @@
 import { html, nothing } from "lit";
 
 import { PageLayout } from "../../components/page-layout/index.js";
-import { ServerComponent } from "../../components/server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class HomePage extends ServerComponent {
   /**

--- a/components/left-sidebar/index.js
+++ b/components/left-sidebar/index.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class LeftSidebar extends ServerComponent {
   /**

--- a/components/logo/index.js
+++ b/components/logo/index.js
@@ -1,6 +1,6 @@
 import { html } from "lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Logo extends ServerComponent {
   /**

--- a/components/menu/index.js
+++ b/components/menu/index.js
@@ -1,6 +1,6 @@
 import { html } from "lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Menu extends ServerComponent {
   /**

--- a/components/navigation/index.js
+++ b/components/navigation/index.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { Logo } from "../logo/index.js";
 import { Menu } from "../menu/index.js";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Navigation extends ServerComponent {
   /**

--- a/components/not-found/index.js
+++ b/components/not-found/index.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 
 import { PageLayout } from "../page-layout/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class NotFound extends ServerComponent {
   /**

--- a/components/observatory-landing/index.js
+++ b/components/observatory-landing/index.js
@@ -8,7 +8,7 @@ import securitySvg from "../observatory/assets/security.svg?lit";
 
 import { PageLayout } from "../page-layout/index.js";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 import { FAQ } from "./faq.js";
 import { Feedback } from "./feedback.js";

--- a/components/observatory-results/index.js
+++ b/components/observatory-results/index.js
@@ -2,7 +2,7 @@ import { html } from "lit";
 
 import { Feedback } from "../observatory-landing/feedback.js";
 import { PageLayout } from "../page-layout/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class ObservatoryResults extends ServerComponent {
   /**

--- a/components/outer-layout/index.js
+++ b/components/outer-layout/index.js
@@ -9,29 +9,17 @@ export class OuterLayout extends ServerComponent {
   /**
    * @param {Fred.Context} context
    * @param {import("lit-html").TemplateResult} markup
-   * @param {import("@rspack/core").StatsCompilation[]} manifest
+   * @param {import("@rspack/core").StatsCompilation} manifest
    * @param {Set<string>} components
    */
   render(context, markup, manifest, components) {
-    const { styleTags: ssrStyleTags } = this.tagsFromManifest(
-      manifest.find((x) => x.name === "ssr"),
-    );
-    const { scriptTags: clientScriptTags, styleTags: clientStyleTags } =
-      this.tagsFromManifest(manifest.find((x) => x.name === "client"));
-    const componentStyleTags = [...components].flatMap(
+    const { scriptTags } = this.tagsFromManifest(manifest);
+    const styleTags = ["global", ...components].flatMap(
       (component) =>
-        this.tagsFromManifest(
-          manifest.find((x) => x.name === "ssr"),
-          `styles-${toCamelCase(component)}`,
-        ).styleTags,
+        this.tagsFromManifest(manifest, `styles-${toCamelCase(component)}`)
+          .styleTags,
     );
 
-    const tags = [
-      ssrStyleTags,
-      clientScriptTags,
-      clientStyleTags,
-      ...componentStyleTags,
-    ];
     return html`
       <!doctype html>
       <html lang="en" style="color-scheme: light dark;">
@@ -41,7 +29,8 @@ export class OuterLayout extends ServerComponent {
             name="viewport"
             content="width=device-width, initial-scale=1.0"
           />
-          ${unsafeHTML(`<script>${inlineScript}</script>`)} ${tags}
+          ${unsafeHTML(`<script>${inlineScript}</script>`)} ${styleTags}
+          ${scriptTags}
           <title>${context.pageTitle || "MDN"}</title>
         </head>
         ${markup}

--- a/components/outer-layout/index.js
+++ b/components/outer-layout/index.js
@@ -3,7 +3,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { toCamelCase } from "../../build/utils.js";
 import inlineScript from "../../entry.inline.js?source&csp=true";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class OuterLayout extends ServerComponent {
   /**

--- a/components/page-layout/index.js
+++ b/components/page-layout/index.js
@@ -4,7 +4,7 @@ import { Banner } from "../banner/index.js";
 import { Breadcrumbs } from "../breadcrumbs/index.js";
 import { Footer } from "../footer/index.js";
 import { Navigation } from "../navigation/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class PageLayout extends ServerComponent {
   /**

--- a/components/reference-layout/index.js
+++ b/components/reference-layout/index.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { Content } from "../content/index.js";
 import { LeftSidebar } from "../left-sidebar/index.js";
 import { ReferenceToc } from "../reference-toc/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class ReferenceLayout extends ServerComponent {
   /**

--- a/components/reference-toc/index.js
+++ b/components/reference-toc/index.js
@@ -1,6 +1,6 @@
 import { html } from "lit";
 
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class ReferenceToc extends ServerComponent {
   /**

--- a/components/search/index.js
+++ b/components/search/index.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 
 import { PageLayout } from "../../components/page-layout/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Search extends ServerComponent {
   /**

--- a/components/server/async-local-storage.js
+++ b/components/server/async-local-storage.js
@@ -1,0 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** @type {AsyncLocalStorage<{ componentsUsed: Set<string> }>} */
+export const asyncLocalStorage = new AsyncLocalStorage();

--- a/components/server/index.js
+++ b/components/server/index.js
@@ -1,4 +1,4 @@
-import { getSymmetricContext } from "../symmetric-context/both.js";
+import { getSymmetricContext } from "../../symmetric-context/both.js";
 
 export class ServerComponent {
   /**

--- a/components/server/index.js
+++ b/components/server/index.js
@@ -1,4 +1,4 @@
-import { getSymmetricContext } from "../../symmetric-context/both.js";
+import { asyncLocalStorage } from "./async-local-storage.js";
 
 export class ServerComponent {
   /**
@@ -8,7 +8,7 @@ export class ServerComponent {
    * @returns {ReturnType<InstanceType<T>["render"]>}
    */
   static render(...args) {
-    getSymmetricContext().serverComponents?.add(this.name);
+    asyncLocalStorage.getStore()?.componentsUsed?.add(this.name);
     return new this().render(...args);
   }
 

--- a/components/settings/index.js
+++ b/components/settings/index.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { Breadcrumbs } from "../../components/breadcrumbs/index.js";
 import { Footer } from "../../components/footer/index.js";
 import { Navigation } from "../../components/navigation/index.js";
-import { ServerComponent } from "../server.js";
+import { ServerComponent } from "../server/index.js";
 
 export class Settings extends ServerComponent {
   /**

--- a/entry.ssr.js
+++ b/entry.ssr.js
@@ -22,7 +22,7 @@ import { runWithContext } from "./symmetric-context/server.js";
 /**
  * @param {string} path
  * @param {Rari.BuiltPage} page
- * @param {import("@rspack/core").StatsCompilation[]} manifest
+ * @param {import("@rspack/core").StatsCompilation} manifest
  */
 export async function render(path, page, manifest) {
   const locale = path.split("/")[1] || "en-US";

--- a/entry.ssr.js
+++ b/entry.ssr.js
@@ -15,6 +15,7 @@ import { ObservatoryResults } from "./components/observatory-results/index.js";
 import { OuterLayout } from "./components/outer-layout/index.js";
 import { PageLayout } from "./components/page-layout/index.js";
 import { Search } from "./components/search/index.js";
+import { asyncLocalStorage } from "./components/server/async-local-storage.js";
 import { Settings } from "./components/settings/index.js";
 import { addFluent } from "./l10n/context.js";
 import { runWithContext } from "./symmetric-context/server.js";
@@ -36,66 +37,66 @@ export async function render(path, page, manifest) {
     ...page,
   };
 
-  // TODO: maybe don't use symmetric context, or give it a different name?
-  const serverComponents = new Set();
-
-  return runWithContext({ locale, serverComponents }, async () => {
-    const component = (() => {
-      switch (context.renderer) {
-        case "BlogIndex":
-          return BlogIndex.render(context);
-        case "BlogPost":
-          return BlogPost.render(context);
-        case "ContributorSpotlight":
-          return ContributorSpotlight.render(context);
-        case "CurriculumAbout":
-        case "CurriculumDefault":
-        case "CurriculumLanding":
-        case "CurriculumModule":
-        case "CurriculumOverview":
-          return Curriculum.render(context);
-        case "Doc":
-          return Doc.render(context);
-        case "GenericAbout":
-        case "GenericCommunity":
-        case "GenericDoc":
-          return Generic.render(context);
-        case "Homepage":
-          return HomePage.render(context);
-        case "SpaAdvertise":
-          return PageLayout.render(context, "TODO: Advertise");
-        case "SpaObservatoryAnalyze":
-          return ObservatoryResults.render(context);
-        case "SpaObservatoryLanding":
-          return ObservatoryLanding.render(context);
-        case "SpaPlay":
-          return PageLayout.render(context, "TODO: Playground");
-        case "SpaPlusAiHelp":
-          return PageLayout.render(context, "TODO: AI Help");
-        case "SpaPlusCollections":
-          return PageLayout.render(context, "TODO: Collections");
-        case "SpaPlusCollectionsFrequentlyViewed":
-          return PageLayout.render(
-            context,
-            "TODO: Collections frequently viewed",
-          );
-        case "SpaPlusLanding":
-          return PageLayout.render(context, "TODO: Plus landing");
-        case "SpaPlusSettings":
-          return Settings.render(context);
-        case "SpaPlusUpdates":
-          return PageLayout.render(context, "TODO: BUpdates");
-        case "SpaSearch":
-          return Search.render(context);
-        case "SpaUnknown":
-          return PageLayout.render(context, `Unknown: ${context.pageTitle}`);
-        case "SpaNotFound":
-        default:
-          return NotFound.render(context);
-      }
-    })();
-    return await collectResult(
-      r(OuterLayout.render(context, component, manifest, serverComponents)),
-    );
-  });
+  return asyncLocalStorage.run({ componentsUsed: new Set() }, () =>
+    runWithContext({ locale }, async () => {
+      const component = (() => {
+        switch (context.renderer) {
+          case "BlogIndex":
+            return BlogIndex.render(context);
+          case "BlogPost":
+            return BlogPost.render(context);
+          case "ContributorSpotlight":
+            return ContributorSpotlight.render(context);
+          case "CurriculumAbout":
+          case "CurriculumDefault":
+          case "CurriculumLanding":
+          case "CurriculumModule":
+          case "CurriculumOverview":
+            return Curriculum.render(context);
+          case "Doc":
+            return Doc.render(context);
+          case "GenericAbout":
+          case "GenericCommunity":
+          case "GenericDoc":
+            return Generic.render(context);
+          case "Homepage":
+            return HomePage.render(context);
+          case "SpaAdvertise":
+            return PageLayout.render(context, "TODO: Advertise");
+          case "SpaObservatoryAnalyze":
+            return ObservatoryResults.render(context);
+          case "SpaObservatoryLanding":
+            return ObservatoryLanding.render(context);
+          case "SpaPlay":
+            return PageLayout.render(context, "TODO: Playground");
+          case "SpaPlusAiHelp":
+            return PageLayout.render(context, "TODO: AI Help");
+          case "SpaPlusCollections":
+            return PageLayout.render(context, "TODO: Collections");
+          case "SpaPlusCollectionsFrequentlyViewed":
+            return PageLayout.render(
+              context,
+              "TODO: Collections frequently viewed",
+            );
+          case "SpaPlusLanding":
+            return PageLayout.render(context, "TODO: Plus landing");
+          case "SpaPlusSettings":
+            return Settings.render(context);
+          case "SpaPlusUpdates":
+            return PageLayout.render(context, "TODO: BUpdates");
+          case "SpaSearch":
+            return Search.render(context);
+          case "SpaUnknown":
+            return PageLayout.render(context, `Unknown: ${context.pageTitle}`);
+          case "SpaNotFound":
+          default:
+            return NotFound.render(context);
+        }
+      })();
+      const { componentsUsed = new Set() } = asyncLocalStorage.getStore() || {};
+      return await collectResult(
+        r(OuterLayout.render(context, component, manifest, componentsUsed)),
+      );
+    }),
+  );
 }

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -27,7 +27,7 @@ const common = {
   },
   experiments: {
     outputModule: true,
-    // futureDefaults: true
+    futureDefaults: true,
   },
   plugins: [
     /** @type {import("@rspack/core").Plugin} */
@@ -85,9 +85,15 @@ const common = {
         loader: "./build/loaders/fluent.js",
       },
       {
+        // don't do anything with css, because we don't want direct imports to work
+        // in server components: we have a path-based system for loading the correct
+        // styles. set type to javascript/auto to disable native rspack css handling
+        test: /\.css$/i,
+        type: "javascript/auto",
+      },
+      {
         test: /\.css$/i,
         resourceQuery: /lit/,
-        type: "javascript/auto",
         use: [
           "./build/loaders/lit-css.js",
           {
@@ -194,7 +200,6 @@ export default [
       rules: [
         {
           test: /\.css$/i,
-          type: "javascript/auto",
           use: [
             rspack.CssExtractRspackPlugin.loader,
             "css-loader",

--- a/symmetric-context/types.d.ts
+++ b/symmetric-context/types.d.ts
@@ -1,4 +1,3 @@
 export interface SymmetricContext {
   locale: string;
-  serverComponents?: Set<string>;
 }


### PR DESCRIPTION
- **fix(rspack): move css into client bundle**
- **fix(rspack): don't allow importing css directly in server components**
- **fix(rspack): enable futureDefaults (i.e. native css) but ensure it doesn't work in server components**
- **chore(server-components): move parent class to components/server/index.js**
- **fix(server-components): don't use symmetric context for tracking used components**