### PR TITLE
fix(content-section): style anchor links too

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -42,7 +42,7 @@
     letter-spacing: 0.025em;
   }
 
-  a:not([href^="#"]) {
+  a {
     &:link {
       color: var(--color-link-normal);
     }

--- a/components/heading-anchor/server.css
+++ b/components/heading-anchor/server.css
@@ -3,13 +3,13 @@
 }
 
 .heading-anchor {
-  color: inherit;
+  color: inherit !important;
 
   &::before {
     position: absolute;
 
-    padding-inline-end: 0.4em;
-    margin-inline-start: -0.8em;
+    padding-right: 0.4em;
+    margin-left: -0.8em;
 
     color: var(--color-text-secondary);
 


### PR DESCRIPTION
### Description

Otherwise, anchor links are not styled.

Also, getting rid of logical properties, since we don’t use them consistently.