### PR TITLE
fix(interactive-examples): dark theme now applies on load

### DIFF
--- a/components/color-theme/controller.js
+++ b/components/color-theme/controller.js
@@ -23,13 +23,7 @@ export class ThemeController {
   /** @param {Event} [event] */
   _updateTheme(event) {
     let value = event instanceof CustomEvent && this._lightOrDark(event.detail);
-    try {
-      value ||= this._lightOrDark(
-        getComputedStyle(this.#host).getPropertyValue("color-scheme"),
-      );
-    } catch {
-      /* no-op */
-    }
+    value ||= this._lightOrDark(document.documentElement.style.colorScheme);
     value ||= this._matchMedia?.matches ? "dark" : "light";
     const oldValue = this.value;
     this.value = value;


### PR DESCRIPTION
https://github.com/mdn/fred/commit/dbf60d16afe109bba069c7f61d4ff2eff9513d39 fixed things for the playground but not interactive examples

