### PR TITLE
ci(main-review-companion): exclude forks

### DIFF
--- a/.github/workflows/main-review-companion.yml
+++ b/.github/workflows/main-review-companion.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    if: github.event_name == 'schedule' || github.actor != 'dependabot[bot]'
+    if: github.repository_owner == 'mdn' && (github.event_name == 'schedule' || github.actor != 'dependabot[bot]')
     uses: ./.github/workflows/_deploy.yml
     secrets: inherit
     with:


### PR DESCRIPTION
### Description

Prevent deploy workflow running on `main` in forks.

### Motivation

When I sync my fork from upstream, the CI runs on `main`, which will fail.

- https://github.com/bsmth/fred/actions