### PR TITLE
fix(sidebar-filter): highlight was causing weird layouts

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -88,7 +88,7 @@
   }
 
   a,
-  span {
+  span:not(.highlight-container) {
     display: inline-flex;
     padding-block: 0.25rem;
   }


### PR DESCRIPTION
before:

<img width="291" height="218" alt="Screenshot 2025-07-15 at 21-14-36 How to implement a promise-based API" src="https://github.com/user-attachments/assets/0d16d742-900b-4a62-b13b-979ff7532f84" />

after:

<img width="297" height="195" alt="Screenshot 2025-07-15 at 21-14-44 How to implement a promise-based API" src="https://github.com/user-attachments/assets/dbb5de8c-05ef-4604-9eff-45484996adef" />

before:

<img width="308" height="252" alt="Screenshot 2025-07-15 at 21-14-18 Window showDirectoryPicker() method" src="https://github.com/user-attachments/assets/4ad7d3d0-acb9-4afd-ab16-5f645e39dd96" />

after:

<img width="305" height="237" alt="Screenshot 2025-07-15 at 21-14-25 Window showDirectoryPicker() method" src="https://github.com/user-attachments/assets/f5182d69-828a-4903-acf6-199c36f081a4" />
