### PR TITLE
enhance(sidebar-filter): use mask icon, improve focus

### DIFF
--- a/components/sidebar-filter/element.css
+++ b/components/sidebar-filter/element.css
@@ -4,101 +4,102 @@
   position: relative;
   display: flex;
   flex-direction: column;
+}
 
-  .sidebar-filter {
-    display: flex;
-    place-items: center;
+.sidebar-filter {
+  display: flex;
+  place-items: center;
+}
+
+.sidebar-filter-label {
+  position: absolute;
+  top: 0.4em;
+  left: 0.6em; /* Move icon inside field. */
+
+  &::before {
+    display: inline-block;
+
+    width: 1.25em;
+    height: 1.25em;
+
+    content: "";
+
+    background-color: var(--color-text-secondary);
+
+    mask-image: url("../icon/filter.svg");
+    mask-size: cover;
+  }
+}
+
+.clear-sidebar-filter-button {
+  --button-bg: none;
+  --button-color: var(--color-text-primary);
+  --button-border-color: none;
+  position: absolute;
+  right: 0;
+
+  &::part(button) {
+    border-radius: 50%;
   }
 
-  .sidebar-filter-label {
-    position: absolute;
-    top: 0.375em;
-    left: 0.375em; /* Move icon inside field. */
+  &::part(button):hover {
+    background-color: transparent;
+  }
+}
+
+.sidebar-filter-input-field {
+  width: 100%;
+
+  padding-top: 0.6em;
+  padding-bottom: 0.6em;
+  padding-left: 2.5em;
+
+  color: var(--color-text-primary);
+
+  border: 1px solid var(--color-border-primary);
+  border-radius: calc(infinity * 1px);
+
+  &::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  &:focus {
+    border-color: transparent;
 
     .icon {
-      color: var(--color-text-primary);
+      color: var(--color-border-primary);
     }
   }
 
-  .clear-sidebar-filter-button {
-    --button-bg: none;
-    --button-color: var(--color-text-primary);
-    --button-border-color: none;
+  &[value=""]:not(:focus, .is-active) {
+    /** Filter collapsed. */
+    width: 5em;
+
+    ~ .sidebar-filter-count,
+    ~ .clear-sidebar-filter-button {
+      display: none;
+    }
+  }
+
+  &:focus,
+  &.is-active {
+    /** Filter is focused or active. */
+    padding-right: 7.5em;
+  }
+
+  ~ .sidebar-filter-count {
     position: absolute;
-    right: 0;
+    right: 2.5em;
 
-    &:hover {
-      --button-color: var(--color-text-secondary);
-    }
-  }
+    padding: 0 0.5em;
 
-  .sidebar-filter-input-field {
-    width: 100%;
+    font-size: 0.7rem;
 
-    padding-top: 0.5em;
-    padding-bottom: 0.5em;
-    padding-left: 2em;
+    color: var(--color-text-secondary);
 
-    color: var(--color-text-primary);
+    white-space: nowrap;
 
-    border: 1px solid var(--color-border-primary);
+    background: var(--color-background-blue);
     border-radius: 1em;
-
-    &:focus {
-      outline: 0 none;
-      border-color: light-dark(#0085f2, #5e9eff);
-
-      .icon {
-        color: var(--color-border-primary);
-      }
-    }
-
-    &[value=""]:not(:focus, .is-active) {
-      /** Filter collapsed. */
-      width: 5em;
-
-      ~ .sidebar-filter-count,
-      ~ .clear-sidebar-filter-button {
-        display: none;
-      }
-    }
-
-    &:focus,
-    &.is-active {
-      /** Filter is focused or active. */
-      padding-right: 7.5em;
-    }
-
-    ~ .sidebar-filter-count {
-      position: absolute;
-      right: 2.5em;
-
-      padding: 0 0.5em;
-
-      font-size: 0.7rem;
-
-      color: var(--color-text-secondary);
-
-      white-space: nowrap;
-
-      background: var(--color-background-blue);
-      border-radius: 1em;
-    }
-  }
-
-  /** Commons. */
-
-  .button {
-    /* Reset. */
-    appearance: none;
-    background: none;
-    border: none;
-  }
-
-  .icon {
-    svg {
-      width: 1em;
-      height: 1em;
-    }
   }
 }

--- a/components/sidebar-filter/element.js
+++ b/components/sidebar-filter/element.js
@@ -6,7 +6,6 @@ import { LitElement, html } from "lit";
 
 import { L10nMixin } from "../../l10n/mixin.js";
 import cancelIcon from "../icon/cancel.svg?lit";
-import filterIcon from "../icon/filter.svg?lit";
 
 import styles from "./element.css?lit";
 import { SidebarFilterer } from "./sidebar-filterer.js";
@@ -159,7 +158,6 @@ class MDNSidebarFilter extends L10nMixin(LitElement) {
           class="sidebar-filter-label"
           for="sidebar-filter-input"
         >
-          <span class="icon">${filterIcon}</span>
           <span class="visually-hidden">${this.l10n`Filter sidebar`}</span>
         </label>
         <input


### PR DESCRIPTION
### Description

- Use the mask icon
- Remove background from the hovered clear button
- Use native outline
- Improve the placeholder’s contrast
- Make the input and the button pill-shaped
- Align the icon better

### Before/after

<img width="2000" height="1800" alt="before-after" src="https://github.com/user-attachments/assets/1ea8721f-85c1-4a66-8732-45bb782c4f47" />
