### PR TITLE
Don’t render disabled links in pagination

### DIFF
--- a/components/pagination/server.css
+++ b/components/pagination/server.css
@@ -28,11 +28,6 @@
       text-decoration: none;
     }
 
-    .pagination__link--disabled {
-      cursor: not-allowed;
-      opacity: 0.5;
-    }
-
     .pagination__item--prev > .pagination__link,
     .pagination__item--next > .pagination__link {
       padding: 0 1rem;

--- a/components/pagination/server.js
+++ b/components/pagination/server.js
@@ -97,25 +97,24 @@ export class Pagination extends ServerComponent {
    * @param {boolean} disabled
    * @param {(page: number) => string} pageUrl
    * @param {import("@fred").Context} context
-   * @returns {import("@lit").TemplateResult}
+   * @returns {import("@lit").TemplateResult | typeof nothing}
    */
   renderPrevNextButton(prevNext, prevNextPage, disabled, pageUrl, context) {
-    const url = disabled ? "#" : pageUrl(prevNextPage);
+    const url = pageUrl(prevNextPage);
 
-    return html`
-      <li class=${`pagination__item pagination__item--${prevNext}`}>
-        <a
-          href=${url}
-          class="pagination__link ${disabled
-            ? "pagination__link--disabled"
-            : ""}"
-          aria-label=${context.l10n(`pagination_${prevNext}`)}
-          ${disabled ? 'aria-disabled="true"' : ""}
-        >
-          ${prevNext === "next" ? "→" : "←"}
-        </a>
-      </li>
-    `;
+    return disabled
+      ? html`
+          <li class=${`pagination__item pagination__item--${prevNext}`}>
+            <a
+              class="pagination__link"
+              href=${url}
+              aria-label=${context.l10n(`pagination_${prevNext}`)}
+            >
+              ${prevNext === "next" ? "→" : "←"}
+            </a>
+          </li>
+        `
+      : nothing;
   }
 
   /**


### PR DESCRIPTION
### Description

Disabling interactive elements is not a good idea: they are still focusable and very confusing for screen readers. It’s better not to render them at all or render something inert instead. I’d suggest the simplest solution: render nothing.

### Note

Also, linter gives me the following error on line 148:

> This attribute binds the type 'DirectiveResult<{ prototype: any; directiveName: string; resultType: number; new(partInfo: ChildPartInfo | AttributePartInfo | ElementPartInfo) => UnsafeHTMLDirective; }> | undefined' which can end up binding the string 'undefined'. Use the 'ifDefined' directive?