### PR TITLE
ci(npm-publish-simulation): wait for rari

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -65,7 +65,10 @@ jobs:
         working-directory: mdn/content
         run: yarn start:fred > /tmp/stdout.log 2> /tmp/stderr.log &
 
-      - name: View some URLs on localhost:3000
+      - name: Wait for Rari (localhost:8083)
+        run: curl --retry-connrefused --retry 5 -I http://localhost:8083/en-US/
+
+      - name: Test Fred (localhost:3000)
         run: |
           curl --retry-connrefused --retry 5 -I http://localhost:3000
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Waits for rari before requesting pages from fred in the `npm-publish-simulation` workflow.

### Motivation

The workflow is currently failing, because rari isn't ready yet (and returns HTTP 504s) when fred tries to access it.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

