### PR TITLE
fix(content-section): revert anchor styling

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -42,8 +42,28 @@
     letter-spacing: 0.025em;
   }
 
-  a:visited {
-    color: var(--color-link-visited);
+  a {
+    &:visited {
+      color: var(--color-link-visited);
+    }
+
+    /* Regular links */
+    &:not([href^="#"]) {
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+
+    /* Anchor links */
+    &[href^="#"] {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   code {


### PR DESCRIPTION
### Description

No decoration for anchors. Needs to be further improved with the `self-link` class