### PR TITLE
refactor(favicon): update favicon snippet

### DIFF
--- a/components/favicon/pure.js
+++ b/components/favicon/pure.js
@@ -1,13 +1,16 @@
 import { html } from "@lit-labs/ssr";
 
 export default function Favicon() {
-  return html`<link
-      rel="shortcut icon"
+  return html`
+    <link
+      rel="icon"
+      sizes="32x32"
       href="https://developer.mozilla.org/favicon.ico"
     />
     <link
-      rel="alternate icon"
+      rel="icon"
       type="image/svg+xml"
       href="https://developer.mozilla.org/favicon.svg"
-    />`;
+    />
+  `;
 }

--- a/components/pagination/server.js
+++ b/components/pagination/server.js
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 
-
 import arrowLeftIcon from "../icon/arrow-left.svg?lit";
 import arrowRightIcon from "../icon/arrow-right.svg?lit";
 import { ServerComponent } from "../server/index.js";


### PR DESCRIPTION
### Description

- Cleans up the snippet
- Fixes the double-icon download in Chrome
  - Only SVG is downloaded now (like in Firefox)
  - Safari still downloads both, oh well

### Before/after

![before](https://github.com/user-attachments/assets/06196aaa-4863-4d40-a6ca-d09765650ab4)

![after](https://github.com/user-attachments/assets/811cfe73-0118-4780-8f72-bef947a654b6)