### PR TITLE
fix(specifications-list): collapse only specs with multiple urls

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -266,6 +266,13 @@
     }
   }
 
+  ul.specifications-list {
+    li:has(details) {
+      margin-left: -0.875rem;
+      list-style: none;
+    }
+  }
+
   /* Article footer */
   &.article-footer {
     margin: 2rem 0;

--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -268,8 +268,55 @@
 
   ul.specifications-list {
     li:has(details) {
-      margin-left: -0.875rem;
+      margin-left: -1.25rem;
       list-style: none;
+    }
+
+    details {
+      width: 100%;
+
+      &[open] {
+        > summary {
+          margin-bottom: 0.5rem;
+
+          &::before {
+            transform: rotate(90deg);
+          }
+        }
+      }
+
+      summary {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+
+        &::before {
+          display: inline-block;
+
+          flex-shrink: 0;
+
+          width: 1rem;
+          height: 1rem;
+
+          margin: 0.125rem;
+
+          content: "";
+
+          background-color: currentcolor;
+
+          mask-image: url("../icon/chevron-right.svg");
+          mask-size: cover;
+        }
+
+        &:hover {
+          background-color: var(--color-background-secondary);
+
+          &:has(a:hover) {
+            /* Don't highlight, as link click doesn't toggle. */
+            background-color: unset;
+          }
+        }
+      }
     }
   }
 

--- a/components/specifications-list/index.js
+++ b/components/specifications-list/index.js
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html } from "lit";
 import { join } from "lit/directives/join.js";
 
 /**
@@ -21,28 +21,23 @@ export function SpecificationsList(context, specifications) {
   return html`<p>
       ${context.l10n`This feature is defined in the following specifications`}:
     </p>
-    ${specifications.length > 1
-      ? urlsByTitle.entries().map(([title, urls]) => {
-          return html`<details
-            class="specifications-list"
-            ?open=${specifications.length <= 3}
-          >
-            <summary>${title}</summary>
-            <ul>
-              ${urls.map((url) => html`<li>${SpecificationLink(url)}</li>`)}
-            </ul>
-          </details>`;
-        })
-      : specifications[0]
-        ? html`<ul class="specifications-list">
-            <li>
-              ${SpecificationLink(
-                specifications[0].bcdSpecificationURL,
-                specifications[0].title,
-              )}
-            </li>
-          </ul>`
-        : nothing}`;
+    <ul class="specifications-list">
+      ${urlsByTitle.entries().map(([title, urls]) =>
+        urls.length > 1
+          ? html`<li>
+              <details
+                class="specifications-list"
+                ?open=${specifications.length <= 3}
+              >
+                <summary>${title}</summary>
+                <ul>
+                  ${urls.map((url) => html`<li>${SpecificationLink(url)}</li>`)}
+                </ul>
+              </details>
+            </li>`
+          : urls.map((url) => html`<li>${SpecificationLink(url, title)}</li>`),
+      )}
+    </ul>`;
 }
 
 /**


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Collapses the grouped specification links only if the group has more than one link.

### Motivation

Avoids cases where the specification itself is linked without a text fragment.

### Additional details

Test URLs:

- http://localhost:3000/en-US/docs/Web/HTML/Reference/Global_attributes#specifications
- http://localhost:3000/en-US/docs/Web/CSS/CSS_Values_and_Units#specifications
- http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Operators#specifications

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

