### PR TITLE
fix(menu): change curriculum link to en-US

### DIFF
--- a/components/menu/server.js
+++ b/components/menu/server.js
@@ -575,9 +575,7 @@ export class Menu extends ServerComponent {
                         </a>
                       </li>
                       <li>
-                        <a href=${`/${context.locale}/curriculum/`}
-                          >Curriculum</a
-                        >
+                        <a href="/en-US/curriculum/">Curriculum</a>
                       </li>
                     </ul>
                   </dd>


### PR DESCRIPTION
We only serve the Curriclum in English so hard code the link.

There's a wider issue here around displaying links in the top nav if they're not available in that locale, but without switching the top nav to structured data, we have no way of knowing at render time if they're available or not.

The 404 page should save us, but that has oddities of its own in locales: https://github.com/mdn/fred/issues/465