### PR TITLE
fix(header): layout shift due to login link

### DIFF
--- a/components/icon/log-in.svg
+++ b/components/icon/log-in.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/></svg>

--- a/components/navigation/desktop.css
+++ b/components/navigation/desktop.css
@@ -39,4 +39,9 @@
   .navigation__button {
     display: none;
   }
+
+  mdn-user-menu {
+    width: 2.125rem;
+    height: 2.125rem;
+  }
 }

--- a/components/navigation/mobile.css
+++ b/components/navigation/mobile.css
@@ -84,4 +84,9 @@
     padding: 0.7rem;
     border-top: 1px solid var(--color-border-primary);
   }
+
+  mdn-user-menu {
+    display: block;
+    border-top: 1px solid var(--color-border-primary);
+  }
 }

--- a/components/user-menu/base.css
+++ b/components/user-menu/base.css
@@ -1,12 +1,5 @@
 /* Base */
 
-/* Login link */
-
-.user-menu__login {
-  color: inherit;
-  white-space: nowrap;
-}
-
 /* User menu dropdown */
 
 .user-menu__button {

--- a/components/user-menu/desktop.css
+++ b/components/user-menu/desktop.css
@@ -3,8 +3,20 @@
 @media (--screen-menu-full) {
   .user-menu {
     position: relative;
-    width: 34px;
-    height: 34px;
+  }
+
+  .user-menu__login {
+    width: 100%;
+    height: 100%;
+
+    &::part(label) {
+      position: absolute;
+
+      width: 0;
+      height: 0;
+
+      overflow: hidden;
+    }
   }
 
   /* User menu dropdown */

--- a/components/user-menu/element.js
+++ b/components/user-menu/element.js
@@ -6,10 +6,13 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { L10nMixin } from "../../l10n/mixin.js";
 
 import { FXA_SIGNIN_URL, FXA_SIGNOUT_URL } from "../env/index.js";
+import logInIcon from "../icon/log-in.svg?lit";
 import { globalUser } from "../user/context.js";
 
 import styles from "./element.css?lit";
 import { getLinks } from "./links.js";
+
+import "../button/element.js";
 
 export class MDNUserMenu extends L10nMixin(LitElement) {
   static styles = styles;
@@ -116,9 +119,14 @@ export class MDNUserMenu extends L10nMixin(LitElement) {
                 </div>
               `
             : html`
-                <a class="user-menu__login" href=${this.#loginUrl()}>
+                <mdn-button
+                  class="user-menu__login"
+                  href=${this.#loginUrl()}
+                  .icon=${logInIcon}
+                  variant="plain"
+                >
                   ${this.l10n("login")}
-                </a>
+                </mdn-button>
               `;
         },
     });

--- a/components/user-menu/mobile.css
+++ b/components/user-menu/mobile.css
@@ -4,18 +4,7 @@
   /* Login link */
 
   .user-menu__login {
-    display: block;
-
-    padding: 0.9rem 0.7rem;
-
-    line-height: 1.25rem;
-
-    border-top: 1px solid var(--color-border-primary);
-
-    &:hover {
-      color: var(--color-text-blue);
-      background-color: var(--color-background-blue);
-    }
+    margin: 0.9rem 0.7rem;
   }
 
   /* User menu dropdown */
@@ -31,7 +20,6 @@
 
     background-color: transparent;
     border: none;
-    border-top: 1px solid var(--color-border-primary);
 
     &::before,
     &::after {


### PR DESCRIPTION
use simple icon and set width/height outside of web component

| before | after |
| - | - |
| <img width="750" height="1334" alt="Screen Shot 2025-07-17 at 18 38 14" src="https://github.com/user-attachments/assets/ac7d3830-8ba1-4ab3-ba66-dff71b61b364" /> | <img width="750" height="1334" alt="Screen Shot 2025-07-17 at 18 47 43" src="https://github.com/user-attachments/assets/672be4aa-50bb-4116-bd36-5716f6f5a676" /> |

before:

<img width="1280" height="800" alt="Screen Shot 2025-07-17 at 18 37 58" src="https://github.com/user-attachments/assets/312741c2-b955-4b95-84fb-4c41a9aa95a8" />

after:

<img width="1280" height="800" alt="Screen Shot 2025-07-17 at 18 38 05" src="https://github.com/user-attachments/assets/7be77e39-3f8f-4ff9-a2fd-7a48046131e3" />
