### PR TITLE
fix(playground): catch cross origin errors when attempting to check origin

### DIFF
--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -205,10 +205,14 @@ ${"```"}`,
         (controller.srcPrefix !== srcPrefix ||
           !compareCode(controller.initialCode, code))
       ) {
-        if (
-          !opener?.location?.origin ||
-          opener?.location?.origin !== location.origin
-        ) {
+        try {
+          if (
+            !opener?.location?.origin ||
+            opener?.location?.origin !== location.origin
+          ) {
+            throw new Error("origin doesn't match");
+          }
+        } catch {
           this._autoRun = false;
           controller.runOnStart = false;
           controller.runOnChange = false;


### PR DESCRIPTION
Steps to reproduce bug on `main`:

1. Open [a page with a live example on it](https://test.developer.allizom.org/en-US/docs/Web/HTML/Reference/Elements/input/date#value)
2. Press "Play" over the example
3. Open devtools console
4. Replace "https://test.developer.allizom.org" with "http://localhost:3000"
5. See an error:

<img width="819" height="188" alt="image" src="https://github.com/user-attachments/assets/9c794592-7abb-4561-be5a-30b2d31b6d5e" />

These steps are a bit edge-case-y, but I'm sure there's other ways to trigger it, and doesn't harm us wrapping the condition in a `try`/`catch`.