### PR TITLE
chore(content-section): style tables including properties

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -84,6 +84,15 @@
     width: 100%;
     border-collapse: collapse;
 
+    tr {
+      background-color: var(--color-background-primary);
+    }
+
+    thead tr,
+    tr:nth-of-type(2n) {
+      background-color: var(--color-background-page);
+    }
+
     th,
     td {
       padding: 0.5rem 0.75rem;
@@ -93,18 +102,9 @@
     th {
       font-weight: normal;
       text-align: left;
-      background-color: var(--color-background-secondary);
     }
 
     &.properties {
-      tr {
-        background-color: var(--color-background-primary);
-      }
-
-      tr:nth-of-type(2n) {
-        background-color: var(--color-background-page);
-      }
-
       th,
       td {
         border-width: 1px 0;

--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -95,6 +95,26 @@
       text-align: left;
       background-color: var(--color-background-secondary);
     }
+
+    &.properties {
+      tr {
+        background-color: var(--color-background-primary);
+      }
+
+      tr:nth-of-type(2n) {
+        background-color: var(--color-background-page);
+      }
+
+      th,
+      td {
+        border-width: 1px 0;
+      }
+
+      th {
+        font-weight: bold;
+        background-color: transparent;
+      }
+    }
   }
 
   .code-example,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates styling for tables with the `.properties` class

<img width="626" alt="Screenshot 2025-07-07 at 16 48 03" src="https://github.com/user-attachments/assets/f5d790d6-f89f-4f2a-8795-9eed76d34185" />

Also updates styling for 'regular' tables in content to include zebra striping


