### PR TITLE
fix(code-example): add prism theme from yari

### DIFF
--- a/components/code-example/element.css
+++ b/components/code-example/element.css
@@ -1,5 +1,5 @@
 @import url("../global/global.css");
-@import url("prismjs/themes/prism.css");
+@import url("./prism.css");
 @import url("./common.css");
 
 .code-example {

--- a/components/code-example/prism.css
+++ b/components/code-example/prism.css
@@ -1,0 +1,60 @@
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: light-dark(#858585, #b3b3b3);
+}
+
+.token.punctuation {
+  color: light-dark(#858585, #b3b3b3);
+}
+
+.token.attr-name,
+.token.builtin,
+.token.inserted,
+.token.selector,
+.token.property,
+.token.class-name,
+.token.function {
+  color: light-dark(#d30038, #ff97a0);
+}
+
+.token.atrule,
+.token.attr-value {
+  color: light-dark(#007936, #00d061);
+}
+
+.token.keyword {
+  color: light-dark(#0069c2, #c1cff1);
+}
+
+.token.tag,
+.token.char,
+.token.string,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: light-dark(#007936, #00d061);
+}
+
+.token.selector,
+.token.builtin,
+.token.template-string > .token.string,
+.token.inserted {
+  color: light-dark(#872bff, #bea5ff);
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}


### PR DESCRIPTION
Light example:

<img width="1353" height="896" alt="Screenshot 2025-07-11 at 16-01-35 Array from()" src="https://github.com/user-attachments/assets/7f30eb98-6d90-4593-ab6d-dd6a4fc7bb2d" />

Dark example:

<img width="1353" height="896" alt="Screenshot 2025-07-11 at 16-01-29 Array from()" src="https://github.com/user-attachments/assets/fe209259-d9a1-4f85-bff1-80454ab8606d" />
