### PR TITLE
enhance(breadcrumbs-bar): show language-switcher on non-Doc pages

### DIFF
--- a/components/breadcrumbs-bar/server.js
+++ b/components/breadcrumbs-bar/server.js
@@ -20,6 +20,19 @@ export class BreadcrumbsBar extends ServerComponent {
       ? html`<mdn-toggle-sidebar></mdn-toggle-sidebar>`
       : nothing;
 
+    /**
+     * @type {import("@rari").Translation[]}
+     */
+    const other_translations =
+      "other_translations" in context
+        ? context.other_translations
+        : "doc" in context && "other_translations" in context.doc
+          ? context.doc.other_translations
+          : [];
+    const native = other_translations.find(
+      (t) => t.locale === context.locale,
+    )?.native;
+
     return html`
       <div class="breadcrumbs-bar" data-scheme=${colorScheme}>
         ${toggleSidebar} ${Breadcrumbs.render(context)}
@@ -30,15 +43,11 @@ export class BreadcrumbsBar extends ServerComponent {
             ></mdn-collection-save-button>`
           : nothing}
         <mdn-color-theme></mdn-color-theme>
-        ${"doc" in context
+        ${other_translations.length > 0
           ? html`<mdn-language-switcher
               locale=${context.locale}
-              native=${context.doc.native}
-              translations=${JSON.stringify(
-                "other_translations" in context.doc
-                  ? context.doc.other_translations
-                  : [],
-              )}
+              native=${native}
+              translations=${JSON.stringify(other_translations)}
               url=${context.url}
             ></mdn-language-switcher>`
           : nothing}

--- a/components/breadcrumbs-bar/server.js
+++ b/components/breadcrumbs-bar/server.js
@@ -39,13 +39,13 @@ export class BreadcrumbsBar extends ServerComponent {
    * @param {import("@fred").Context} context
    */
   _renderLanguageSwitcher(context) {
-    const other_translations =
+    const translations =
       "other_translations" in context
         ? context.other_translations
         : "doc" in context && "other_translations" in context.doc
           ? context.doc.other_translations
           : [];
-    const native = other_translations.find(
+    const native = translations.find(
       (t) => t.locale === context.locale,
     )?.native;
 
@@ -56,7 +56,7 @@ export class BreadcrumbsBar extends ServerComponent {
     return html`<mdn-language-switcher
       locale=${context.locale}
       native=${native}
-      translations=${JSON.stringify(other_translations)}
+      translations=${JSON.stringify(translations)}
       url=${context.url}
     ></mdn-language-switcher>`;
   }

--- a/components/breadcrumbs-bar/server.js
+++ b/components/breadcrumbs-bar/server.js
@@ -20,19 +20,6 @@ export class BreadcrumbsBar extends ServerComponent {
       ? html`<mdn-toggle-sidebar></mdn-toggle-sidebar>`
       : nothing;
 
-    /**
-     * @type {import("@rari").Translation[]}
-     */
-    const other_translations =
-      "other_translations" in context
-        ? context.other_translations
-        : "doc" in context && "other_translations" in context.doc
-          ? context.doc.other_translations
-          : [];
-    const native = other_translations.find(
-      (t) => t.locale === context.locale,
-    )?.native;
-
     return html`
       <div class="breadcrumbs-bar" data-scheme=${colorScheme}>
         ${toggleSidebar} ${Breadcrumbs.render(context)}
@@ -43,15 +30,34 @@ export class BreadcrumbsBar extends ServerComponent {
             ></mdn-collection-save-button>`
           : nothing}
         <mdn-color-theme></mdn-color-theme>
-        ${other_translations.length > 0
-          ? html`<mdn-language-switcher
-              locale=${context.locale}
-              native=${native}
-              translations=${JSON.stringify(other_translations)}
-              url=${context.url}
-            ></mdn-language-switcher>`
-          : nothing}
+        ${this._renderLanguageSwitcher(context)}
       </div>
     `;
+  }
+
+  /**
+   * @param {import("@fred").Context} context
+   */
+  _renderLanguageSwitcher(context) {
+    const other_translations =
+      "other_translations" in context
+        ? context.other_translations
+        : "doc" in context && "other_translations" in context.doc
+          ? context.doc.other_translations
+          : [];
+    const native = other_translations.find(
+      (t) => t.locale === context.locale,
+    )?.native;
+
+    if (!native) {
+      return nothing;
+    }
+
+    return html`<mdn-language-switcher
+      locale=${context.locale}
+      native=${native}
+      translations=${JSON.stringify(other_translations)}
+      url=${context.url}
+    ></mdn-language-switcher>`;
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Shows the language switcher also on other pages.

### Motivation

Consistency: The language selector was previously only shown on doc pages.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Upstream:

- https://github.com/mdn/rari/pull/272

(Until that change has landed and is released, tsc will complain.)
