### PR TITLE
fix(content-section): style plain pre tags

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -66,13 +66,25 @@
     }
   }
 
+  pre {
+    padding: 1rem;
+    overflow: auto;
+
+    &:not(.code-example &) {
+      border: 1px solid var(--color-border-primary);
+      border-radius: 0.25em;
+    }
+  }
+
   code {
     padding: 0.125em 0.25em;
-
-    font-family: var(--font-family-code);
-
-    background-color: var(--color-background-secondary);
     border-radius: 0.25em;
+  }
+
+  pre,
+  code {
+    font-family: var(--font-family-code);
+    background-color: var(--color-background-secondary);
   }
 
   img {


### PR DESCRIPTION
Alternative to https://github.com/mdn/fred/pull/334.

We shouldn't "upgrade" these plain pre tags to code blocks without changes in rari to ensure they have a header, so we don't get content shifts.

So for now, just style them like we do on prod:

## Current fred:

<img width="787" height="720" alt="Screenshot 2025-07-11 at 14-08-16 HTML Creating the content" src="https://github.com/user-attachments/assets/1473633c-0379-41c0-8fed-703e2b9b72e8" />

## Current prod:

<img width="790" height="727" alt="Screenshot 2025-07-11 at 14-08-00 HTML Creating the content - Learn web development MDN" src="https://github.com/user-attachments/assets/a725def0-9dbc-4cfb-86ae-3e9d5e084491" />

## New fred:

<img width="788" height="755" alt="Screenshot 2025-07-11 at 14-16-36 HTML Creating the content" src="https://github.com/user-attachments/assets/9ce15cce-3ba3-4c21-ad99-2c61051605ab" />
