### PR TITLE
fix(blog): responsiveness

### DIFF
--- a/components/blog-index/server.css
+++ b/components/blog-index/server.css
@@ -59,6 +59,10 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: 2rem;
+
+  @media (--screen-large-and-narrower) {
+    grid-template-columns: auto;
+  }
 }
 
 .blog-post-preview {
@@ -113,7 +117,7 @@
     display: flex;
 
     width: auto;
-    height: 200px;
+    max-height: 200px;
 
     margin: 0 0 0.125rem;
     margin-bottom: 0;

--- a/components/blog-index/server.js
+++ b/components/blog-index/server.js
@@ -12,13 +12,12 @@ import { ServerComponent } from "../server/index.js";
  * @param {object} params
  * @param {import("@rari").BlogImage} params.image
  * @param {string} params.slug
- * @param {number} params.width
  * @param {number} params.height
  * @param {boolean} params.lazyLoad
  */
 export function BlogIndexImageFigure(
   _context,
-  { image, slug, width, height, lazyLoad },
+  { image, slug, height, lazyLoad },
 ) {
   const src = `/en-US/blog/${slug}/${image.file}`;
   return html`<figure class="blog-post-preview__figure">
@@ -27,7 +26,6 @@ export function BlogIndexImageFigure(
         alt=${image.alt || ""}
         src=${src}
         height=${height}
-        width=${width}
         loading=${lazyLoad ? "lazy" : "eager"}
       />
     </a>
@@ -46,8 +44,7 @@ function PostPreview(context, blogMeta, lazyLoad = false) {
       ${BlogIndexImageFigure(context, {
         image: blogMeta.image,
         slug: blogMeta.slug,
-        width: 1200,
-        height: 630,
+        height: 200,
         lazyLoad,
       })}
       <h2>


### PR DESCRIPTION
### Description

Fixed 1-col / 2-col responsiveness on the blog index page

### Motivation

Yari parity.

Before:
<img width="635" height="570" alt="image" src="https://github.com/user-attachments/assets/690692a9-6979-49f6-aea5-126ecca0d325" />

After:
<img width="633" height="579" alt="image" src="https://github.com/user-attachments/assets/fbe9adb8-3385-4ede-8fb7-f658518265e0" />
