### PR TITLE
fix(inter): ligatures causing arrows in titles

### DIFF
--- a/components/font/inter.css
+++ b/components/font/inter.css
@@ -12,6 +12,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 100 900;
+  font-feature-settings: "calt" 0;
 
   src: url("fonts/inter-latin.woff2") format("woff2");
   font-display: swap;
@@ -25,6 +26,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 100 900;
+  font-feature-settings: "calt" 0;
 
   src: url("fonts/inter-italic-latin.woff2") format("woff2");
   font-display: swap;
@@ -40,6 +42,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 100 900;
+  font-feature-settings: "calt" 0;
 
   src: url("fonts/inter-latin-extended.woff2") format("woff2");
   font-display: swap;
@@ -53,6 +56,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 100 900;
+  font-feature-settings: "calt" 0;
 
   src: url("fonts/inter-italic-latin-extended.woff2") format("woff2");
   font-display: swap;
@@ -68,6 +72,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 100 900;
+  font-feature-settings: "calt" 0;
 
   src: url("fonts/inter-cyrillic.woff2") format("woff2");
   font-display: swap;
@@ -78,6 +83,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 100 900;
+  font-feature-settings: "calt" 0;
 
   src: url("fonts/inter-italic-cyrillic.woff2") format("woff2");
   font-display: swap;

--- a/components/html/global.css
+++ b/components/html/global.css
@@ -3,6 +3,7 @@
 html {
   font-family: var(--font-family-text);
   font-size: var(--font-size-normal);
+  font-feature-settings: "calt" 0;
   font-variant-alternates: styleset(disambiguation);
 
   line-height: var(--font-line-normal);


### PR DESCRIPTION
E.g. https://fred.review.mdn.allizom.net/en-US/docs/Web/HTML/Guides/Comments

Before:

<img width="614" height="68" alt="Screenshot 2025-07-21 at 12-39-43 Using HTML comments !-- … --" src="https://github.com/user-attachments/assets/ffdb7484-7d30-41f2-b016-6bdcf2c8d368" />

After:

<img width="628" height="69" alt="Screenshot 2025-07-21 at 12-39-16 Using HTML comments !-- … --" src="https://github.com/user-attachments/assets/1476494a-41b2-426d-aabb-8ec4afff66f1" />
