### PR TITLE
feat(language-switcher,translation-banner): add Remember language

### DIFF
--- a/components/button/element.js
+++ b/components/button/element.js
@@ -13,6 +13,7 @@ export class MDNButton extends LitElement {
     icon: { state: true },
     iconOnly: { type: Boolean, attribute: "icon-only" },
     href: { type: String },
+    target: { type: String },
   };
 
   constructor() {
@@ -27,6 +28,8 @@ export class MDNButton extends LitElement {
     this.action = undefined;
     /** @type {string | undefined} */
     this.href = undefined;
+    /** @type {string | undefined} */
+    this.target = undefined;
   }
 
   render() {
@@ -38,6 +41,7 @@ export class MDNButton extends LitElement {
       variant: this.variant,
       action: this.action,
       href: this.href,
+      target: this.target,
     });
   }
 }

--- a/components/button/pure.js
+++ b/components/button/pure.js
@@ -8,6 +8,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
  * @param {boolean} [options.iconOnly]
  * @param {boolean} [options.disabled]
  * @param {string} [options.href]
+ * @param {string} [options.target]
  * @param {import("./types.js").ButtonVariants} [options.variant]
  * @param {import("./types.js").ButtonActions} [options.action]
  */
@@ -17,6 +18,7 @@ export default function Button({
   iconOnly,
   disabled = false,
   href,
+  target,
   variant = "primary",
   action,
 }) {
@@ -27,6 +29,7 @@ export default function Button({
   return href
     ? html`<a
         href=${href}
+        target=${ifDefined(target)}
         class="button"
         aria-labelledby="label"
         data-variant=${ifDefined(variant)}

--- a/components/cookie/utils.js
+++ b/components/cookie/utils.js
@@ -1,0 +1,40 @@
+/** @param {string} name */
+export function getCookieValue(name) {
+  let value = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`));
+
+  if (value && value.includes("=")) {
+    value = value.split("=")[1];
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} name
+ * @param {string} value
+ * @param {object} options
+ * @param {Date} [options.expires]
+ * @param {number} [options.maxAge]
+ * @param {string} [options.path]
+ */
+export function setCookieValue(name, value, { expires, maxAge, path = "/" }) {
+  const cookieValue = [
+    `${name}=${value}`,
+    expires && `expires=${expires.toUTCString()}`,
+    maxAge && `max-age=${maxAge}`,
+    `path=${path}`,
+    document.location.hostname !== "localhost" && "secure",
+  ]
+    .filter(Boolean)
+    .join(";");
+
+  // eslint-disable-next-line unicorn/no-document-cookie
+  document.cookie = cookieValue;
+}
+
+/** @param {string} name */
+export function deleteCookie(name) {
+  setCookieValue(name, "", { expires: new Date(0) });
+}

--- a/components/language-always-redirect-button/element.js
+++ b/components/language-always-redirect-button/element.js
@@ -1,0 +1,36 @@
+import { LitElement, html } from "lit";
+
+import { setPreferredLocale } from "../preferred-locale/utils.js";
+
+export class MDNLanguageAlwaysRedirectButton extends LitElement {
+  static properties = {
+    locale: { type: String },
+    to: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.locale = "";
+    this.to = "";
+  }
+
+  _handleClick() {
+    setPreferredLocale(this.to);
+    const url = document.location.pathname.replace(
+      `/${this.locale}/`,
+      `/${this.to}/`,
+    );
+    document.location.replace(url);
+  }
+
+  render() {
+    return html`<mdn-button variant="plain" @click=${this._handleClick}
+      ><slot></slot
+    ></mdn-button>`;
+  }
+}
+
+customElements.define(
+  "mdn-language-always-redirect-button",
+  MDNLanguageAlwaysRedirectButton,
+);

--- a/components/language-switcher/element.css
+++ b/components/language-switcher/element.css
@@ -57,8 +57,28 @@
   border: 1px solid var(--color-border-primary);
 }
 
