### PR TITLE
refactor(l10n): convert ids to kebab case

### DIFF
--- a/components/article-footer/server.js
+++ b/components/article-footer/server.js
@@ -59,7 +59,7 @@ function LastModified(context) {
 
   return html`<p class="article-footer__last-modified">
     ${context.l10n.raw({
-      id: "article-footer_last-modified",
+      id: "article-footer-last-modified",
       args: {
         date: formattedDate,
       },
@@ -101,7 +101,7 @@ function GitHubSourceLink(context) {
     class="external"
     href=${`${github_url}?plain=1`}
     title=${context.l10n.raw({
-      id: "article-footer_source_title",
+      id: "article-footer-source-title",
       args: {
         folder,
       },

--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -102,7 +102,7 @@ export class BaselineIndicator extends ServerComponent {
 
         if (supported.length > 0 && unsupported.length > 0) {
           return context.l10n.raw({
-            id: "baseline_supported_and_unsupported_in",
+            id: "baseline-supported-and-unsupported-in",
             args: {
               supported: formatter.format(supported),
               unsupported: formatter.format(unsupported),
@@ -110,12 +110,12 @@ export class BaselineIndicator extends ServerComponent {
           });
         } else if (supported.length > 0) {
           return context.l10n.raw({
-            id: "baseline_supported_in",
+            id: "baseline-supported-in",
             args: { browsers: formatter.format(supported) },
           });
         } else if (unsupported.length > 0) {
           return context.l10n.raw({
-            id: "baseline_unsupported_in",
+            id: "baseline-unsupported-in",
             args: { browsers: formatter.format(unsupported) },
           });
         } else {
@@ -181,7 +181,7 @@ export class BaselineIndicator extends ServerComponent {
         ${level === "high" && low_date
           ? html`<p>
               ${context.l10n.raw({
-                id: "baseline_high_extra",
+                id: "baseline-high-extra",
                 args: {
                   date: low_date.toLocaleDateString(context.locale, {
                     year: "numeric",
@@ -193,7 +193,7 @@ export class BaselineIndicator extends ServerComponent {
           : level === "low" && low_date
             ? html`<p>
                 ${context.l10n.raw({
-                  id: "baseline_low_extra",
+                  id: "baseline-low-extra",
                   args: {
                     date: low_date.toLocaleDateString(DEFAULT_LOCALE, {
                       year: "numeric",
@@ -202,11 +202,11 @@ export class BaselineIndicator extends ServerComponent {
                   },
                 })}
               </p>`
-            : html`<p>${context.l10n("baseline_not_extra")}</p>`}
+            : html`<p>${context.l10n("baseline-not-extra")}</p>`}
         ${status.asterisk
           ? html`<p>
               ${context.l10n.raw({
-                id: "baseline_asterisk",
+                id: "baseline-asterisk",
                 args: { asterisk: "*" },
               })}
             </p>`

--- a/components/blog-post/server.js
+++ b/components/blog-post/server.js
@@ -53,7 +53,7 @@ function PrevNextLinks(context, { blogMeta }) {
     ? html`
         <a href="../${blogMeta.links.previous.slug}/">
           <article>
-            ${context.l10n("blog_previous")`Previous Post`}
+            ${context.l10n("blog-previous")`Previous Post`}
             ${blogMeta.links.previous.title}
           </article>
         </a>
@@ -63,7 +63,7 @@ function PrevNextLinks(context, { blogMeta }) {
     ? html`
         <a href="../${blogMeta.links.next.slug}/">
           <article>
-            ${context.l10n("blog_next")`Next post`} ${blogMeta.links.next.title}
+            ${context.l10n("blog-next")`Next post`} ${blogMeta.links.next.title}
           </article>
         </a>
       `
@@ -84,7 +84,7 @@ export class BlogPost extends ServerComponent {
       return PageLayout.render(
         context,
         html`<p>
-          ${context.l10n("blog_post_not_found")`Blog post not found`}
+          ${context.l10n("blog-post-not-found")`Blog post not found`}
         </p>`,
       );
     }

--- a/components/blog/index.js
+++ b/components/blog/index.js
@@ -66,7 +66,7 @@ export function TimeToRead(context, { readTime }) {
   }
   return html`<span className="read-time"
     >${context.l10n.raw({
-      id: "blog_time_to_read",
+      id: "blog-time-to-read",
       args: { minutes: readTime },
     })}
   </span>`;

--- a/components/color-theme/element.js
+++ b/components/color-theme/element.js
@@ -98,7 +98,7 @@ export class MDNColorTheme extends L10nMixin(LitElement) {
                 type="button"
                 @click=${this._setMode}
               >
-                ${this.l10n("theme_default")`OS default`}
+                ${this.l10n("theme-default")`OS default`}
               </button>
             </li>
             <li>

--- a/components/compat-table-lazy/element.js
+++ b/components/compat-table-lazy/element.js
@@ -62,9 +62,9 @@ export class MDNCompatTableLazy extends L10nMixin(LitElement) {
       target="_blank"
       rel="noopener noreferrer"
       title=${this.l10n(
-        "compat_link_report_missing_title",
+        "compat-link-report-missing-title",
       )`Report missing compatibility data`}
-      >${this.l10n("compat_link_report_missing")`Report this issue`}</a
+      >${this.l10n("compat-link-report-missing")`Report this issue`}</a
     >`;
   }
 
@@ -92,8 +92,8 @@ export class MDNCompatTableLazy extends L10nMixin(LitElement) {
 
   render() {
     return this._dataTask.render({
-      initial: () => html`<p>${this.l10n("compat_loading")`Loading…`}</p>`,
-      pending: () => html`<p>${this.l10n("compat_loading")`Loading…`}</p>`,
+      initial: () => html`<p>${this.l10n("compat-loading")`Loading…`}</p>`,
+      pending: () => html`<p>${this.l10n("compat-loading")`Loading…`}</p>`,
 
       complete:
         /**

--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -229,11 +229,11 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
         target="_blank"
         rel="noopener noreferrer"
         title=${this.l10n(
-          "compat_link_report_issue_title",
+          "compat-link-report-issue-title",
         )`Report an issue with this compatibility data`}
       >
         ${this.l10n(
-          "compat_link_report_issue",
+          "compat-link-report-issue",
         )`Report problems with this compatibility data`}</a
       >${source_file
         ? html` •
@@ -243,13 +243,13 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
               target="_blank"
               rel="noopener noreferrer"
               title=${this.l10n.raw({
-                id: "compat_link_source_title",
+                id: "compat-link-source-title",
                 args: {
                   filename: source_file,
                 },
               })}
             >
-              ${this.l10n("compat_link_source")`View data on GitHub`}
+              ${this.l10n("compat-link-source")`View data on GitHub`}
             </a>`
         : undefined}
     </div>`;
@@ -500,7 +500,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
    * @returns {import("@lit").TemplateResult}
    */
   _renderIcon(name) {
-    const title = this.l10n.raw({ id: `compat_legend_${name}` });
+    const title = this.l10n.raw({ id: `compat-legend-${name}` });
 
     return html`<abbr class="only-icon" title=${ifDefined(title)}>
       <span>${name}</span>
@@ -520,9 +520,9 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
     if (status.experimental) {
       icons.push({
         title: this.l10n(
-          "compat_legend_experimental",
+          "compat-legend-experimental",
         )`Experimental. Expect behavior to change in the future.`,
-        text: this.l10n("compat_experimental")`Experimental`,
+        text: this.l10n("compat-experimental")`Experimental`,
         iconClassName: "icon-experimental",
       });
     }
@@ -530,9 +530,9 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
     if (status.deprecated) {
       icons.push({
         title: this.l10n(
-          "compat_legend_deprecated",
+          "compat-legend-deprecated",
         )`Deprecated. Not for use in new websites.`,
-        text: this.l10n("compat_deprecated")`Experimental`,
+        text: this.l10n("compat-deprecated")`Experimental`,
         iconClassName: "icon-deprecated",
       });
     }
@@ -540,9 +540,9 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
     if (!status.standard_track) {
       icons.push({
         title: this.l10n(
-          "compat_legend_nonstandard",
+          "compat-legend-nonstandard",
         )`Non-standard. Expect poor cross-browser support.`,
-        text: this.l10n("compat_nonstandard")`Non-standard`,
+        text: this.l10n("compat-nonstandard")`Non-standard`,
         iconClassName: "icon-nonstandard",
       });
     }
@@ -582,7 +582,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
             ? {
                 iconName: "footnote",
                 label: this.l10n.raw({
-                  id: "compat_support_removed",
+                  id: "compat-support-removed",
                   args: {
                     version: labelFromString(item.version_removed, browser),
                   },
@@ -592,14 +592,14 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
           item.partial_implementation
             ? {
                 iconName: "footnote",
-                label: this.l10n("compat_support_partial")`Partial support`,
+                label: this.l10n("compat-support-partial")`Partial support`,
               }
             : undefined,
           item.prefix
             ? {
                 iconName: "prefix",
                 label: this.l10n.raw({
-                  id: "compat_support_prefix",
+                  id: "compat-support-prefix",
                   args: {
                     prefix: item.prefix,
                   },
@@ -610,7 +610,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
             ? {
                 iconName: "altname",
                 label: this.l10n.raw({
-                  id: "compat_support_altname",
+                  id: "compat-support-altname",
                   args: {
                     altname: item.alternative_name,
                   },
@@ -686,7 +686,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
                 /** @param {string} impl_url */ (impl_url) => ({
                   iconName: "footnote",
                   label: this.l10n.raw({
-                    id: "compat_support_see_impl_url",
+                    id: "compat-support-see-impl-url",
                     args: {
                       label: bugURLToString(impl_url),
                     },
@@ -704,7 +704,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
             ? {
                 iconName: "footnote",
                 label: this.l10n(
-                  "compat_support_preview",
+                  "compat-support-preview",
                 )`Preview browser support`,
               }
             : undefined,
@@ -715,12 +715,12 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
           !versionIsPreview(item.version_added, browser)
             ? {
                 iconName: "footnote",
-                label: this.l10n("compat_support_full")`Full support`,
+                label: this.l10n("compat-support-full")`Full support`,
               }
             : isNotSupportedAtAll(item)
               ? {
                   iconName: "footnote",
-                  label: this.l10n("compat_support_no")`No support`,
+                  label: this.l10n("compat-support-no")`No support`,
                 }
               : undefined,
         ]
@@ -730,7 +730,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
         if (supportNotes.length === 0) {
           supportNotes.push({
             iconName: "unknown",
-            label: this.l10n("compat_support_unknown")`Support unknown`,
+            label: this.l10n("compat-support-unknown")`Support unknown`,
           });
         }
 
@@ -816,42 +816,42 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
 
     switch (status.isSupported) {
       case "yes": {
-        title = this.l10n("compat_support_full")`Full support`;
+        title = this.l10n("compat-support-full")`Full support`;
         label = status.label || this.l10n("compat_yes")`Yes`;
         break;
       }
 
       case "partial": {
-        title = this.l10n("compat_support_partial")`Partial support`;
+        title = this.l10n("compat-support-partial")`Partial support`;
         label = status.label || this.l10n("compat_partial")`Partial`;
         break;
       }
 
       case "removed-partial": {
         if (timeline) {
-          title = this.l10n("compat_support_partial")`Partial support`;
+          title = this.l10n("compat-support-partial")`Partial support`;
           label = status.label || this.l10n("compat_partial")`Partial`;
         } else {
-          title = this.l10n("compat_support_no")`No support`;
-          label = status.label || this.l10n("compat_no")`No`;
+          title = this.l10n("compat-support-no")`No support`;
+          label = status.label || this.l10n("compat-no")`No`;
         }
         break;
       }
 
       case "no": {
-        title = this.l10n("compat_support_no")`No support`;
-        label = status.label || this.l10n("compat_no")`No`;
+        title = this.l10n("compat-support-no")`No support`;
+        label = status.label || this.l10n("compat-no")`No`;
         break;
       }
 
       case "preview": {
-        title = this.l10n("compat_support_preview")`Preview support`;
+        title = this.l10n("compat-support-preview")`Preview support`;
         label = status.label || browser.preview_name;
         break;
       }
 
       case "unknown": {
-        title = this.l10n("compat_support_unknown")`Support unknown`;
+        title = this.l10n("compat-support-unknown")`Support unknown`;
         label = "?";
         break;
       }
@@ -883,7 +883,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
           class="bc-version-label"
           title=${browserReleaseDate && !timeline
             ? this.l10n.raw({
-                id: "compat_browser_version_date",
+                id: "compat-browser-version-date",
                 args: {
                   browser: browser.name,
                   version: added,
@@ -916,7 +916,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
       browserInfo,
       browsers,
     ).map((key) => {
-      const label = this.l10n(`compat_legend_${key}`);
+      const label = this.l10n(`compat-legend-${key}`);
       return ["yes", "partial", "no", "unknown", "preview"].includes(key)
         ? html`<div class="bc-legend-item">
             <dt class="bc-legend-item-dt">
@@ -941,11 +941,11 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
 
     return html`<section class="bc-legend">
       <h3 class="visually-hidden" id="Legend">
-        ${this.l10n("compat_legend")`Legend`}
+        ${this.l10n("compat-legend")`Legend`}
       </h3>
       <p class="bc-legend-tip">
         ${this.l10n(
-          "compat_legend_tip",
+          "compat-legend-tip",
         )`Tip: you can click/tap on a cell for more information.`}
       </p>
       <dl class="bc-legend-items-container">${items}</dl>

--- a/components/content-feedback/element.js
+++ b/components/content-feedback/element.js
@@ -76,7 +76,7 @@ export class MDNContentFeedback extends L10nMixin(LitElement) {
   _renderVote() {
     return html`<label
         >${this.l10n(
-          "content-feedback_question",
+          "content-feedback-question",
         )`Was this page helpful to you?`}
       </label>
       <div class="content-feedback--buttons">
@@ -110,7 +110,7 @@ export class MDNContentFeedback extends L10nMixin(LitElement) {
 
     return html`<label
         >${this.l10n(
-          "content-feedback_reason",
+          "content-feedback-reason",
         )`Why was this page not helpful to you?`}</label
       >
       ${Object.entries(
@@ -138,7 +138,7 @@ export class MDNContentFeedback extends L10nMixin(LitElement) {
 
   _renderThanks() {
     return html`<span class="thank-you">
-      ${this.l10n("content-feedback_thanks")`Thank you for your feedback!`}
+      ${this.l10n("content-feedback-thanks")`Thank you for your feedback!`}
       <span class="emoji">❤️</span>
     </span>`;
   }

--- a/components/footer/server.js
+++ b/components/footer/server.js
@@ -164,7 +164,7 @@ export class Footer extends ServerComponent {
             <a class="footer__logo" href="/">${mdn}</a>
             <p>
               ${context.l10n(
-                "footer_tagline",
+                "footer-tagline",
               )`Your blueprint for a better internet.`}
             </p>
           </div>
@@ -220,14 +220,14 @@ export class Footer extends ServerComponent {
           </ul>
           <p>
             ${context.l10n.raw({
-              id: "footer_mofo",
+              id: "footer-mofo",
               elements: {
                 moco: { tag: "a", href: "https://www.mozilla.org/" },
                 mofo: { tag: "a", href: "https://foundation.mozilla.org/" },
               },
             })}<br />
             ${context.l10n.raw({
-              id: "footer_copyright",
+              id: "footer-copyright",
               elements: {
                 cc: {
                   tag: "a",

--- a/components/homepage-hero/server.js
+++ b/components/homepage-hero/server.js
@@ -10,13 +10,13 @@ export class HomepageHero extends ServerComponent {
     return html`<section class="homepage-hero">
       <h1>
         ${context.l10n.raw({
-          id: "homepage-hero_title",
+          id: "homepage-hero-title",
           elements: { developers: { tag: "u" } },
         })}
       </h1>
       <p>
         ${context.l10n.raw({
-          id: "homepage-hero_description",
+          id: "homepage-hero-description",
           elements: {
             css: {
               tag: "a",

--- a/components/not-found/element.js
+++ b/components/not-found/element.js
@@ -43,7 +43,7 @@ export class MDNNotFound extends L10nMixin(LitElement) {
     return html`
       <p>
         ${this.l10n.raw({
-          id: "not_found_description",
+          id: "not-found-description",
           args: { url },
           elements: { url: { tag: "code" } },
         })}
@@ -55,7 +55,7 @@ export class MDNNotFound extends L10nMixin(LitElement) {
             return html`<div class="notecard tip">
               <p>
                 ${this.l10n.raw({
-                  id: "not_found_fallback_english",
+                  id: "not-found-fallback-english",
                   elements: { strong: { tag: "strong" }, em: { tag: "em" } },
                 })}
               </p>
@@ -77,7 +77,7 @@ export class MDNNotFound extends L10nMixin(LitElement) {
               .reverse();
 
             return html`<div class="notecard note">
-              <p>${this.l10n("not_found_fallback_search")}
+              <p>${this.l10n("not-found-fallback-search")}
               <ul>
                 ${normalizedLocationParts.map(
                   (part) =>

--- a/components/not-found/server.js
+++ b/components/not-found/server.js
@@ -11,10 +11,10 @@ export class NotFound extends ServerComponent {
     return PageLayout.render(
       context,
       html`<main id="content" class="not-found">
-        <h1>${context.l10n("not_found_title")}</h1>
+        <h1>${context.l10n("not-found-title")}</h1>
         <mdn-not-found></mdn-not-found>
         <p>
-          <a href="/">${context.l10n("not_found_back")}</a>
+          <a href="/">${context.l10n("not-found-back")}</a>
         </p>
       </main>`,
     );

--- a/components/observatory-landing/server.js
+++ b/components/observatory-landing/server.js
@@ -27,10 +27,10 @@ export class ObservatoryLanding extends ServerComponent {
         <section class="obs-landing-top">
           <section class="obs-landing-top__form">
             <h1>
-              <span class="accent">${context.l10n("obs_title")}</span>
+              <span class="accent">${context.l10n("obs-title")}</span>
             </h1>
             <p>
-              ${context.l10n("obs_landing_intro")}
+              ${context.l10n("obs-landing-intro")}
             </p>
             <mdn-observatory-form></mdn-observatory-form>
           </section>
@@ -46,7 +46,7 @@ export class ObservatoryLanding extends ServerComponent {
                 ${assessmentSvg}
                 <figcaption>
                   <p>
-                    ${context.l10n("obs_assessment")}
+                    ${context.l10n("obs-assessment")}
                   </p>
                 </figcaption>
               </figure>
@@ -55,7 +55,7 @@ export class ObservatoryLanding extends ServerComponent {
                 ${scanningSvg}
                 <figcaption>
                   <p>
-                    ${context.l10n("obs_scanning")}
+                    ${context.l10n("obs-scanning")}
                   </p>
                 </figcaption>
               </figure>
@@ -64,7 +64,7 @@ export class ObservatoryLanding extends ServerComponent {
                 ${securitySvg}
                 <figcaption>
                   <p>
-                    ${context.l10n("obs_security")}
+                    ${context.l10n("obs-security")}
                   </p>
                 </figcaption>
               </figure>
@@ -73,7 +73,7 @@ export class ObservatoryLanding extends ServerComponent {
                 ${mdnSvg}
                 <figcaption>
                   <p>
-                    ${context.l10n("obs_mdn")}
+                    ${context.l10n("obs-mdn")}
                   </p>
                 </figcaption>
               </figure>

--- a/components/observatory-results/server.js
+++ b/components/observatory-results/server.js
@@ -31,7 +31,7 @@ export class ObservatoryResults extends ServerComponent {
               <section class="obs-results__header">
                 <h1 class="obs-results__title">
                   <span class="obs-results__title-accent"
-                    >${context.l10n("obs_title")}</span
+                    >${context.l10n("obs-title")}</span
                   >
                   ${context.l10n("Report")}
                 </h1>
@@ -39,7 +39,7 @@ export class ObservatoryResults extends ServerComponent {
               </section>
 
               <aside class="obs-toc">
-                <h2 class="obs-toc__heading">${context.l10n("obs_title")}</h2>
+                <h2 class="obs-toc__heading">${context.l10n("obs-title")}</h2>
                 <ul class="obs-toc__list">
                   <li class="obs-toc__item">
                     <a

--- a/components/pagination/server.js
+++ b/components/pagination/server.js
@@ -109,7 +109,7 @@ export class Pagination extends ServerComponent {
           class="pagination__link ${disabled
             ? "pagination__link--disabled"
             : ""}"
-          aria-label=${context.l10n(`pagination_${prevNext}`)}
+          aria-label=${context.l10n(`pagination-${prevNext}`)}
           ${disabled ? 'aria-disabled="true"' : ""}
         >
           ${prevNext === "next" ? "→" : "←"}
@@ -147,9 +147,9 @@ export class Pagination extends ServerComponent {
               : ""}"
             aria-current=${isCurrentPage ? "page" : "false"}
             aria-label=${isCurrentPage
-              ? context.l10n("pagination_current")
+              ? context.l10n("pagination-current")
               : context.l10n.raw({
-                  id: "pagination_goto",
+                  id: "pagination-goto",
                   args: { page: pageNumber },
                 })}
           >

--- a/components/placement-no/element.js
+++ b/components/placement-no/element.js
@@ -51,7 +51,7 @@ class MDNPlacementNo extends L10nMixin(LitElement) {
                   ? "/en-US/plus/settings?ref=nope"
                   : "/en-US/plus?ref=nope"}
               >
-                ${this.l10n("placement_no")}
+                ${this.l10n("placement-no")}
               </a>`
             : nothing;
         },

--- a/components/placement-note/element.js
+++ b/components/placement-note/element.js
@@ -14,7 +14,7 @@ class MDNPlacementNote extends L10nMixin(LitElement) {
       data-glean="pong: pong-&gt;about"
       target="_blank"
       rel="noreferrer"
-      >${this.l10n("placement_note")}</a
+      >${this.l10n("placement-note")}</a
     >`;
   }
 }

--- a/components/reference-toc/server.js
+++ b/components/reference-toc/server.js
@@ -10,7 +10,7 @@ export class ReferenceToc extends ServerComponent {
    */
   render(context) {
     return html`<nav class="reference-toc">
-      <h2>${context.l10n("reference_toc_header")`In this article`}</h2>
+      <h2>${context.l10n("reference-toc-header")`In this article`}</h2>
       <ul>
         ${context?.doc?.toc?.map(
           ({ id, text }) =>

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -197,7 +197,7 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
                 <a
                   href=${`/${this.locale}/search?${new URLSearchParams({ q: this._query })}`}
                   >${this.l10n.raw({
-                    id: "search-modal_site-search",
+                    id: "search-modal-site-search",
                     args: {
                       query: this._query,
                     },

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -85,7 +85,7 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
         results
           ? html`<h1>
                 ${this.l10n.raw({
-                  id: "search_title",
+                  id: "search-title",
                   args: {
                     query: this._query,
                   },
@@ -131,7 +131,7 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
               <section class="site-search__results">
                 <h2>${this.l10n`Results`}</h2>
                 ${this.l10n.raw({
-                  id: "search_stats",
+                  id: "search-stats",
                   args: {
                     results: results.metadata.total.value,
                     time: results.metadata.took_ms,

--- a/l10n/de.ftl
+++ b/l10n/de.ftl
@@ -1,23 +1,23 @@
-content-feedback_question = War diese Übersetzung hilfreich?
-content-feedback_reason = Warum war diese Übersetzung nicht hilfreich?
-content-feedback_thanks = Vielen Dank für die Rückmeldung!
+content-feedback-question = War diese Übersetzung hilfreich?
+content-feedback-reason = Warum war diese Übersetzung nicht hilfreich?
+content-feedback-thanks = Vielen Dank für die Rückmeldung!
 
-reference_toc_header = In diesem Artikel
+reference-toc-header = In diesem Artikel
 
-footer_tagline = Dein Bauplan für ein besseres Internet.
-footer_mofo = Besuche die gemeinnützige Muttergesellschaft der <a data-l10n-name="moco">Mozilla Corporation</a>, die <a data-l10n-name="mofo">Mozilla Foundation</a>.
-footer_copyright = Teile dieses Inhalts sind ©1998–2024 von einzelnen mozilla.org-Mitwirkenden. Inhalte sind verfügbar unter <a data-l10n-name="cc">einer Creative-Commons-Lizenz</a>.
+footer-tagline = Dein Bauplan für ein besseres Internet.
+footer-mofo = Besuche die gemeinnützige Muttergesellschaft der <a data-l10n-name="moco">Mozilla Corporation</a>, die <a data-l10n-name="mofo">Mozilla Foundation</a>.
+footer-copyright = Teile dieses Inhalts sind ©1998–2024 von einzelnen mozilla.org-Mitwirkenden. Inhalte sind verfügbar unter <a data-l10n-name="cc">einer Creative-Commons-Lizenz</a>.
 
-theme_default = Systemstandard
+theme-default = Systemstandard
 
-blog_time_to_read = { $minutes ->
+blog-time-to-read = { $minutes ->
     [one]   { $minutes } Minute Lesezeit
    *[other] { $minutes } Minuten Lesezeit
 }
-blog_post_not_found = Blogartikel nicht gefunden.
+blog-post-not-found = Blogartikel nicht gefunden.
 
-blog_previous = Voriger Artikel
-blog_next = Nächster Artikel
+blog-previous = Voriger Artikel
+blog-next = Nächster Artikel
 
 No = Nein
 Submit = Abschicken
@@ -25,9 +25,9 @@ Yes = Ja
 
 Report = Report
 
-obs_title = HTTP Observatory
-obs_landing_intro = Sei 2016 verbessert HTTP Observatory die Sicherheit durch Analyse der Einhaltung bewährter Sicherheitspraktiken. Es hat durch 47 Millionen Scans Einblicke in über 6,9 Millionen Websites geliefert.
-obs_assessment = Das von Mozilla entwickelte HTTP Observatory führt eine umfassende Bewertung der HTTP-Header und weiterer zentraler Sicherheitskonfigurationen einer Website durch.
-obs_scanning = Der automatisierte Scan-Prozess liefert Entwicklern und Website-Administratoren detailliertes, handlungsorientiertes Feedback und konzentriert sich darauf, potenzielle Sicherheitslücken zu erkennen und zu beheben.
-obs_security = Das Tool unterstützt Entwickler und Website-Administratoren maßgeblich dabei, ihre Websites in einem sich stetig weiterentwickelnden digitalen Umfeld gegen häufige Sicherheitsbedrohungen abzusichern.
-obs_mdn = Das HTTP Observatory bietet wirksame Sicherheitseinblicke auf Grundlage von Mozillas Expertise und Engagement für ein sichereres Internet sowie basierend auf etablierten Trends und Richtlinien.
+obs-title = HTTP Observatory
+obs-landing-intro = Sei 2016 verbessert HTTP Observatory die Sicherheit durch Analyse der Einhaltung bewährter Sicherheitspraktiken. Es hat durch 47 Millionen Scans Einblicke in über 6,9 Millionen Websites geliefert.
+obs-assessment = Das von Mozilla entwickelte HTTP Observatory führt eine umfassende Bewertung der HTTP-Header und weiterer zentraler Sicherheitskonfigurationen einer Website durch.
+obs-scanning = Der automatisierte Scan-Prozess liefert Entwicklern und Website-Administratoren detailliertes, handlungsorientiertes Feedback und konzentriert sich darauf, potenzielle Sicherheitslücken zu erkennen und zu beheben.
+obs-security = Das Tool unterstützt Entwickler und Website-Administratoren maßgeblich dabei, ihre Websites in einem sich stetig weiterentwickelnden digitalen Umfeld gegen häufige Sicherheitsbedrohungen abzusichern.
+obs-mdn = Das HTTP Observatory bietet wirksame Sicherheitseinblicke auf Grundlage von Mozillas Expertise und Engagement für ein sichereres Internet sowie basierend auf etablierten Trends und Richtlinien.

--- a/l10n/en-US.ftl
+++ b/l10n/en-US.ftl
@@ -1,97 +1,96 @@
-# TODO Use kebab-case, see: https://firefox-source-docs.mozilla.org/l10n/fluent/review.html#message-identifiers
 # TODO Use comments, see: https://firefox-source-docs.mozilla.org/l10n/fluent/review.html#comments
 # TODO Consider using terms, see: https://firefox-source-docs.mozilla.org/l10n/fluent/review.html#terms and https://projectfluent.org/fluent/guide/references.html#message-references
 
-article-footer_last-modified = This page was last modified on <time data-l10n-name="date">{ $date }</timestamp> by <a data-l10n-name="contributors">MDN contributors</a>.
-article-footer_source_title = Folder: { $folder } (Opens in a new tab)
+article-footer-last-modified = This page was last modified on <time data-l10n-name="date">{ $date }</timestamp> by <a data-l10n-name="contributors">MDN contributors</a>.
+article-footer-source-title = Folder: { $folder } (Opens in a new tab)
 
-baseline_asterisk = { $asterisk } Some parts of this feature may have varying levels of support.
-baseline_high_extra = This feature is well established and works across many devices and browser versions. It’s been available across browsers since { $date }.
-baseline_low_extra = Since { $date }, this feature works across the latest devices and browser versions. This feature might not work in older devices or browsers.
-baseline_not_extra = This feature is not Baseline because it does not work in some of the most widely-used browsers.
-baseline_supported_in = Supported in { $browsers }
-baseline_unsupported_in = Not widely supported in { $browsers }
-baseline_supported_and_unsupported_in = Supported in { $supported }, but not widely supported in { $unsupported }
+baseline-asterisk = { $asterisk } Some parts of this feature may have varying levels of support.
+baseline-high-extra = This feature is well established and works across many devices and browser versions. It’s been available across browsers since { $date }.
+baseline-low-extra = Since { $date }, this feature works across the latest devices and browser versions. This feature might not work in older devices or browsers.
+baseline-not-extra = This feature is not Baseline because it does not work in some of the most widely-used browsers.
+baseline-supported-in = Supported in { $browsers }
+baseline-unsupported-in = Not widely supported in { $browsers }
+baseline-supported-and-unsupported-in = Supported in { $supported }, but not widely supported in { $unsupported }
 
-homepage-hero_title = Resources for <u data-l10n-name="developers">Developers</u>,<br> by Developers
-homepage-hero_description = Documenting <a data-l10n-name="css">CSS</a>, <a data-l10n-name="html">HTML</a>, and <a data-l10n-name="js">JavaScript</a>, since 2005.
+homepage-hero-title = Resources for <u data-l10n-name="developers">Developers</u>,<br> by Developers
+homepage-hero-description = Documenting <a data-l10n-name="css">CSS</a>, <a data-l10n-name="html">HTML</a>, and <a data-l10n-name="js">JavaScript</a>, since 2005.
 
-not_found_title = Page not found
-not_found_description = Sorry, the page <code data-l10n-name="url">{ $url }</code> could not be found.
-not_found_fallback_english = <strong data-l10n-name="strong">Good news:</strong> The page you requested exists in <em data-l10n-name="em">English</em>.
-not_found_fallback_search = The page you requested doesn't exist, but you could try a site search for:
-not_found_back = Go back to the home page
+not-found-title = Page not found
+not-found-description = Sorry, the page <code data-l10n-name="url">{ $url }</code> could not be found.
+not-found-fallback-english = <strong data-l10n-name="strong">Good news:</strong> The page you requested exists in <em data-l10n-name="em">English</em>.
+not-found-fallback-search = The page you requested doesn't exist, but you could try a site search for:
+not-found-back = Go back to the home page
 
-reference_toc_header = In this article
+reference-toc-header = In this article
 
-footer_mofo = Visit <a data-l10n-name="moco">Mozilla Corporation’s</a> not-for-profit parent, the <a data-l10n-name="mofo">Mozilla Foundation</a>.
-footer_copyright = Portions of this content are ©1998–2024 by individual mozilla.org contributors. Content available under <a data-l10n-name="cc">a Creative Commons license</a>.
+footer-mofo = Visit <a data-l10n-name="moco">Mozilla Corporation’s</a> not-for-profit parent, the <a data-l10n-name="mofo">Mozilla Foundation</a>.
+footer-copyright = Portions of this content are ©1998–2024 by individual mozilla.org contributors. Content available under <a data-l10n-name="cc">a Creative Commons license</a>.
 
-search_title = Search results for: <em>{ $query }</em>
-search_stats = Found { $results } matches in { $time } milliseconds.
+search-title = Search results for: <em>{ $query }</em>
+search-stats = Found { $results } matches in { $time } milliseconds.
 
-search-modal_site-search = Site search for <em>{ $query }</em>
+search-modal-site-search = Site search for <em>{ $query }</em>
 
-blog_time_to_read = { $minutes ->
+blog-time-to-read = { $minutes ->
     [one]   { $minutes } minute read
    *[other] { $minutes } minutes read
 }
-blog_post_not_found = Blog post not found.
+blog-post-not-found = Blog post not found.
 
-blog_previous = Previous Post
-blog_next = Next Post
+blog-previous = Previous Post
+blog-next = Next Post
 
 Report = Report
 
-obs_title = HTTP Observatory
-obs_landing_intro = Launched in 2016, the HTTP Observatory enhances web security by analyzing compliance with best security practices. It has provided insights to over 6.9 million websites through 47 million scans.
-obs_assessment = Developed by Mozilla, the HTTP Observatory performs an in-depth assessment of a site’s HTTP headers and other key security configurations.
-obs_scanning = Its automated scanning process provides developers and website administrators with detailed, actionable feedback, focusing on identifying and addressing potential security vulnerabilities.
-obs_security = The tool is instrumental in helping developers and website administrators strengthen their sites against common security threats in a constantly advancing digital environment.
-obs_mdn = The HTTP Observatory provides effective security insights, guided by Mozilla's expertise and commitment to a safer and more secure internet and based on well-established trends and guidelines.
+obs-title = HTTP Observatory
+obs-landing-intro = Launched in 2016, the HTTP Observatory enhances web security by analyzing compliance with best security practices. It has provided insights to over 6.9 million websites through 47 million scans.
+obs-assessment = Developed by Mozilla, the HTTP Observatory performs an in-depth assessment of a site’s HTTP headers and other key security configurations.
+obs-scanning = Its automated scanning process provides developers and website administrators with detailed, actionable feedback, focusing on identifying and addressing potential security vulnerabilities.
+obs-security = The tool is instrumental in helping developers and website administrators strengthen their sites against common security threats in a constantly advancing digital environment.
+obs-mdn = The HTTP Observatory provides effective security insights, guided by Mozilla's expertise and commitment to a safer and more secure internet and based on well-established trends and guidelines.
 
 
-compat_loading = Loading…
+compat-loading = Loading…
 
-compat_browser_version_date = { $browser } { $version } – Released { $date }
+compat-browser-version-date = { $browser } { $version } – Released { $date }
 
-compat_link_report_issue = Report problems with this compatibility data
-compat_link_report_issue_title = Report an issue with this compatibility data
-compat_link_report_missing_title = Report missing compatibility data
-compat_link_report_missing = Report this issue
-compat_link_source = View data on GitHub
-compat_link_source_title = File: { $filename }
+compat-link-report-issue = Report problems with this compatibility data
+compat-link-report-issue-title = Report an issue with this compatibility data
+compat-link-report-missing-title = Report missing compatibility data
+compat-link-report-missing = Report this issue
+compat-link-source = View data on GitHub
+compat-link-source-title = File: { $filename }
 
-compat_deprecated = Deprecated
-compat_experimental = Experimental
-compat_nonstandard = Non-standard
-compat_no = No
+compat-deprecated = Deprecated
+compat-experimental = Experimental
+compat-nonstandard = Non-standard
+compat-no = No
 
-compat_support_full = Full support
-compat_support_partial = Partial support
-compat_support_no = No support
-compat_support_unknown = Support unknown
-compat_support_preview = Preview browser support
-compat_support_prefix = Implemented with the vendor prefix: { $prefix }
-compat_support_altname = Alternate name: { $altname }
-compat_support_removed = Removed in { $version } and later
-compat_support_see_impl_url = See <a data-l10n-name="impl_url">{ $label }</a>
+compat-support-full = Full support
+compat-support-partial = Partial support
+compat-support-no = No support
+compat-support-unknown = Support unknown
+compat-support-preview = Preview browser support
+compat-support-prefix = Implemented with the vendor prefix: { $prefix }
+compat-support-altname = Alternate name: { $altname }
+compat-support-removed = Removed in { $version } and later
+compat-support-see-impl-url = See <a data-l10n-name="impl_url">{ $label }</a>
 
-compat_legend = Legend
-compat_legend_tip = Tip: you can click/tap on a cell for more information.
-compat_legend_yes = { compat_support_full }
-compat_legend_partial = { compat_support_partial }
-compat_legend_preview = In development. Supported in a pre-release version.
-compat_legend_no = { compat_support_no }
-compat_legend_unknown = Compatibility unknown
-compat_legend_experimental = { compat_experimental }. Expect behavior to change in the future.
-compat_legend_nonstandard = { compat_nonstandard }. Check cross-browser support before using.
-compat_legend_deprecated = { compat_deprecated }. Not for use in new websites.
-compat_legend_footnote = See implementation notes.
-compat_legend_disabled = User must explicitly enable this feature.
-compat_legend_altname = Uses a non-standard name.
-compat_legend_prefix = Requires a vendor prefix or different name for use.
-compat_legend_more = Has more compatibility info.
+compat-legend = Legend
+compat-legend-tip = Tip: you can click/tap on a cell for more information.
+compat-legend-yes = { compat-support-full }
+compat-legend-partial = { compat-support-partial }
+compat-legend-preview = In development. Supported in a pre-release version.
+compat-legend-no = { compat-support-no }
+compat-legend-unknown = Compatibility unknown
+compat-legend-experimental = { compat-experimental }. Expect behavior to change in the future.
+compat-legend-nonstandard = { compat-nonstandard }. Check cross-browser support before using.
+compat-legend-deprecated = { compat-deprecated }. Not for use in new websites.
+compat-legend-footnote = See implementation notes.
+compat-legend-disabled = User must explicitly enable this feature.
+compat-legend-altname = Uses a non-standard name.
+compat-legend-prefix = Requires a vendor prefix or different name for use.
+compat-legend-more = Has more compatibility info.
 
 sidebar-filter-matches = { $matches ->
   [0] No matches
@@ -99,13 +98,13 @@ sidebar-filter-matches = { $matches ->
    *[other] { $matches } matches
 }
 
-placement_note = Ad
-placement_no = Don't want to see ads?
+placement-note = Ad
+placement-no = Don't want to see ads?
 
-pagination_next = Next page
-pagination_prev = Previous page
-pagination_current = Current page
-pagination_goto = Go to page { $page }
+pagination-next = Next page
+pagination-prev = Previous page
+pagination-current = Current page
+pagination-goto = Go to page { $page }
 
 logout = Sign out
 login = Log in

--- a/l10n/es.ftl
+++ b/l10n/es.ftl
@@ -1,2 +1,2 @@
-blog_toc_title = En este artículo
+blog-toc-title = En este artículo
 

--- a/l10n/fr.ftl
+++ b/l10n/fr.ftl
@@ -1,1 +1,1 @@
-blog_toc_title = Dans cet article
+blog-toc-title = Dans cet article

--- a/l10n/ja.ftl
+++ b/l10n/ja.ftl
@@ -1,2 +1,2 @@
-blog_toc_title = この記事では
+blog-toc-title = この記事では
 

--- a/l10n/ko.ftl
+++ b/l10n/ko.ftl
@@ -1,1 +1,1 @@
-blog_toc_title = 목차
+blog-toc-title = 목차

--- a/l10n/pt-BR.ftl
+++ b/l10n/pt-BR.ftl
@@ -1,2 +1,2 @@
-blog_toc_title = Neste artigo
+blog-toc-title = Neste artigo
 

--- a/l10n/ru.ftl
+++ b/l10n/ru.ftl
@@ -1,1 +1,1 @@
-blog_toc_title = В этой статье
+blog-toc-title = В этой статье

--- a/l10n/zh-CN.ftl
+++ b/l10n/zh-CN.ftl
@@ -1,1 +1,1 @@
-blog_toc_title = 在本文中
+blog-toc-title = 在本文中

--- a/l10n/zh-TW.ftl
+++ b/l10n/zh-TW.ftl
@@ -1,1 +1,1 @@
-blog_toc_title = 在本文中
+blog-toc-title = 在本文中


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Converts l10n IDs to kebab case (with dashes instead of underscores).

### Motivation

Addresses feedback by the Mozilla L10n team.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

