### PR TITLE
fix(curriculum): responsive fix on landing page

### DIFF
--- a/components/curriculum-landing/server.css
+++ b/components/curriculum-landing/server.css
@@ -569,7 +569,7 @@
       > ul {
         display: grid;
 
-        grid-template-areas: "beginner advanced employ educator";
+        grid-template-areas: "beginner" "advanced" "employ" "educator";
 
         gap: 1rem;
 
@@ -600,13 +600,12 @@
             "i h"
             "p p"
             "c c";
-          grid-template-rows: 4rem minmax(7rem, max-content) max-content;
+          grid-template-rows: 4rem minmax(2rem, max-content) max-content;
           grid-template-columns: 3rem 1fr;
 
           gap: 1rem;
           align-items: center;
 
-          width: 80vw;
           height: max-content;
 
           padding: 1rem 0.5rem;
@@ -669,6 +668,8 @@
           }
 
           h3 {
+            grid-area: h;
+
             margin-top: 0;
 
             font-weight: var(--font-weight-bold);
@@ -676,6 +677,14 @@
             line-height: var(--font-line-normal);
 
             color: var(--text-primary);
+          }
+
+          p:nth-child(2) {
+            grid-area: p;
+          }
+
+          p:nth-child(3) {
+            grid-area: c;
           }
 
           em {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes a problem with responsiveness on the curriculum landing page

### Motivation

Usability on narrow screens

### Additional details

Before
<img width="400" height="831" alt="image" src="https://github.com/user-attachments/assets/f9c46cbf-8210-4708-a3df-913198cf9940" />

After
<img width="400" height="784" alt="image" src="https://github.com/user-attachments/assets/459a6fa6-73d8-48cf-98be-3cde3da7d165" />


### Related issues and pull requests

Fixes #479
