### PR TITLE
fix(search): close when clicking backdrop cross-browser

### DIFF
--- a/components/modal/element.js
+++ b/components/modal/element.js
@@ -27,7 +27,7 @@ export class MDNModal extends LitElement {
 
   render() {
     return html`
-      <dialog>
+      <dialog closedby="any">
         <header>
           ${this.modalTitle ? html`<h2>${this.modalTitle}</h2>` : nothing}
           <mdn-button

--- a/components/search-modal/element.css
+++ b/components/search-modal/element.css
@@ -47,7 +47,7 @@ dialog {
       "search   close"
       "progress progress"
       "results  results";
-    grid-template-rows: var(--top-nav-height) min-content 1fr;
+    grid-template-rows: var(--top-nav-height) min-content min-content;
     grid-template-columns: 1fr min-content;
   }
 }

--- a/entry.client.js
+++ b/entry.client.js
@@ -3,6 +3,7 @@ import "@lit-labs/ssr-client/lit-element-hydrate-support.js";
 
 // hooks:
 import "./hooks/glean-init.js";
+import "./hooks/dialog-closedby.js";
 import "./hooks/load-elements.js";
 import "./hooks/sidebar-scroll-to-current.js";
 import "./components/navigation/hook.js";

--- a/hooks/dialog-closedby.js
+++ b/hooks/dialog-closedby.js
@@ -1,0 +1,42 @@
+/**
+ * dialog closedby polyfill based on https://github.com/tak-dcxi/dialog-closedby-polyfill
+ *
+ * @license MIT
+ *
+ * Copyright (c) 2025 Takahiro Arai
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+if (!("closedBy" in HTMLDialogElement.prototype)) {
+  addEventListener("click", (event) => {
+    const source = event.composedPath()[0];
+    if (
+      source instanceof HTMLDialogElement &&
+      source.getAttribute("closedby") === "any"
+    ) {
+      const rect = source.getBoundingClientRect();
+      const { clientX: x, clientY: y } = event;
+      const inside =
+        rect.top <= y && y <= rect.bottom && rect.left <= x && x <= rect.right;
+
+      if (!inside) source.close();
+    }
+  });
+}


### PR DESCRIPTION
the `closedby` attribute on `<dialog>` allows us to close these (including the search) by clicking on the backdrop, but this doesn't work in Firefox Release (only Firefox Nightly). https://github.com/tak-dcxi/dialog-closedby-polyfill fixes this, but it's a bit heavy - and really covers all edge cases, which we don't use - so I cut it down a lot, and included only what we need

Tested in Firefox Release/Nightly and Chrome: would be great to get a test in Safari too