+.language_switcher__remember {
+  display: flex;
+
+  place-items: center;
+
+  width: 100%;
+
+  font-size: var(--font-size-small);
+
+  border-bottom: 1px solid var(--color-border-primary);
+
+  mdn-switch {
+    padding: 0.25rem;
+
+    &:hover {
+      background-color: var(--color-background-secondary);
+    }
+  }
+}
+
 .language-switcher__list {
-  width: max-content;
+  width: 100%;
 
   padding: 0;
   margin: 0;

--- a/components/preferred-locale/utils.js
+++ b/components/preferred-locale/utils.js
@@ -1,0 +1,24 @@
+import {
+  deleteCookie,
+  getCookieValue,
+  setCookieValue,
+} from "../cookie/utils.js";
+
+const COOKIE_NAME = "preferredlocale";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365 * 3; // 3 years.
+
+/** @returns {string|undefined} */
+export function getPreferredLocale() {
+  return getCookieValue(COOKIE_NAME);
+}
+
+/** @param {string} locale */
+export function setPreferredLocale(locale) {
+  setCookieValue(COOKIE_NAME, locale, {
+    maxAge: COOKIE_MAX_AGE,
+  });
+}
+
+export function resetPreferredLocale() {
+  deleteCookie(COOKIE_NAME);
+}

--- a/components/switch/element.css
+++ b/components/switch/element.css
@@ -1,0 +1,59 @@
+@property --switch-position {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+.switch {
+  display: flex;
+
+  gap: 0.5em;
+  place-items: center;
+
+  cursor: pointer;
+}
+
+.switch__input {
+  --switch-size: 1.25em;
+
+  display: inline-block;
+
+  width: calc(var(--switch-size) * 1.6);
+  height: var(--switch-size);
+
+  margin: 0;
+
+  appearance: none;
+
+  background-color: var(--color-text-secondary);
+  background-image: radial-gradient(
+    circle at calc(var(--switch-size) / 2),
+    var(--color-background-primary) calc((var(--switch-size) / 2) * 0.8),
+    transparent calc((var(--switch-size) / 2) * 0.8 + 1px)
+  );
+  background-repeat: no-repeat;
+  background-position: var(--switch-position) 0%;
+  background-size: var(--switch-size);
+  border-radius: calc(infinity * 1px);
+
+  transition: --switch-position 0.2s;
+
+  &:checked {
+    --switch-position: 100%;
+
+    background-color: var(--color-link-normal);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-link-normal);
+    outline-offset: 2px;
+  }
+
+  &:active:not(:disabled) {
+    filter: brightness(1.2);
+  }
+
+  &:disabled {
+    opacity: 0.7;
+  }
+}

--- a/components/switch/element.js
+++ b/components/switch/element.js
@@ -1,0 +1,39 @@
+import { LitElement, html } from "lit";
+
+import styles from "./element.css?lit";
+
+export class MDNSwitch extends LitElement {
+  static styles = styles;
+
+  static properties = {
+    label: { type: String },
+    checked: { type: Boolean, reflect: true },
+    disabled: { type: Boolean },
+  };
+
+  constructor() {
+    super();
+    this.label = "";
+    this.checked = false;
+    this.disabled = false;
+  }
+
+  _toggle() {
+    this.dispatchEvent(new Event("toggle", { bubbles: true, composed: true }));
+  }
+
+  render() {
+    return html` <label class="switch">
+      <input
+        class="switch__input"
+        type="checkbox"
+        ?checked=${this.checked}
+        ?disabled=${this.disabled}
+        @change=${this._toggle}
+      ></input>
+      <slot></slot>
+    </label>`;
+  }
+}
+
+customElements.define("mdn-switch", MDNSwitch);

--- a/components/translation-banner/server.css
+++ b/components/translation-banner/server.css
@@ -1,0 +1,3 @@
+.translation-banner__switch {
+  text-align: right;
+}

--- a/components/translation-banner/server.js
+++ b/components/translation-banner/server.js
@@ -73,8 +73,37 @@ export class TranslationBanner extends ServerComponent {
       return nothing;
     }
 
-    return html`<div class="notecard note">
+    const switchToEnglish = this._renderSwitchToEnglish(context);
+
+    return html`<div class="translation-banner notecard note">
       <p>${this._renderBody(locale)}</p>
+      ${switchToEnglish ? html`<p>${switchToEnglish}</p>` : nothing}
     </div>`;
+  }
+
+  /**
+   * @param {import("@fred").Context<import("@rari").DocPage>} context
+   */
+  _renderSwitchToEnglish(context) {
+    const { locale } = context;
+    if (
+      locale === "en-US" ||
+      !context.doc.other_translations.some(({ locale }) => locale === "en-US")
+    ) {
+      return nothing;
+    }
+
+    const url = context.doc.mdn_url.replace(`/${locale}/`, `/en-US/`);
+
+    // Note: Do not translate, this is intentionally in English.
+
+    return html`<p class="translation-banner__switch" lang="en-US">
+      <mdn-button data-variant="secondary" href=${url}
+        >View in English</mdn-button
+      >
+      <mdn-language-always-redirect-button locale=${context.locale} to="en-US"
+        >Always switch to English</mdn-language-always-redirect-button
+      >
+    </p>`;
   }
 }

--- a/types/element-map.d.ts
+++ b/types/element-map.d.ts
@@ -52,6 +52,7 @@ declare global {
     "mdn-sidebar-filter": import("../components/sidebar-filter/element.js").MDNSidebarFilter;
     "mdn-site-search": import("../components/site-search/element.js").MDNSiteSearch;
     "mdn-survey": import("../components/survey/element.js").MDNSurvey;
+    "mdn-switch": import("../components/switch/element.js").MDNSwitch;
     "mdn-themed-image": import("../components/themed-image/element.js").MDNThemedImage;
     "mdn-toggle-sidebar": import("../components/toggle-sidebar/element.js").MDNToggleSidebar;
     "mdn-user-menu": import("../components/user-menu/element.js").MDNUserMenu;

--- a/types/element-map.d.ts
+++ b/types/element-map.d.ts
@@ -22,6 +22,7 @@ declare global {
     "mdn-ix-tab": import("../components/ix-tab/element.js").MDNIXTab;
     "mdn-ix-tab-panel": import("../components/ix-tab-panel/element.js").MDNIXTabPanel;
     "mdn-ix-tab-wrapper": import("../components/ix-tab-wrapper/element.js").MDNIXTabWrapper;
+    "mdn-language-always-redirect-button": import("../components/language-always-redirect-button/element.js").MDNLanguageAlwaysRedirectButton;
     "mdn-language-switcher": import("../components/language-switcher/element.js").MDNLanguageSwitcher;
     "mdn-live-sample-result": import("../components/live-sample-result/element.js").MDNLiveSampleResult;
     "mdn-login-button": import("../components/login-button/element.js").MDNLoginButton;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds the "Remember language" feature to the language switcher.
Also adds `en-US` shortcuts to the translation banner.

### Motivation

Parity with yari, and improved UX for users preferring `en-US` despite their browser indicating preference for another locale.

### Additional details

Included related changes:

- Adds the `switch` component, [based on ux-components](https://mdn.github.io/ux-components/pages/sandbox/index.html#switch).
- Adds the `cookie` utils component, [based on yari](https://github.com/mdn/yari/blob/5465a64478c25a19119f1d70152a20b318eae531/client/src/utils.ts#L166-L202).
- Adds the `preferred-locale` utils component, [based on yari](https://github.com/mdn/yari/blob/5465a64478c25a19119f1d70152a20b318eae531/client/src/ui/organisms/article-actions/language-menu/index.tsx#L144-L158).
- Adds the `target` property to the `button` component.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

