### PR TITLE
fix(navigation): don’t stretch logo link on mobile

### DIFF
--- a/components/navigation/mobile.css
+++ b/components/navigation/mobile.css
@@ -7,7 +7,11 @@
 
   .navigation {
     display: grid;
+
     grid-template-columns: 1fr min-content;
+
+    justify-items: start;
+
     height: var(--top-nav-height);
 
     &[data-open="true"] {


### PR DESCRIPTION
### Description

Otherwise, there’s a phantom clickable area across the header