### PR TITLE
chore(outer-layout): move favicons below scripts

### DIFF
--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -77,7 +77,7 @@ export class OuterLayout extends ServerComponent {
             content="width=device-width, initial-scale=1.0"
           />
           <title>${context.pageTitle || "MDN"}</title>
-          ${Favicon()} ${unsafeHTML(`<script>${inlineScript}</script>`)}
+          ${unsafeHTML(`<script>${inlineScript}</script>`)}
           ${styles.map(
             (path) =>
               html`<link rel="stylesheet" href=${path} fetchpriority="high" />`,
@@ -96,7 +96,7 @@ export class OuterLayout extends ServerComponent {
           ${scripts?.map(
             (path) => html`<script src=${path} type="module"></script>`,
           )}
-          ${this._renderMeta(context)}
+          ${Favicon()} ${this._renderMeta(context)}
           <link
             rel="canonical"
             href=${`https://developer.mozilla.org${context.url}`}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Moves the favicon `<link>`s below the `<script>`s.

### Motivation

Improve performance by prioritizing elements critical for rendering. 

### Additional details

See: https://rviscomi.github.io/capo.js/user/demo/?url=https%3A%2F%2Ffred.review.mdn.allizom.net%2Fen-US%2F

### Related issues and pull requests

See: https://github.com/mdn/yari/pull/12375
