### PR TITLE
fix(content-section): make anchors text color

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -256,17 +256,21 @@
       margin: 1rem 0 2rem;
     }
 
-    a[href^="#"]:hover::before {
-      position: absolute;
+    a[href^="#"] {
+      color: inherit;
 
-      margin-top: 0.3em;
-      margin-left: -0.9em;
+      &:hover::before {
+        position: absolute;
 
-      font-size: var(--font-size-small);
+        margin-top: 0.3em;
+        margin-left: -0.9em;
 
-      color: var(--color-text-secondary);
+        font-size: var(--font-size-small);
 
-      content: "#";
+        color: var(--color-text-secondary);
+
+        content: "#";
+      }
     }
   }
 


### PR DESCRIPTION
### Description

<img width="724" height="466" alt="Screenshot 2025-07-18 at 10 59 59" src="https://github.com/user-attachments/assets/fbd06776-b753-4d66-b0e0-4efad9f571d9" />

Anchors in dls:

- Text color
- No underline until hovered
- `#` next to it once hovered