### PR TITLE
fix(curriculum): add `code` element background

### DIFF
--- a/components/curriculum/shared.css
+++ b/components/curriculum/shared.css
@@ -133,6 +133,7 @@
       code {
         padding: 0.125rem 0.25rem;
         background: var(--color-background-secondary);
+        border-radius: 0.25em;
       }
 
       blockquote.curriculum-notes {

--- a/components/curriculum/shared.css
+++ b/components/curriculum/shared.css
@@ -130,6 +130,11 @@
         margin-top: 2rem;
       }
 
+      code {
+        padding: 0.125rem 0.25rem;
+        background: var(--color-background-secondary);
+      }
+
       blockquote.curriculum-notes {
         padding: 1rem;
         margin: 1rem;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds missing background for inline `code` elements.

### Motivation

Yari parity

### Additional details

<img width="526" height="355" alt="image" src="https://github.com/user-attachments/assets/896c368a-2382-4e75-ae8d-2c6903d8bb65" />
