### PR TITLE
fix(live-samples): assets wouldn't load in playground

### DIFF
--- a/components/live-sample-result/element.css
+++ b/components/live-sample-result/element.css
@@ -1,3 +1,4 @@
+@import url("../global/global.css");
 @import url("../code-example/common.css");
 
 .code-example {

--- a/components/live-sample-result/element.js
+++ b/components/live-sample-result/element.js
@@ -75,6 +75,8 @@ export class MDNLiveSampleResult extends L10nMixin(LitElement) {
     }
     const playUrl = new URL("/en-US/play", location.href);
     playUrl.search = new URL(this._runnerSrc).search;
+    if (this.srcPrefix)
+      playUrl.searchParams.append("srcPrefix", this.srcPrefix);
     this.breakoutLink = playUrl.href;
   }
 
@@ -92,7 +94,11 @@ export class MDNLiveSampleResult extends L10nMixin(LitElement) {
       <div class="code-example">
         <div class="example-header">
           ${this.breakoutLink
-            ? html`<mdn-button variant="secondary" href=${this.breakoutLink}
+            ? html`<mdn-button
+                variant="secondary"
+                href=${this.breakoutLink}
+                target="_blank"
+                rel="opener"
                 >${this.l10n`Play`}</mdn-button
               >`
             : nothing}

--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -173,13 +173,16 @@ ${"```"}`,
       const params = new URLSearchParams(location.search);
       const idParam = params.get("id");
       const stateParam = params.get("state");
+      const srcPrefixParam = params.get("srcPrefix");
 
-      const { srcPrefix, code } =
+      const { srcPrefix: srcPrefixState, code } =
         (await (idParam
           ? this._sessionFromApi(idParam)
           : stateParam
             ? this._sessionFromState(stateParam)
             : undefined)) || {};
+
+      const srcPrefix = srcPrefixParam || srcPrefixState;
 
       if (
         srcPrefix !== undefined &&

--- a/server.js
+++ b/server.js
@@ -277,6 +277,19 @@ export async function startServer() {
     );
   }
 
+  // live sample assets
+  play.use(
+    createProxyMiddleware({
+      target: RARI_URL,
+      changeOrigin: true,
+      proxyTimeout: 20_000,
+      timeout: 20_000,
+      headers: {
+        Connection: "keep-alive",
+      },
+    }),
+  );
+
   const httpServer = app.listen(3000, () => {
     console.log(
       `Server started at ${http2 ? "https" : "http"}://localhost:3000`,


### PR DESCRIPTION
fix size of header, open play link in new tab, and autorun

proxy assets in dev environment

example: https://fred.review.mdn.allizom.net/en-US/docs/Web/API/Canvas_API/Tutorial/Using_images#art_gallery_example