### PR TITLE
fix(code-example): highlight good and bad examples

### DIFF
--- a/components/code-example/common.css
+++ b/components/code-example/common.css
@@ -23,22 +23,62 @@
   }
 
   pre {
-    padding: 1rem;
+    display: flex;
     margin: 0;
-
-    overflow: auto;
-
     background-color: var(--color-background-secondary);
 
     code {
-      padding: 0;
+      flex-grow: 1;
+      flex-shrink: 1;
+
+      padding: 1rem;
+
+      overflow: auto;
+
       font-family: var(--font-family-code);
+
       background-color: transparent;
     }
 
     &.hidden,
     &[class*="interactive-example"] {
       display: none;
+    }
+
+    &.example-good,
+    &.example-bad {
+      &::after {
+        display: inline-block;
+
+        flex-shrink: 0;
+
+        width: 1.24rem;
+        height: 1.24rem;
+
+        margin: 1.255rem 1rem;
+
+        content: "";
+
+        mask-size: cover;
+      }
+    }
+
+    &.example-good {
+      background-color: var(--color-background-green);
+
+      &::after {
+        background-color: var(--color-text-green);
+        mask-image: url("../icon/circle-check.svg");
+      }
+    }
+
+    &.example-bad {
+      background-color: var(--color-background-red);
+
+      &::after {
+        background-color: var(--color-text-red);
+        mask-image: url("../icon/circle-x.svg");
+      }
     }
   }
 

--- a/components/code-example/element.js
+++ b/components/code-example/element.js
@@ -82,7 +82,9 @@ export class MDNCodeExample extends LitElement {
               >`
             : nothing}
         </div>
-        <pre><code ${ref(this._codeRef)}>${this._highlightTask.render({
+        <pre class=${this.className}><code ${ref(
+          this._codeRef,
+        )}>${this._highlightTask.render({
           initial: () => this.code,
           pending: () => this.code,
           complete: (highlighted) => unsafeHTML(highlighted),
@@ -107,16 +109,13 @@ export function upgradePre(pre) {
     const hidden = [...pre.classList].some(
       (c) => c === "hidden" || c.startsWith("interactive-example"),
     );
-    const liveSampleClasses = [...pre.classList].filter(
-      (c) => c.startsWith("live-sample___") || c.startsWith("live-sample---"),
-    );
     const code = pre.querySelector("code")?.textContent;
     if (example && language && code) {
       const newExample = document.createElement("mdn-code-example");
       newExample.language = language;
       newExample.code = code;
       newExample.hidden = hidden;
-      newExample.classList = [...liveSampleClasses].join(" ");
+      newExample.className = pre.className;
       example.replaceWith(newExample);
       return newExample;
     }

--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -66,14 +66,13 @@
     }
   }
 
-  pre {
+  pre:not(.code-example pre) {
     padding: 1rem;
+
     overflow: auto;
 
-    &:not(.code-example &) {
-      border: 1px solid var(--color-border-primary);
-      border-radius: 0.25em;
-    }
+    border: 1px solid var(--color-border-primary);
+    border-radius: 0.25rem;
   }
 
   code {


### PR DESCRIPTION
Examples of good and bad example blocks: http://localhost:3000/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#links

Example of plain `pre` styling which I had to adjust a bit: http://localhost:3000/en-US/docs/Glossary/Base64#base64_characters