### PR TITLE
fix(legacy): environment variables weren't being bundled

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -80,15 +80,6 @@ const common = {
     new StatsWriterPlugin({
       fields: ["publicPath", "entrypoints"],
     }),
-    new rspack.DefinePlugin({
-      "process.env": JSON.stringify({
-        ...Object.fromEntries(
-          Object.entries(process.env).filter(([key]) =>
-            key.startsWith("FRED_"),
-          ),
-        ),
-      }),
-    }),
   ],
   optimization: {
     minimizer: [
@@ -156,6 +147,17 @@ const common = {
 
 /** @type {import("@rspack/core").RspackOptions} */
 const clientAndSsrCommon = {
+  plugins: [
+    new rspack.DefinePlugin({
+      "process.env": JSON.stringify({
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(([key]) =>
+            key.startsWith("FRED_"),
+          ),
+        ),
+      }),
+    }),
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
the legacy env vars were being clobbered by the non-legacy ones

explored some better ways of doing environment variables in non-legacy code, before opting for the simple solution - we should probably revamp this a little bit, but not until after launch
