### PR TITLE
fix(syntax-highlighting): ensure comment colour is accessible

### DIFF
--- a/components/code-example/prism.css
+++ b/components/code-example/prism.css
@@ -4,11 +4,11 @@
   .token.prolog,
   .token.doctype,
   .token.cdata {
-    color: light-dark(var(--color-gray-40), #b3b3b3);
+    color: light-dark(#51565d, #b3b3b3);
   }
 
   .token.punctuation {
-    color: light-dark(var(--color-gray-40), #b3b3b3);
+    color: light-dark(#51565d, #b3b3b3);
   }
 
   .token.attr-name,

--- a/components/code-example/prism.css
+++ b/components/code-example/prism.css
@@ -4,11 +4,11 @@
   .token.prolog,
   .token.doctype,
   .token.cdata {
-    color: light-dark(#858585, #b3b3b3);
+    color: light-dark(var(--color-gray-40), #b3b3b3);
   }
 
   .token.punctuation {
-    color: light-dark(#858585, #b3b3b3);
+    color: light-dark(var(--color-gray-40), #b3b3b3);
   }
 
   .token.attr-name,


### PR DESCRIPTION
Also not accessible on yari, so this is an improvement here.

Before:

<img width="768" height="280" alt="Screenshot 2025-07-15 at 18-55-23 Control flow and error handling" src="https://github.com/user-attachments/assets/70b8fbdd-9009-4603-a0bb-13632cacda79" />

After:

<img width="768" height="281" alt="Screenshot 2025-07-15 at 18-51-30 Control flow and error handling" src="https://github.com/user-attachments/assets/cc8942a0-7f44-4262-a45e-bc7eab0216ac" />

Contrast check for light and dark mode:

<img width="348" height="90" alt="Screenshot 2025-07-15 185243" src="https://github.com/user-attachments/assets/ba795552-24ef-421c-8cb0-884e5fc05db3" />
<img width="352" height="92" alt="Screenshot 2025-07-15 185258" src="https://github.com/user-attachments/assets/44625785-caca-4711-9ad7-b6b978701186" />
