### PR TITLE
fix(left-sidebar): some items displayed horizontally

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -63,16 +63,10 @@
         }
       }
     }
-
-    ol {
-      padding-left: 1.5rem;
-    }
   }
 
   li {
-    display: flex;
-    align-items: center;
-    justify-content: stretch;
+    display: block;
 
     &:not(:last-child) {
       margin-bottom: 0.5rem;
@@ -85,12 +79,17 @@
         margin-top: 1em;
       }
     }
+
+    ol {
+      padding-left: 1.5rem;
+    }
   }
 
   a,
   span:not(.highlight-container) {
     display: inline-flex;
     padding-block: 0.25rem;
+    vertical-align: middle;
   }
 
   a {
@@ -111,9 +110,7 @@
   }
 
   em {
-    display: inline-flex;
-
-    align-items: center;
+    display: block;
 
     padding-inline: 0.5rem;
 


### PR DESCRIPTION
Examples:
- https://test.developer.allizom.org/en-US/docs/Web/HTTP/Guides/Proxy_servers_and_tunneling
- https://test.developer.allizom.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments

Attempted to keep flex, but it's not possible without using not-yet-baseline-green `:has` selector. Reverted to normal block display, which makes the icons less pretty when overflowing - but so be it, the sidebars need some more thorough attention.