### PR TITLE
fix(content-section): add scroll-margin-top on :target

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -6,6 +6,10 @@
 .content-section {
   line-height: var(--font-line-content);
 
+  :target {
+    scroll-margin-top: var(--sticky-header-height);
+  }
+
   h1,
   h2,
   h3,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds `scroll-margin-top` to `:target` elements within content.

### Motivation

Fixes an issue where clicking e.g. [#autofocus](https://fred.review.mdn.allizom.net/en-US/docs/Web/HTML/Reference/Elements/button#autofocus) scrolls the clicked item behind the page header.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

