### PR TITLE
fix(external-link): icon alignment

### DIFF
--- a/components/external-link/global.css
+++ b/components/external-link/global.css
@@ -1,21 +1,21 @@
-.external {
-  &::after {
-    display: inline-block;
+.external::after {
+  display: inline-block;
 
-    width: 1em;
-    height: 1em;
+  width: 1em;
+  height: 1em;
 
-    margin-left: 0.25em;
+  margin-left: 0.25em;
 
-    /*
-      Unicode zero width space as `<content replacement>` to expose the alt text in the a11y tree.
-      See: https://bugzilla.mozilla.org/show_bug.cgi?id=1976574
-    */
-    content: "\200b" / " (external)";
+  vertical-align: text-top;
 
-    background-color: currentcolor;
+  /*
+    Unicode zero width space as `<content replacement>` to expose the alt text in the a11y tree.
+    See: https://bugzilla.mozilla.org/show_bug.cgi?id=1976574
+  */
+  content: "\200b" / " (external)";
 
-    mask-image: url("../icon/external-link.svg");
-    mask-size: cover;
-  }
+  background-color: currentcolor;
+
+  mask-image: url("../icon/external-link.svg");
+  mask-size: cover;
 }


### PR DESCRIPTION
### Description

Added `vertical-align: middle`, otherwise non-empty `content` pushes it up
