### PR TITLE
fix(content-section): add margin to dl > ul

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -212,6 +212,10 @@
       padding-left: 1rem;
       border-left: 1px solid var(--color-border-primary);
     }
+
+    ul {
+      margin: 1rem 0 2rem;
+    }
   }
 
   /* Article footer */


### PR DESCRIPTION
### Description

Adds back missing margin for dl > ul that browsers remove for some reason.

<img width="739" height="551" alt="Screenshot 2025-07-15 at 16 05 22" src="https://github.com/user-attachments/assets/ba98cd39-825b-439a-968e-a163fa03a2f9" />
