### PR TITLE
chore(env): set safe defaults, disable survey, add glean debug

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -21,6 +21,10 @@ RARI_URL="http://localhost:8083"
 # uncomment to enable writer mode
 # FRED_WRITER_MODE=true
 
+# uncomment to enable glean
+# FRED_GLEAN_ENABLED=true
+# FRED_GLEAN_DEBUG=true
+
 # legacy react-specific environment variables
 REACT_APP_KUMA_HOST="localhost:3000"
 REACT_APP_FXA_SIGNIN_URL="/users/fxa/login/authenticate/"

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -128,6 +128,14 @@ jobs:
           FRED_ROBOTS_GLOBAL_ALLOW: false
           FRED_BCD_BASE_URL: https://bcd.developer.allizom.org
           FRED_OBSERVATORY_API_URL: https://observatory-api.mdn.allizom.net
+          REACT_APP_FXA_SETTINGS_URL: https://accounts.stage.mozaws.net/settings/
+          REACT_APP_MDN_PLUS_SUBSCRIBE_URL_SP3_BASE: https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net
+          REACT_APP_MDN_PLUS_5M_SP3_ID: mdnplus5mstage
+          REACT_APP_MDN_PLUS_5Y_SP3_ID: mdnplus5ystage
+          REACT_APP_MDN_PLUS_10M_SP3_ID: mdnsupporter10mstage
+          REACT_APP_MDN_PLUS_10Y_SP3_ID: mdnsupporter10ystage
+          REACT_APP_GLEAN_CHANNEL: review
+          REACT_APP_GLEAN_ENABLED: true
         run: npm run build
 
       - name: Build (rari)

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -124,7 +124,6 @@ jobs:
         env:
           FRED_GLEAN_ENABLED: true
           FRED_GLEAN_CHANNEL: review
-          FRED_GLEAN_DEBUG: true
           FRED_PLAYGROUND_BASE_HOST: mdnyalp.dev
           FRED_ROBOTS_GLOBAL_ALLOW: false
           FRED_BCD_BASE_URL: https://bcd.developer.allizom.org

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -125,7 +125,7 @@ jobs:
           FRED_GLEAN_ENABLED: true
           FRED_GLEAN_CHANNEL: review
           FRED_PLAYGROUND_BASE_HOST: mdnyalp.dev
-          # FRED_ROBOTS_GLOBAL_ALLOW: false
+          FRED_ROBOTS_GLOBAL_ALLOW: false
           FRED_BCD_BASE_URL: https://bcd.developer.allizom.org
           FRED_OBSERVATORY_API_URL: https://observatory-api.mdn.allizom.net
         run: npm run build

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           FRED_GLEAN_ENABLED: true
           FRED_GLEAN_CHANNEL: review
+          FRED_GLEAN_DEBUG: true
           FRED_PLAYGROUND_BASE_HOST: mdnyalp.dev
           FRED_ROBOTS_GLOBAL_ALLOW: false
           FRED_BCD_BASE_URL: https://bcd.developer.allizom.org

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -124,6 +124,10 @@ jobs:
         env:
           FRED_GLEAN_ENABLED: true
           FRED_GLEAN_CHANNEL: review
+          FRED_PLAYGROUND_BASE_HOST: mdnyalp.dev
+          # FRED_ROBOTS_GLOBAL_ALLOW: false
+          FRED_BCD_BASE_URL: https://bcd.developer.allizom.org
+          FRED_OBSERVATORY_API_URL: https://observatory-api.mdn.allizom.net
         run: npm run build
 
       - name: Build (rari)

--- a/components/compat-table-lazy/element.js
+++ b/components/compat-table-lazy/element.js
@@ -4,10 +4,10 @@ import { LitElement, html } from "lit";
 import "../compat-table/element.js";
 import { L10nMixin } from "../../l10n/mixin.js";
 import {
-  BCD_BASE_URL,
   DEFAULT_LOCALE,
   ISSUE_METADATA_TEMPLATE,
 } from "../compat-table/constants.js";
