### PR TITLE
fix(lang-switch): directly point to the label

### DIFF
--- a/components/language-switcher/element.js
+++ b/components/language-switcher/element.js
@@ -63,8 +63,13 @@ export class MDNLanguageSwitcher extends L10nMixin(LitElement) {
 
     return html`<div class="language-switcher">
       <mdn-dropdown>
-        <button slot="button" class="language-switcher__button" type="button">
-          <span>${native ?? locale}</span>
+        <button
+          slot="button"
+          class="language-switcher__button"
+          type="button"
+          aria-labelledby="current-locale"
+        >
+          <span id="current-locale">${native ?? locale}</span>
         </button>
         <div
           slot="dropdown"


### PR DESCRIPTION
### Description

The button had no label on narrow screens (`display: none` for the label). Setting the label via the `aria-labelledby` fixes the labeling.