### PR TITLE
feat(playground): add reporting modal for shared examples

### DIFF
--- a/components/playground/element.css
+++ b/components/playground/element.css
@@ -129,11 +129,8 @@
 mdn-modal {
   section {
     display: flex;
-
     flex-direction: column;
-
     gap: 0.5rem;
-    align-items: center;
 
     &:first-child {
       margin-bottom: 1rem;
@@ -144,5 +141,24 @@ mdn-modal {
     margin: 0;
     font-size: var(--font-size-normal);
     font-weight: normal;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  &.share section {
+    align-items: center;
+  }
+
+  &.report section:last-child {
+    flex-direction: row;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
Replicates the behaviour from yari.

Example flag here: https://github.com/mdn/playground-flags/issues/512

<img width="2470" height="1644" alt="Screenshot 2025-07-14 at 18-21-49 Playground MDN" src="https://github.com/user-attachments/assets/10490262-47da-4773-9cf9-8eed01d68814" />
