### PR TITLE
enhance(search-modal): align highlight with sidebar/toc

### DIFF
--- a/components/search-modal/element.css
+++ b/components/search-modal/element.css
@@ -102,10 +102,12 @@ ul {
 
 li[data-selected] {
   background: var(--color-background-blue);
+  border-color: var(--color-blue-50);
 }
 
 li {
   list-style-type: none;
+  border-inline-start: 2px solid transparent;
 
   &:not([data-selected]):hover {
     background-color: var(--color-background-secondary);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Aligns the highlight of the current item in the search dialog with the sidebar and TOC.

### Motivation

- Increases consistency
- Avoids ambiguity, especially when two items are highlighted (the current one, and the one under the mouse).

### Additional details

| Before | After |
|--------|--------|
| <img width="818" height="452" alt="image" src="https://github.com/user-attachments/assets/42108173-d829-441f-9b6b-4e33c48454fb" /> | <img width="818" height="452" alt="image" src="https://github.com/user-attachments/assets/de9eeb24-4451-4391-b7b7-0fd53ff329f3" /> |
| <img width="818" height="452" alt="image" src="https://github.com/user-attachments/assets/98f5a849-674c-485b-a625-84a19f281284" /> | <img width="818" height="452" alt="image" src="https://github.com/user-attachments/assets/9df4b044-1553-4477-a3ad-c77f96303117" /> | 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

