### PR TITLE
fix(not-found): use global link styles

### DIFF
--- a/components/not-found/element.css
+++ b/components/not-found/element.css
@@ -1,3 +1,4 @@
+@import url("../global/global.css");
 @import url("../notecard/index.css");
 
 code {

--- a/components/not-found/element.js
+++ b/components/not-found/element.js
@@ -83,7 +83,7 @@ export class MDNNotFound extends L10nMixin(LitElement) {
                     <a
                       href=${`/${locale}/search?q=${encodeURIComponent(part)}`}
                     >
-                      <code>${part}</code>
+                      ${part}
                     </a>
                   </li>`,
               )}


### PR DESCRIPTION
### Description

- Uses global link styles
- Removes code wrapper from suggested links (they are not code)

### Before

<img width="2450" height="1442" alt="image" src="https://github.com/user-attachments/assets/f2746105-9651-4824-8863-1c92c52c8223" />

### After

<img width="2450" height="1448" alt="image" src="https://github.com/user-attachments/assets/d788ac47-8664-4a2b-82b2-a32308082023" />
