### PR TITLE
enhance(doc): add `<wbr>`s to title for better overflow wrapping

### DIFF
--- a/components/reference-layout/server.js
+++ b/components/reference-layout/server.js
@@ -23,7 +23,7 @@ export class ReferenceLayout extends ServerComponent {
         <main id="content" class="reference-layout__content">
           <div class="reference-layout__header">
             ${TranslationBanner.render(context)}
-            <h1>${doc.title}</h1>
+            <h1>${wbrify(doc.title)}</h1>
             ${BaselineIndicator.render(context)} ${description}
           </div>
           <aside class="reference-layout__toc">
@@ -41,4 +41,18 @@ export class ReferenceLayout extends ServerComponent {
       </div>
     `;
   }
+}
+
+/**
+ * Insert <wbr>s to wrap code-like strings in a pretty way
+ * NB: don't use in client side code because we use lookbehind assertions
+ * which aren't baseline green (yet)
+ * @param {string} text
+ */
+function wbrify(text) {
+  return text
+    .split(
+      /(?=\.)|(?<=[a-z])(?=[A-Z0-9])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=[A-Z])(?=[0-9])/,
+    )
+    .flatMap((part, i) => (i ? [html`<wbr />`, part] : part));
 }


### PR DESCRIPTION
Split from https://github.com/mdn/fred/pull/402 given the screen-reader bug raised in https://github.com/mdn/fred/pull/402#issuecomment-3081431827.

We need to test if setting `hidden` or `aria-hidden` fixes the issue in VoiceOver.