### PR TITLE
fix(observatory): Rescan button text 

### DIFF
--- a/components/observatory-rescan-button/element.js
+++ b/components/observatory-rescan-button/element.js
@@ -60,7 +60,7 @@ export class MDNObservatoryRescanButton extends L10nMixin(LitElement) {
     const progressPercent = (remainingSecs * 100) / 60;
 
     return isExpired
-      ? html`<mdn-button>Rescan</mdn-button>`
+      ? html`<mdn-button>${this.l10n`Rescan`}</mdn-button>`
       : html` <mdn-button disabled .icon=${this._icon(progressPercent)}
           >${this.l10n`Wait a minute to rescan`}</mdn-button
         >`;


### PR DESCRIPTION
### Description

Changed the text of the rescan button in 'wait' mode to be accessible (wait time is spelled out), make it translatable.

### Motivation

Accessibility

### Additional details

<img width="278" height="162" alt="image" src="https://github.com/user-attachments/assets/c695e686-6666-4658-a31c-bfd3cd2c33fd" />

