### PR TITLE
fix(ai-help): nav and sidebar overlap on mobile

### DIFF
--- a/components/about-tabs/element.css
+++ b/components/about-tabs/element.css
@@ -6,7 +6,7 @@
 
 .tablist-wrapper {
   position: sticky;
-  top: var(--top-nav-height);
+  top: var(--sticky-header-height);
   z-index: 2;
 
   padding: 0 var(--center-padding);

--- a/components/generic-about/server.css
+++ b/components/generic-about/server.css
@@ -1,7 +1,5 @@
 /* variables local to the about page */
 .about-container {
-  --top-nav-height: var(--sticky-header-height);
-
   --max-width: 74rem;
   --gutter: 1rem;
   --about-stats-height: 5.75rem;

--- a/components/navigation/desktop.css
+++ b/components/navigation/desktop.css
@@ -2,7 +2,7 @@
 
 @media (--screen-menu-full) {
   :root {
-    --top-nav-height: 4.125rem;
+    --navigation-height: 4.125rem;
   }
 
   .navigation {
@@ -14,7 +14,7 @@
     align-items: center;
     justify-items: center;
 
-    height: var(--top-nav-height);
+    height: var(--navigation-height);
 
     padding-block: 0.75rem;
     padding-inline: var(--layout-side-padding);

--- a/components/navigation/mobile.css
+++ b/components/navigation/mobile.css
@@ -2,7 +2,7 @@
 
 @media (--screen-menu-hamburger) {
   :root {
-    --top-nav-height: 2.9rem;
+    --navigation-height: 2.9rem;
   }
 
   .navigation {
@@ -14,7 +14,7 @@
     align-items: center;
     justify-items: start;
 
-    height: var(--top-nav-height);
+    height: var(--navigation-height);
 
     &[data-open="true"] {
       position: fixed;

--- a/components/search-modal/element.css
+++ b/components/search-modal/element.css
@@ -47,7 +47,7 @@ dialog {
       "search   close"
       "progress progress"
       "results  results";
-    grid-template-rows: var(--top-nav-height) min-content min-content;
+    grid-template-rows: var(--navigation-height) min-content min-content;
     grid-template-columns: 1fr min-content;
   }
 }

--- a/components/vars/global.css
+++ b/components/vars/global.css
@@ -1,7 +1,7 @@
 :root {
   --top-banner-height: 3.375rem;
   --sticky-header-height: calc(
-    var(--top-nav-height) + var(--breadcrumbs-bar-height)
+    var(--navigation-height) + var(--breadcrumbs-bar-height)
   );
 
   --z-index-sticky-header: 100;

--- a/legacy/index.tsx
+++ b/legacy/index.tsx
@@ -8,6 +8,7 @@ import { GleanProvider } from "@mdn/yari/client/src/telemetry/glean-context";
 import "@mdn/yari/client/src/app.scss";
 import "@mdn/yari/client/src/document/index.scss";
 
+import "./legacy.css";
 import "../hooks/legacy-theme-controller.js";
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);

--- a/legacy/legacy.css
+++ b/legacy/legacy.css
@@ -1,0 +1,5 @@
+:root {
+  --top-nav-height: var(--sticky-header-height);
+  --sticky-header-without-actions-height: var(--sticky-header-height);
+  --z-index-mid: calc(var(--z-index-sticky-header) - 1);
+}


### PR DESCRIPTION
caused by conflicts between variables in our legacy css, and in fred's css: so rename `--top-nav-height` to `--navigation-height` - which better fits the name of the component, anyway

