### PR TITLE
fix(ix): not enough contrast in tab text colour

### DIFF
--- a/components/color/border.css
+++ b/components/color/border.css
@@ -9,5 +9,5 @@
     var(--color-gray-40),
     var(--color-gray-60)
   );
-  --color-border-active: light-dark(var(--color-blue-80), var(--color-blue-20));
+  --color-border-active: light-dark(var(--color-blue-50), var(--color-blue-80));
 }


### PR DESCRIPTION
example here: https://fred.review.mdn.allizom.net/en-US/docs/Web/HTML/Reference/Global_attributes/accesskey#try_it

before:

<img width="768" height="351" alt="image" src="https://github.com/user-attachments/assets/69f53c99-c4bf-4acc-ab27-96c2332ee211" />

after:

<img width="768" height="353" alt="image" src="https://github.com/user-attachments/assets/2fd13b98-2e97-47b6-b561-599e907f77c2" />


