### PR TITLE
enhance(content-section): adjust h4-h5 styles

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -17,7 +17,7 @@
   h5,
   h6 {
     margin: 1rem 0 0;
-    font-weight: normal;
+    font-weight: var(--font-weight-normal);
   }
 
   h1 {
@@ -35,16 +35,14 @@
 
   h4 {
     font-size: var(--font-size-normal);
-    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
 
   h5,
   h6 {
-    font-size: var(--font-size-small);
-    font-weight: 500;
-
-    text-transform: uppercase;
-    letter-spacing: 0.025em;
+    font-size: var(--font-size-normal);
+    font-weight: var(--font-weight-bold);
   }
 
   a {
@@ -154,7 +152,7 @@
     }
 
     th {
-      font-weight: normal;
+      font-weight: var(--font-weight-normal);
       text-align: left;
     }
 
@@ -165,7 +163,7 @@
       }
 
       th {
-        font-weight: bold;
+        font-weight: var(--font-weight-bold);
         background-color: transparent;
       }
     }


### PR DESCRIPTION
### Description

- h4 uppercase
- h5+ bold

### h4s

<img width="2450" height="1748" alt="image" src="https://github.com/user-attachments/assets/7f52d028-800a-492e-af28-33d3a5b4b6ac" />

### h5s

<img width="2450" height="1548" alt="image" src="https://github.com/user-attachments/assets/12bd467c-f8a5-42c9-9cc5-8917e011f543" />

### All together

<img width="2450" height="1904" alt="image" src="https://github.com/user-attachments/assets/48bbbdfc-accd-4378-a4b5-39b90ef80634" />
