### PR TITLE
fix(outer-layout): preload only latin fonts

### DIFF
--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -54,9 +54,12 @@ export class OuterLayout extends ServerComponent {
         assetsForEntry(
           compilationStats.client,
           styleEntryForComponent(component),
-        ).auxiliaryAssets?.woff2?.filter((path) =>
-          path.toLowerCase().includes("inter"),
-        ),
+        ).auxiliaryAssets?.woff2?.filter((path) => {
+          const filename = path.split("/").pop() || "";
+          return /^(inter-latin|jetbrains-mono-latin)\..+\.woff2$/i.test(
+            filename,
+          );
+        }),
       )
       .filter((x) => x !== undefined);
 


### PR DESCRIPTION
### Description

- Preloads only the Latin subset
- Preloads code font as well

Once extended Latin or Cyrillic is used on the page, appropriate font subsets will be loaded by the browser anyway.

### Motivation

Preloading is a powerful tool that gets in the way of the built-in browser preloader and should be used sparingly.

590 KB on the critical path is a lot, but also:

- We only preload the text font, not the code font
- We preload font subsets (extended Latin, Cyrillic) that are often not immediately used

### Before

- 6 font files, only one is most likely used
- No code font
- **590 KB**

<details>
<summary>HTML preloading code</summary>

```html
<link
  rel="preload"
  href="/static/client/inter-italic-latin.fd2627ec16333c05.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
<link
  rel="preload"
  href="/static/client/inter-latin-extended.02dc98170ff37b88.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
<link
  rel="preload"
  href="/static/client/inter-latin.9a3b1bc220d426ef.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
<link
  rel="preload"
  href="/static/client/inter-italic-cyrillic.d153dcd2916c4842.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
<link
  rel="preload"
  href="/static/client/inter-cyrillic.eecfbd79d522303a.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
<link
  rel="preload"
  href="/static/client/inter-italic-latin-extended.0a7409875db33654.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
```

</details>

### After

- 2 fonts, both immediately used
- Code font
- **135 KB**

<details>
<summary>HTML preloading code</summary>

```html
<link
  rel="preload"
  href="/static/client/jetbrains-mono-latin.119994ed445212c7.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
<link
  rel="preload"
  href="/static/client/inter-latin.9a3b1bc220d426ef.woff2"
  as="font"
  type="font/woff2"
  crossorigin="anonymous"
  fetchpriority="low"
/>
```

</details>