### PR TITLE
Revert "enhance(specifications-list): group by specification + collapse if necessary"

### DIFF
--- a/components/specifications-list/index.js
+++ b/components/specifications-list/index.js
@@ -1,5 +1,4 @@
 import { html, nothing } from "lit";
-import { join } from "lit/directives/join.js";
 
 /**
  * @param {import("@fred").Context} context
@@ -10,55 +9,17 @@ export function SpecificationsList(context, specifications) {
     return html`${context.l10n`This feature does not appear to be defined in any specification.`}`;
   }
 
-  /** @type {Map<string, string[]>} */
-  const urlsByTitle = new Map();
-  for (const { title, bcdSpecificationURL: url } of specifications) {
-    const urls = urlsByTitle.get(title) ?? [];
-    urls.push(url);
-    urlsByTitle.set(title, urls);
-  }
-
-  return html`<p>
-      ${context.l10n`This feature is defined in the following specifications`}:
-    </p>
-    ${specifications.length > 1
-      ? urlsByTitle.entries().map(([title, urls]) => {
-          return html`<details
-            class="specifications-list"
-            ?open=${specifications.length <= 3}
+  return html`${context.l10n`This feature is defined in the following specifications`}:
+    <ul>
+      ${specifications.map(({ title, bcdSpecificationURL: url }) => {
+        return html`<li>
+          <a class="external" href=${url} rel="noopener" target="_blank"
+            >${title}${url.includes("#")
+              ? html`<br />
+                  <small># ${url.split("#")[1]}</small>`
+              : nothing}</a
           >
-            <summary>${title}</summary>
-            <ul>
-              ${urls.map((url) => html`<li>${SpecificationLink(url)}</li>`)}
-            </ul>
-          </details>`;
-        })
-      : specifications[0]
-        ? html`<ul class="specifications-list">
-            <li>
-              ${SpecificationLink(
-                specifications[0].bcdSpecificationURL,
-                specifications[0].title,
-              )}
-            </li>
-          </ul>`
-        : nothing}`;
-}
-
-/**
- * @param {string} url
- * @param {string} [title]
- */
-function SpecificationLink(url, title) {
-  const hash = url.split("#")[1];
-
-  const label = [
-    title && html`${title}`,
-    title && hash && html`<br />`,
-    hash && html`# ${hash}`,
-  ].filter(Boolean);
-
-  return html`<a class="external" href=${url} rel="noopener" target="_blank"
-    >${join(label, "")}</a
-  >`;
+        </li>`;
+      })}
+    </ul>`;
 }


### PR DESCRIPTION
This reverts commit dcb51346aac9eb34a3bf954976aada7f944f2ac5.

E.g. http://localhost:3000/en-US/docs/Web/CSS/CSS_Values_and_Units#specifications

Before:

<img width="768" height="364" alt="Screenshot 2025-07-15 at 19-05-51 CSS values and units" src="https://github.com/user-attachments/assets/525910aa-3612-44cc-9b0d-d73f24c911ed" />

After:

<img width="768" height="184" alt="Screenshot 2025-07-15 at 19-05-54 CSS values and units" src="https://github.com/user-attachments/assets/e760f4b1-f16f-42f5-9cb1-f9066dc75c1b" />
