### PR TITLE
fix(plus): removed sidebar entry for offline docs

### DIFF
--- a/components/generic-sidebar/server.js
+++ b/components/generic-sidebar/server.js
@@ -22,7 +22,6 @@ const sidebarData = {
       { href: "/en-US/plus/docs/features/playground", title: "Playground" },
       { href: "/en-US/plus/docs/features/updates", title: "Updates" },
       { href: "/en-US/plus/docs/features/collections", title: "Collections" },
-      { href: "/en-US/plus/docs/features/offline", title: "MDN Offline" },
       { href: "/en-US/plus#subscribe", title: "Try MDN Plus" },
     ],
     styleVariant: "plus",


### PR DESCRIPTION

### Description

Removes the sidebar entry for offline in the plus section

### Motivation

The doc itself has been removed.

