### PR TITLE
fix(live-sample): don't add px to height if it already has it

### DIFF
--- a/components/live-sample-result/element.js
+++ b/components/live-sample-result/element.js
@@ -110,7 +110,9 @@ export class MDNLiveSampleResult extends L10nMixin(LitElement) {
           .sandbox=${this.sandbox}
           .srcPrefix=${this.srcPrefix}
           style=${styleMap({
-            height: this.height ? this.height + "px" : undefined,
+            height: this.height
+              ? `${this.height}${/[0-9]$/.test(this.height) ? "px" : ""}`
+              : undefined,
           })}
         ></mdn-play-runner>
       </div>

--- a/components/play-runner/element.css
+++ b/components/play-runner/element.css
@@ -1,5 +1,8 @@
 iframe {
+  box-sizing: content-box;
+
   width: 100%;
   height: 100%;
+
   border: none;
 }


### PR DESCRIPTION
Tested on:
- http://localhost:3000/en-US/docs/Web/CSS/Layout_cookbook/Center_an_element#result
- http://localhost:3000/en-US/docs/Web/CSS/Layout_cookbook/Column_layouts#the_recipes

The other page *is* a content issue, it has an absurdly low height set (which rari clamps at 60): https://github.com/mdn/content/blob/main/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md?plain=1#L286