### PR TITLE
fix(global): blue buttons in mobile Safari

### DIFF
--- a/components/global/global.css
+++ b/components/global/global.css
@@ -14,6 +14,7 @@ select {
 }
 
 button {
+  color: inherit;
   cursor: pointer;
 }
 

--- a/components/homepage-search/element.css
+++ b/components/homepage-search/element.css
@@ -1,3 +1,5 @@
+@import url("../global/global.css");
+
 .mdn-homepage-search {
   display: flex;
 
@@ -8,8 +10,6 @@
   margin: 0 auto;
 
   font-size: var(--font-size-large);
-
-  cursor: pointer;
 
   background-color: transparent;
   border: 2px solid var(--color-border-primary);


### PR DESCRIPTION
### Description

- Changes global defaults to inherit button color for mobile Safari
- Uses global defaults for the homepage search button

### Before/after

<img width="2398" height="2556" alt="blue" src="https://github.com/user-attachments/assets/e6ee749c-f740-44b2-87f8-d2025209b0d0" />
