### PR TITLE
enhance(homepage-search): use design colors

### DIFF
--- a/components/homepage-search/element.css
+++ b/components/homepage-search/element.css
@@ -1,36 +1,33 @@
 .mdn-homepage-search {
   display: flex;
 
-  gap: 0.5ch;
-  justify-content: center;
+  gap: 0.25em;
+  align-items: center;
 
-  padding: 1em;
+  padding: 0.8em 1em;
   margin: 0 auto;
 
   font-size: var(--font-size-large);
 
-  border-color: var(--color-border-primary);
-  border-style: solid;
-  border-radius: 2em;
+  cursor: pointer;
+
+  background-color: transparent;
+  border: 2px solid var(--color-border-primary);
+  border-radius: calc(infinity * 1px);
+
+  &:hover {
+    background-color: var(--color-background-secondary);
+  }
 
   &::before {
-    display: inline-block;
-
-    flex-shrink: 0;
-
-    width: 1.1em;
-    height: 1.1em;
+    width: 1em;
+    height: 1em;
 
     content: "";
 
-    background-color: var(--color-text-primary);
+    background-color: currentcolor;
 
     mask-image: url("../icon/search.svg");
-    mask-repeat: no-repeat;
     mask-size: contain;
   }
-}
-
-button {
-  cursor: pointer;
 }


### PR DESCRIPTION
### Description

- Uses design color instead of the default browser ones
- Cleans up CSS and normalizes paddings

### Before/after

<img width="2842" height="948" alt="image" src="https://github.com/user-attachments/assets/a53a4bfa-3fa1-4d22-8ef3-38056eae5808" />

<img width="2842" height="948" alt="image" src="https://github.com/user-attachments/assets/94cf159b-e234-450d-bcf4-6930b41029f7" />