### PR TITLE
fix(article-footer): remove link from header

### DIFF
--- a/components/article-footer/server.css
+++ b/components/article-footer/server.css
@@ -19,10 +19,6 @@
     margin-right: 1rem;
     margin-left: 1rem;
   }
-
-  .heading-anchor::before {
-    display: none;
-  }
 }
 
 .article-footer__inner {

--- a/components/article-footer/server.js
+++ b/components/article-footer/server.js
@@ -1,6 +1,5 @@
 import { html } from "lit";
 
-import { HeadingAnchor } from "../heading-anchor/server.js";
 import { ServerComponent } from "../server/index.js";
 
 import svg from "./article-footer.svg?lit";
@@ -16,21 +15,19 @@ export class ArticleFooter extends ServerComponent {
       return;
     }
 
-    return html`<section
-      class="content-section article-footer"
-      aria-labelledby="article_footer"
-    >
-      <div class="article-footer__inner">
-        <div class="article-footer__svg-container">${svg}</div>
-        ${HeadingAnchor.render(
-          2,
-          "article_footer",
-          context.l10n`Help improve MDN`,
-        )}
-        <mdn-content-feedback locale=${context.locale}></mdn-content-feedback>
-        ${Contribute(context)} ${LastModified(context)} ${Links(context)}
-      </div>
-    </section>`;
+    return html`
+      <section
+        class="content-section article-footer"
+        aria-labelledby="feedback"
+      >
+        <div class="article-footer__inner">
+          <div class="article-footer__svg-container">${svg}</div>
+          <h2 id="feedback">Help improve MDN</h2>
+          <mdn-content-feedback locale=${context.locale}></mdn-content-feedback>
+          ${Contribute(context)} ${LastModified(context)} ${Links(context)}
+        </div>
+      </section>
+    `;
   }
 }
 


### PR DESCRIPTION
### Description

- Removes the anchor link from the article footer’s heading
- Uses user-readable `#feedback` anchor

### Before/after

<img width="1361" height="1206" alt="before-after" src="https://github.com/user-attachments/assets/f7bdbb79-31a4-4dda-a838-4ac4bc276885" />
