### PR TITLE
fix(sidebar): Remove top padding for mobile views

### DIFF
--- a/components/reference-layout/server.css
+++ b/components/reference-layout/server.css
@@ -96,7 +96,7 @@
       z-index: var(--z-index-sidebar-mobile);
 
       .left-sidebar {
-        padding: 1rem;
+        padding: 0 1rem;
       }
     }
 


### PR DESCRIPTION
### Description

Fixes an issue where the sidebar is visible above the filter input on small screens

### Additional details

Before:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/19d5be57-33eb-47f4-9463-995b645f807c" />

After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/34b05b28-9843-4e06-a78c-79fb742f649e" />

### Related issues and pull requests

Fixes #482 
Fixes #483