### PR TITLE
chore(breadcrumbs): add structured data

### DIFF
--- a/components/breadcrumbs/server.js
+++ b/components/breadcrumbs/server.js
@@ -58,15 +58,22 @@ export class Breadcrumbs extends ServerComponent {
     }
 
     return html`
-      <ul class="breadcrumbs">
+      <ol
+        class="breadcrumbs"
+        vocab="https://schema.org/"
+        typeof="BreadcrumbList"
+      >
         ${parents.map(
-          ({ uri, title }) => html`
-            <li>
-              <a href=${uri}>${title}</a>
+          ({ uri, title }, index) => html`
+            <li property="itemListElement" typeof="ListItem">
+              <a href=${uri} property="item" typeof="WebPage"
+                ><span property="name">${title}</span></a
+              >
+              <meta property="position" content=${index + 1} />
             </li>
           `,
         )}
-      </ul>
+      </ol>
     `;
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds structured breadcrumbs data.

(Note: Also switches from `<ul>` to `<ol>`, because breadcrumbs _are_ ordered.)

### Motivation

Parity with yari, and SEO.

### Additional details

See: https://developers.google.com/search/docs/appearance/structured-data/breadcrumb#rdfa_1

Tested with: https://search.google.com/test/rich-results

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

