### PR TITLE
enhance(search-modal): show crumbs on top

### DIFF
--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -209,13 +209,13 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
                 ({ title, url }, i) => html`
                   <li ?data-selected=${this._selected === i} data-result=${i}>
                     <a href=${url}
-                      ><span class="title"
-                        >${HighlightMatch(title, this._query)}</span
-                      >
-                      <span class="slug"
+                      ><span class="slug"
                         >${mdnUrl2Breadcrumb(url, this.locale)}</span
                       >
-                    </a>
+                      <span class="title"
+                        >${HighlightMatch(title, this._query)}</span
+                      ></a
+                    >
                   </li>
                 `,
               ),


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Moves the Search result breadcrumbs to the top.

### Motivation

Makes it easier to skim through results, especially if the results contain multiple items with a similar title (e.g `background`).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

