### PR TITLE
refactor(search-button): show search on mobile

### DIFF
--- a/components/logo/server.css
+++ b/components/logo/server.css
@@ -1,3 +1,8 @@
+.logo {
+  display: block;
+  padding: 0.5rem;
+}
+
 .logo__image {
   display: block;
 }

--- a/components/navigation/base.css
+++ b/components/navigation/base.css
@@ -8,11 +8,3 @@
     color-scheme: dark;
   }
 }
-
-/* Tools */
-
-.navigation__tools {
-  display: flex;
-  column-gap: 1rem;
-  align-items: center;
-}

--- a/components/navigation/desktop.css
+++ b/components/navigation/desktop.css
@@ -23,8 +23,6 @@
   /* Logo */
 
   .navigation__logo {
-    padding: 0.5rem;
-    padding-right: 0;
     margin-inline-start: -6px;
   }
 
@@ -39,6 +37,20 @@
   .navigation__button {
     display: none;
   }
+
+  /* Search */
+
+  .navigation__search {
+    &[data-view="mobile"] {
+      display: none;
+    }
+
+    &[data-view="desktop"] {
+      display: block;
+    }
+  }
+
+  /* User menu */
 
   mdn-user-menu {
     width: 2.125rem;

--- a/components/navigation/mobile.css
+++ b/components/navigation/mobile.css
@@ -8,8 +8,10 @@
   .navigation {
     display: grid;
 
-    grid-template-columns: 1fr min-content;
+    grid-template-columns: 1fr min-content min-content;
 
+    column-gap: 0.25rem;
+    align-items: center;
     justify-items: start;
 
     height: var(--top-nav-height);
@@ -42,7 +44,7 @@
   /* Logo */
 
   .navigation__logo {
-    padding: 0.7rem;
+    padding: 0.2rem;
   }
 
   /* Button */
@@ -52,9 +54,14 @@
     margin: 0;
 
     cursor: pointer;
+    outline-offset: -2px;
 
     background-color: transparent;
     border: none;
+
+    &:hover {
+      background-color: var(--color-background-secondary);
+    }
 
     &::before {
       display: block;
@@ -81,9 +88,16 @@
   /* Search */
 
   .navigation__search {
-    padding: 0.7rem;
-    border-top: 1px solid var(--color-border-primary);
+    &[data-view="mobile"] {
+      display: block;
+    }
+
+    &[data-view="desktop"] {
+      display: none;
+    }
   }
+
+  /* User menu */
 
   mdn-user-menu {
     display: block;

--- a/components/navigation/server.js
+++ b/components/navigation/server.js
@@ -20,6 +20,9 @@ export class Navigation extends ServerComponent {
     return html`
       <nav class="navigation" data-scheme=${colorScheme} data-open="false">
         <div class="navigation__logo">${Logo.render(context)}</div>
+        <div class="navigation__search" data-view="mobile">
+          <mdn-search-button></mdn-search-button>
+        </div>
         <button
           class="navigation__button"
           type="button"
@@ -29,15 +32,15 @@ export class Navigation extends ServerComponent {
         ></button>
         <div class="navigation__popup" id="navigation__popup">
           <div class="navigation__menu">${Menu.render(context)}</div>
-          <div class="navigation__search">
+          <div class="navigation__search" data-view="desktop">
             <mdn-search-button></mdn-search-button>
           </div>
           ${WRITER_MODE
             ? nothing
             : html`<mdn-user-menu locale=${context.locale}></mdn-user-menu>`}
         </div>
-        <mdn-search-modal id="search"></mdn-search-modal>
       </nav>
+      <mdn-search-modal id="search"></mdn-search-modal>
     `;
   }
 }

--- a/components/search-button/element.css
+++ b/components/search-button/element.css
@@ -10,11 +10,17 @@
   padding-left: 0.75rem;
   margin: 0;
 
+  color: var(--color-text-primary);
+
   cursor: pointer;
 
   background-color: var(--color-background-page);
   border: 1px solid var(--color-border-primary);
   border-radius: calc(infinity * 1px);
+
+  &:hover {
+    background-color: var(--color-background-secondary);
+  }
 
   &::before {
     width: 15px;

--- a/components/user-menu/mobile.css
+++ b/components/user-menu/mobile.css
@@ -4,7 +4,7 @@
   /* Login link */
 
   .user-menu__login {
-    margin: 0.9rem 0.7rem;
+    padding: 0.45rem 0;
   }
 
   /* User menu dropdown */


### PR DESCRIPTION
### Description

- Shows search button outside of the menu on mobile
- Moves the quick search outside of the dark side
- Cleans up focus and alignment a little

### Menu before/after

<img width="2350" height="2025" alt="mobile" src="https://github.com/user-attachments/assets/9cbfde4c-25da-41f7-b21f-f9de9cb9e161" />

### Search before/after

<img width="2256" height="1514" alt="Screen Shot 2025-07-18 at 17 33 30" src="https://github.com/user-attachments/assets/08f806ad-45a8-430a-b4b4-1bd3e36dda03" />

<img width="2256" height="1514" alt="Screen Shot 2025-07-18 at 17 33 21" src="https://github.com/user-attachments/assets/afcf7f6c-8ed7-4547-b4e0-f308f68253ae" />