### PR TITLE
fix(playground): code blocks wouldn't scroll in certain browsers

### DIFF
--- a/components/playground/element.css
+++ b/components/playground/element.css
@@ -1,3 +1,5 @@
+@import url("../global/global.css");
+
 .wrapper {
   display: grid;
 
@@ -50,8 +52,6 @@
     }
 
     details {
-      display: flex;
-
       flex-shrink: 0;
       flex-direction: column;
 
@@ -66,8 +66,14 @@
         min-height: 12rem;
       }
 
+      &::details-content {
+        display: contents;
+      }
+
       summary {
-        padding: 0.5rem;
+        height: 2em;
+
+        padding: 0.5em;
 
         line-height: var(--font-line-ui);
 
@@ -76,8 +82,7 @@
       }
 
       mdn-play-editor {
-        flex-grow: 1;
-        min-height: 0;
+        height: calc(100% - 2em);
       }
     }
 


### PR DESCRIPTION
applying `display: flex;` to a `<details>` element is only recently supported
so we can't use it

launch this code example in the playground to see (in stable Firefox or Chrome): https://fred.review.mdn.allizom.net/en-US/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls/Example_5