+import { BCD_BASE_URL } from "../env/index.js";
 
 /**
  * @typedef {{data: import("@bcd").Identifier, browsers: import("@bcd").Browsers}} Compat

--- a/components/compat-table/constants.js
+++ b/components/compat-table/constants.js
@@ -1,9 +1,6 @@
 // [libs/constants]
 export const DEFAULT_LOCALE = "en-US";
 
-// [client/env]
-export const BCD_BASE_URL = "https://bcd.developer.mozilla.org";
-
 // [client/telemetry]
 export const BCD_TABLE = "bcd";
 

--- a/components/env/index.js
+++ b/components/env/index.js
@@ -1,3 +1,10 @@
+/**
+ * @file Retrieves environment variables, setting defaults, for other areas of the app.
+ *
+ * We set safe defaults for prod, unless the risk from doing - and having this set
+ * everywhere, across local dev etc. - outweighs the risk of it not being set on prod.
+ */
+
 export const PLAYGROUND_BASE_HOST = parseString(
   "PLAYGROUND_BASE_HOST",
   "mdnplay.dev",
@@ -12,12 +19,29 @@ export const FXA_SIGNOUT_URL = parseString(
   "/users/fxa/login/logout/",
 );
 
+/** Set to non-prod default, because we don't want glean to run without explicitly enabling. */
 export const GLEAN_ENABLED = parseBool("GLEAN_ENABLED", false);
+/** Set to non-prod default, because we don't want glean to run without explicitly enabling. */
 export const GLEAN_CHANNEL = parseString("GLEAN_CHANNEL", "dev");
 
-export const ROBOTS_GLOBAL_ALLOW = parseBool("ROBOTS_GLOBAL_ALLOW", false);
+/**
+ * While there is a risk from not including the `noindex` meta tag on stage etc, we have a
+ * `robots.txt` in place, and the effect of accidentally including it on prod is far worse:
+ * so this must be the prod default.
+ */
+export const ROBOTS_GLOBAL_ALLOW = parseBool("ROBOTS_GLOBAL_ALLOW", true);
 
 export const WRITER_MODE = parseBool("WRITER_MODE", false);
+
+export const BCD_BASE_URL = parseString(
+  "BCD_BASE_URL",
+  "https://bcd.developer.mozilla.org",
+);
+
+export const OBSERVATORY_API_URL = parseString(
+  "OBSERVATORY_API_URL",
+  "https://observatory-api.mdn.mozilla.net",
+);
 
 /**
  * @param {string} name

--- a/components/env/index.js
+++ b/components/env/index.js
@@ -23,6 +23,7 @@ export const FXA_SIGNOUT_URL = parseString(
 export const GLEAN_ENABLED = parseBool("GLEAN_ENABLED", false);
 /** Set to non-prod default, because we don't want glean to run without explicitly enabling. */
 export const GLEAN_CHANNEL = parseString("GLEAN_CHANNEL", "dev");
+export const GLEAN_DEBUG = parseBool("GLEAN_DEBUG", false);
 
 /**
  * While there is a risk from not including the `noindex` meta tag on stage etc, we have a

--- a/components/observatory-comparison-table/element.js
+++ b/components/observatory-comparison-table/element.js
@@ -1,7 +1,7 @@
 import { Task } from "@lit/task";
 import { LitElement, html, nothing, svg } from "lit";
 
-import { OBSERVATORY_API_URL } from "../observatory/constants.js";
+import { OBSERVATORY_API_URL } from "../env/index.js";
 import { formatMinus } from "../observatory/utils.js";
 
 import styles from "./element.css?lit";

--- a/components/observatory-form/element.js
+++ b/components/observatory-form/element.js
@@ -1,5 +1,7 @@
 import { LitElement, html, nothing } from "lit";
 import { createRef, ref } from "lit/directives/ref.js";
+
+import { OBSERVATORY_API_URL } from "../env/index.js";
 import "../progress-bar/element.js";
 import "../button/element.js";
 
@@ -53,9 +55,10 @@ export class MDNObservatoryForm extends LitElement {
     }
     this._queryRunning = true;
     try {
-      const apiUrl = `https://observatory-api.mdn.mozilla.net/api/v2/analyze?host=${encodeURIComponent(
-        this._hostname,
-      )}`;
+      const apiUrl = new URL(
+        OBSERVATORY_API_URL +
+          `/api/v2/analyze?host=${encodeURIComponent(this._hostname)}`,
+      );
       const response = await fetch(apiUrl, { method: "POST" });
       if (!response.ok) {
         const json = await response.json();

--- a/components/observatory-results/element.js
+++ b/components/observatory-results/element.js
@@ -2,7 +2,7 @@ import { Task } from "@lit/task";
 import { LitElement, html } from "lit";
 import { nothing } from "lit";
 
-import { OBSERVATORY_API_URL } from "../observatory/constants.js";
+import { OBSERVATORY_API_URL } from "../env/index.js";
 
 import styles from "./element.css?lit";
 import { Rating } from "./rating.js";

--- a/components/observatory-tests-and-scores/element.js
+++ b/components/observatory-tests-and-scores/element.js
@@ -2,7 +2,7 @@ import { Task } from "@lit/task";
 import { LitElement, html } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
-import { OBSERVATORY_API_URL } from "../observatory/constants.js";
+import { OBSERVATORY_API_URL } from "../env/index.js";
 
 import styles from "./element.css?lit";
 

--- a/components/observatory/constants.js
+++ b/components/observatory/constants.js
@@ -1,5 +1,3 @@
-export const OBSERVATORY_API_URL = "https://observatory-api.mdn.mozilla.net";
-
 /**
  * Scoring table for Observatory grades
  * @type {Array<{grade: string, scoreText: string, score: number, stars?: boolean}>}

--- a/components/survey/surveys.js
+++ b/components/survey/surveys.js
@@ -1,4 +1,4 @@
-import { html } from "lit";
+// import { html } from "lit";
 
 /**
  * @import * as Survey from "./types.js";
@@ -43,25 +43,25 @@ export const SurveyBucket = Object.freeze({
  * @type {Survey.Survey[]}
  */
 export const SURVEYS = [
-  {
-    key: "something unique in the current surveys",
-    bucket: SurveyBucket.FIRST_FRED_2025,
-    show: (mdn_url) => {
-      return /^\/[a-z]{2}(-[A-Z]{2})?\/docs\/Web\/CSS/.test(mdn_url);
-    },
-    src: (mdn_url) => {
-      const url = new URL(
-        "https://survey.alchemer.com/s3/8385674/MDN-short-survey-Fred",
-      );
-      url.searchParams.set("referrer", mdn_url);
-      return url.toString();
-    },
-    teaser: html`Fred is <strong>MDN</strong>'s shiny new frontend!`,
-    question: "How satisfied are you with this new MDN frontend?",
-    footnote: "fred = fr(ont)e(n)d",
-    rateFrom: 0,
-    rateTill: 1,
-    start: 0,
-    end: Infinity,
-  },
+  // {
+  //   key: "something unique in the current surveys",
+  //   bucket: SurveyBucket.FIRST_FRED_2025,
+  //   show: (mdn_url) => {
+  //     return /^\/[a-z]{2}(-[A-Z]{2})?\/docs\/Web\/CSS/.test(mdn_url);
+  //   },
+  //   src: (mdn_url) => {
+  //     const url = new URL(
+  //       "https://survey.alchemer.com/s3/8385674/MDN-short-survey-Fred",
+  //     );
+  //     url.searchParams.set("referrer", mdn_url);
+  //     return url.toString();
+  //   },
+  //   teaser: html`Fred is <strong>MDN</strong>'s shiny new frontend!`,
+  //   question: "How satisfied are you with this new MDN frontend?",
+  //   footnote: "fred = fr(ont)e(n)d",
+  //   rateFrom: 0,
+  //   rateTill: 1,
+  //   start: 0,
+  //   end: Infinity,
+  // },
 ];

--- a/hooks/glean-init.js
+++ b/hooks/glean-init.js
@@ -1,7 +1,11 @@
 // @ts-expect-error "Could not find declaration file"
 import Glean from "@mozilla/glean/web";
 
-import { GLEAN_CHANNEL, GLEAN_ENABLED } from "../components/env/index.js";
+import {
+  GLEAN_CHANNEL,
+  GLEAN_DEBUG,
+  GLEAN_ENABLED,
+} from "../components/env/index.js";
 
 const FIRST_PARTY_DATA_OPT_OUT_COOKIE_NAME = "moz-1st-party-data-opt-out";
 const GLEAN_APP_ID = "mdn-fred";
@@ -11,6 +15,11 @@ const userIsOptedOut = document.cookie
   .includes(`${FIRST_PARTY_DATA_OPT_OUT_COOKIE_NAME}=true`);
 
 const uploadEnabled = !userIsOptedOut && GLEAN_ENABLED;
+
+if (GLEAN_DEBUG) {
+  Glean.setDebugViewTag("mdn-dev");
+  Glean.setLogPings(true);
+}
 
 Glean.initialize(GLEAN_APP_ID, uploadEnabled, {
   enableAutoPageLoadEvents: true,


### PR DESCRIPTION
Relates to https://github.com/mdn/fred/issues/498.

Sets env variables in most cases to prod defaults (with one exception, documented in the file).

~~Testing that `FRED_ROBOTS_GLOBAL_ALLOW` commented out in the review workflow works in the deploy (no `noindex` meta tags should appear), will uncomment and mark as ready for review once done.~~ It does.

Tested:
- `PLAYGROUND_BASE_HOST`: default is prod, review env set to `mdnyalp.dev` which is used on https://fred-pr500.review.mdn.allizom.net/en-US/play
- `FXA_SIGNIN_URL`: default is used in review env
- `FXA_SIGNOUT_URL`: default is used in review env
- `GLEAN_ENABLED`: default is `false`, review env set to `true`: https://fred-pr500.review.mdn.allizom.net sends pings (seen in devtools)
- `GLEAN_CHANNEL`: tested with `GLEAN_DEBUG` set to `true`: pings with the `review` channel set appearing in the glean debug viewer: https://debug-ping-preview.firebaseapp.com/pings/mdn-dev/f110d800-baba-4771-ab79-3e2a0bc0a7a3
- `GLEAN_DEBUG`: tested with above
- `ROBOTS_GLOBAL_ALLOW`: default is `true`, deployed initially with default: no robots meta tag was included; redeployed with `false`: robots meta tag is seen on https://fred-pr500.review.mdn.allizom.net
- `WRITER_MODE`: default is `false`, default used in review env
- `BCD_BASE_URL`: default is prod, review env set to `https://bcd.developer.allizom.org` which can be seen used on https://fred-pr500.review.mdn.allizom.net/en-US/docs/MDN/Kitchensink#browser_compatibility
- `OBSERVATORY_API_URL`: default is prod, review env set to `https://observatory-api.mdn.allizom.net`: used for all requests on https://fred-pr500.review.mdn.allizom.net/en-US/observatory/