### PR TITLE
feat(site-search): implement site search suggestions

### DIFF
--- a/components/site-search/element.css
+++ b/components/site-search/element.css
@@ -3,14 +3,10 @@
 
   a {
     color: var(--color-link-normal);
-
-    /* text-decoration: none; */
   }
 
   a:visited {
     color: var(--color-link-visited);
-
-    /* text-decoration: none; */
   }
 
   a:hover,

--- a/components/site-search/element.css
+++ b/components/site-search/element.css
@@ -1,17 +1,21 @@
 :host {
+  line-height: var(--font-line-content);
+
   a {
     color: var(--color-link-normal);
-    text-decoration: none;
+
+    /* text-decoration: none; */
   }
 
   a:visited {
     color: var(--color-link-visited);
-    text-decoration: none;
+
+    /* text-decoration: none; */
   }
 
   a:hover,
   a:active {
-    text-decoration: underline;
+    text-decoration: none;
   }
   --color-highlight-background: light-dark(
     var(--color-yellow-80),
@@ -98,6 +102,43 @@
   font-weight: 400;
 }
 
+.site-search-suggestions__list {
+  padding: 0;
+  padding-inline: 0;
+}
+
+.site-search-suggestions__item {
+  &::before {
+    display: inline-block;
+
+    width: 1em;
+    height: 1em;
+
+    margin-right: 0.1em;
+
+    vertical-align: middle;
+
+    content: "";
+
+    background-color: var(--color-text-secondary);
+
+    mask-image: url("./../icon/arrow-right.svg");
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: contain;
+  }
+  list-style-type: none;
+}
+
+.site-search-suggestions__text {
+  margin: 1rem 0;
+}
+
+.site-search-suggestions__matches {
+  font-size: var(--font-size-small);
+  color: var(--color-text-secondary);
+}
+
 .site-search-form {
   display: flex;
   flex-direction: column;
@@ -138,11 +179,11 @@
   article {
     display: grid;
     grid-template-areas:
-      "title"
       "path"
+      "title"
       "description";
   }
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .site-search-results__title {
@@ -157,10 +198,12 @@
 
 .site-search-results__path {
   grid-area: path;
-  margin: 0 0 0.25rem;
+
+  margin: 0;
+
   font-size: var(--font-size-small);
 
-  /* color: var(--color-text-secondary); */
+  color: var(--color-text-secondary);
 }
 
 .site-search-results__description {

--- a/components/site-search/types.d.ts
+++ b/components/site-search/types.d.ts
@@ -1,6 +1,7 @@
 export interface SearchResponse {
   metadata: SearchMetadata;
   documents: SearchDocument[];
+  suggestions: SearchSuggestion[];
 }
 
 export type SearchHighlight = {

--- a/l10n/de.ftl
+++ b/l10n/de.ftl
@@ -8,6 +8,22 @@ footer-tagline = Dein Bauplan für ein besseres Internet.
 footer-mofo = Besuche die gemeinnützige Muttergesellschaft der <a data-l10n-name="moco">Mozilla Corporation</a>, die <a data-l10n-name="mofo">Mozilla Foundation</a>.
 footer-copyright = Teile dieses Inhalts sind ©1998–2024 von einzelnen mozilla.org-Mitwirkenden. Inhalte sind verfügbar unter <a data-l10n-name="cc">einer Creative-Commons-Lizenz</a>.
 
+search-title = Suchergebnisse für: <em>{ $query }</em>
+search-stats = { $results } Dokumente gefunden.
+search-modal-site-search = Erweiterte Suche nach <em>{ $query }</em>
+suggestion-matches =  { $relation ->
+    [gt] mehr als{ $matches ->
+        [one]   { $matches } Übereinstimmung
+       *[other] { $matches } Übereinstimmungen
+    }
+   *[eq] { $matches ->
+        [one]   { $matches } Übereinstimmung
+       *[other] { $matches } Übereinstimmungen
+    }
+}
+search-suggestions-text = Your search did not yield any results. Did you mean:
+
+
 theme-default = Systemstandard
 
 blog-time-to-read = { $minutes ->

--- a/l10n/de.ftl
+++ b/l10n/de.ftl
@@ -8,11 +8,11 @@ footer-tagline = Dein Bauplan für ein besseres Internet.
 footer-mofo = Besuche die gemeinnützige Muttergesellschaft der <a data-l10n-name="moco">Mozilla Corporation</a>, die <a data-l10n-name="mofo">Mozilla Foundation</a>.
 footer-copyright = Teile dieses Inhalts sind ©1998–2024 von einzelnen mozilla.org-Mitwirkenden. Inhalte sind verfügbar unter <a data-l10n-name="cc">einer Creative-Commons-Lizenz</a>.
 
-search-title = Suchergebnisse für: <em>{ $query }</em>
-search-stats = { $results } Dokumente gefunden.
 search-modal-site-search = Erweiterte Suche nach <em>{ $query }</em>
-suggestion-matches =  { $relation ->
-    [gt] mehr als{ $matches ->
+
+site-search-search-stats = { $results } Dokumente gefunden.
+site-search-suggestion-matches =  { $relation ->
+    [gt] mehr als { $matches ->
         [one]   { $matches } Übereinstimmung
        *[other] { $matches } Übereinstimmungen
     }
@@ -21,7 +21,7 @@ suggestion-matches =  { $relation ->
        *[other] { $matches } Übereinstimmungen
     }
 }
-search-suggestions-text = Your search did not yield any results. Did you mean:
+site-search-suggestions-text = Meinten Sie:
 
 
 theme-default = Systemstandard

--- a/l10n/en-US.ftl
+++ b/l10n/en-US.ftl
@@ -27,9 +27,19 @@ footer-mofo = Visit <a data-l10n-name="moco">Mozilla Corporation’s</a> not-for
 footer-copyright = Portions of this content are ©1998–2024 by individual mozilla.org contributors. Content available under <a data-l10n-name="cc">a Creative Commons license</a>.
 
 search-title = Search results for: <em>{ $query }</em>
-search-stats = Found { $results } matches in { $time } milliseconds.
-
+search-stats = Found { $results } documents.
 search-modal-site-search = Site search for <em>{ $query }</em>
+suggestion-matches =  { $relation ->
+    [gt] more than { $matches ->
+        [one]   { $matches } match
+       *[other] { $matches } matches
+    }
+   *[eq] { $matches ->
+        [one]   { $matches } match
+       *[other] { $matches } matches
+    }
+}
+search-suggestions-text = Your search did not yield any results. Did you mean:
 
 blog-time-to-read = { $minutes ->
     [one]   { $minutes } minute read
@@ -81,11 +91,11 @@ compat-support-flags =
     [one] From version { $version_added }
     *[other] {""}
   }{ $has_last ->
-    [one] { NUMBER($has_added) -> 
+    [one] { NUMBER($has_added) ->
           *[zero] Until { $versionLast } users
           [one] {" "}until { $versionLast } users
       }
-    *[zero] { NUMBER($has_added) -> 
+    *[zero] { NUMBER($has_added) ->
           *[zero] Users
           [one] {" "}users
       }

--- a/l10n/en-US.ftl
+++ b/l10n/en-US.ftl
@@ -26,10 +26,10 @@ reference-toc-header = In this article
 footer-mofo = Visit <a data-l10n-name="moco">Mozilla Corporation’s</a> not-for-profit parent, the <a data-l10n-name="mofo">Mozilla Foundation</a>.
 footer-copyright = Portions of this content are ©1998–2024 by individual mozilla.org contributors. Content available under <a data-l10n-name="cc">a Creative Commons license</a>.
 
-search-title = Search results for: <em>{ $query }</em>
-search-stats = Found { $results } documents.
 search-modal-site-search = Site search for <em>{ $query }</em>
-suggestion-matches =  { $relation ->
+
+site-search-search-stats = Found { $results } documents.
+site-search-suggestion-matches =  { $relation ->
     [gt] more than { $matches ->
         [one]   { $matches } match
        *[other] { $matches } matches
@@ -39,7 +39,7 @@ suggestion-matches =  { $relation ->
        *[other] { $matches } matches
     }
 }
-search-suggestions-text = Your search did not yield any results. Did you mean:
+site-search-suggestions-text = Did you mean:
 
 blog-time-to-read = { $minutes ->
     [one]   { $minutes } minute read


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Implementing the suggestions when passed down from the search backend.

### Motivation

Parity with yari

### Additional details

Before:
<img width="661" height="405" alt="image" src="https://github.com/user-attachments/assets/e65d3b8d-7b7a-4677-aedb-e3859ada1875" />

After:
<img width="526" height="295" alt="image" src="https://github.com/user-attachments/assets/aa61ddde-3a82-440a-900d-d308d1b6c1ea" />


