### PR TITLE
chore(outer-layout): add robots meta

### DIFF
--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -1,4 +1,5 @@
 import { html } from "@lit-labs/ssr";
+import { nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
@@ -110,6 +111,21 @@ export class OuterLayout extends ServerComponent {
    * @param {import("@fred").Context} context
    */
   _renderMeta(context) {
+    const ALWAYS_ALLOW_ROBOTS = false; // FIXME
+    const noIndexing =
+      "doc" in context
+        ? context.doc.noIndexing
+        : "noIndexing" in context
+          ? context.noIndexing
+          : false;
+    const onlyFollow = "onlyFollow" in context ? context.onlyFollow : false;
+    const robots =
+      !ALWAYS_ALLOW_ROBOTS || noIndexing
+        ? "noindex, nofollow"
+        : onlyFollow
+          ? "noindex, follow"
+          : "";
+
     const title =
       ("doc" in context ? context.doc.pageTitle : context.pageTitle) ||
       "MDN Web Docs";
@@ -121,11 +137,9 @@ export class OuterLayout extends ServerComponent {
           : "") ||
       "The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps.";
 
-    const names = {
+    const entries = {
+      robots,
       description,
-    };
-
-    const og = {
       "og:url": `https://developer.mozilla.org${context.url}`,
       "og:title": title,
       "og:locale": context.locale.replace("-", "_"),
@@ -138,25 +152,12 @@ export class OuterLayout extends ServerComponent {
       "og:image:alt":
         "The MDN Web Docs logo, featuring a blue accent color, displayed on a solid black background.",
       "og:site_name": "MDN Web Docs",
-    };
-
-    const twitter = {
       "twitter:card": "summary_large_image",
       "twitter:creator": "MozDevNet",
     };
 
-    const tags = [
-      ...Object.entries(names).map(
-        ([key, value]) => html`<meta name=${key} content=${value} />`,
-      ),
-      ...Object.entries(og).map(
-        ([key, value]) => html`<meta name=${key} content=${value} />`,
-      ),
-      ...Object.entries(twitter).map(
-        ([key, value]) => html`<meta name=${key} content=${value} />`,
-      ),
-    ];
-
-    return html`${tags}`;
+    return Object.entries(entries).map(([key, value]) =>
+      value ? html`<meta name=${key} content=${value} />` : nothing,
+    );
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds a `robots` meta tag to the outer layout.

### Motivation

Avoids that search engines index pages we don't want them to index (like the MDN Kitchensink).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

