### PR TITLE
fix(compat-table): fluent error from incorrect NUMBER cast

### DIFF
--- a/l10n/en-US.ftl
+++ b/l10n/en-US.ftl
@@ -108,7 +108,7 @@ compat-support-flags =
     [one] {" "}to <code data-l10n-name="value">{ $flag_value }</code>
     *[other] {""}
   }{"."}
-  { NUMBER($flag_type) ->
+  { $flag_type ->
     [preference] To change preferences in { $browser_name }, visit { $browser_pref_url }.
     *[other] {""}
   }


### PR DESCRIPTION
e.g. console on https://fred.review.mdn.allizom.net/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal is filled with errors:

<img width="1479" height="212" alt="Screenshot 2025-07-18 152118" src="https://github.com/user-attachments/assets/1b556dda-7a8e-48de-8a16-8421675ad3ed" />
