### PR TITLE
feat(radius): add global radius vars

### DIFF
--- a/components/homepage-search/element.css
+++ b/components/homepage-search/element.css
@@ -13,7 +13,7 @@
 
   background-color: transparent;
   border: 2px solid var(--color-border-primary);
-  border-radius: calc(infinity * 1px);
+  border-radius: var(--radius-full);
 
   &:hover {
     background-color: var(--color-background-secondary);

--- a/components/radius/global.css
+++ b/components/radius/global.css
@@ -1,0 +1,6 @@
+/* Radius */
+
+:root {
+  --radius-normal: 0.25rem;
+  --radius-full: 9999px;
+}

--- a/components/search-button/element.css
+++ b/components/search-button/element.css
@@ -16,7 +16,7 @@
 
   background-color: var(--color-background-page);
   border: 1px solid var(--color-border-primary);
-  border-radius: calc(infinity * 1px);
+  border-radius: var(--radius-full);
 
   &:hover {
     background-color: var(--color-background-secondary);

--- a/components/sidebar-filter/element.css
+++ b/components/sidebar-filter/element.css
@@ -57,7 +57,7 @@
   color: var(--color-text-primary);
 
   border: 1px solid var(--color-border-primary);
-  border-radius: calc(infinity * 1px);
+  border-radius: var(--radius-full);
 
   &::placeholder {
     color: var(--color-text-secondary);

--- a/components/switch/element.css
+++ b/components/switch/element.css
@@ -34,7 +34,7 @@
   background-repeat: no-repeat;
   background-position: var(--switch-position) 0%;
   background-size: var(--switch-size);
-  border-radius: calc(infinity * 1px);
+  border-radius: var(--radius-full);
 
   transition: --switch-position 0.2s;
 


### PR DESCRIPTION
### Description

Introduces global vars for border-radius values:

- Normal: 0.25rem (4px) one for all cases (as discussed with Ruth: “we need only one value, a very small one”)
- Full: extra large to make sure that the object becomes circular or pill-shaped
- Addresses the issue with compatibility of the `infinity` method, [mentioned here](https://github.com/mdn/fred/pull/456#discussion_r2236585117)