### PR TITLE
fix(blog): avoid page jumping on load

### DIFF
--- a/components/blog-index/server.css
+++ b/components/blog-index/server.css
@@ -113,8 +113,7 @@
     display: flex;
 
     width: auto;
-    height: auto;
-    max-height: 200px;
+    height: 200px;
 
     margin: 0 0 0.125rem;
     margin-bottom: 0;

--- a/components/blog-index/server.js
+++ b/components/blog-index/server.js
@@ -46,8 +46,8 @@ function PostPreview(context, blogMeta, lazyLoad = false) {
       ${BlogIndexImageFigure(context, {
         image: blogMeta.image,
         slug: blogMeta.slug,
-        width: 200,
-        height: 200,
+        width: 1200,
+        height: 630,
         lazyLoad,
       })}
       <h2>


### PR DESCRIPTION
### Description

- Add proper sizing for covers (1200 x 630)
- Set the height, use auto from the image

Before/after

https://github.com/user-attachments/assets/3935814a-7cd4-4bbd-9366-d0b9e85eb2f5