### PR TITLE
fix(language-switcher): show locales that exist on 404

### DIFF
--- a/components/breadcrumbs-bar/server.js
+++ b/components/breadcrumbs-bar/server.js
@@ -72,11 +72,14 @@ export class BreadcrumbsBar extends ServerComponent {
       return nothing;
     }
 
+    const notFound = context.renderer === "SpaNotFound";
+
     return html`<mdn-language-switcher
       locale=${context.locale}
       native=${native}
       translations=${JSON.stringify(translations)}
-      url=${context.url}
+      url=${notFound ? context.path : context.url}
+      ?not-found=${notFound}
     ></mdn-language-switcher>`;
   }
 }

--- a/components/language-switcher/element.css
+++ b/components/language-switcher/element.css
@@ -1,3 +1,5 @@
+@import url("../global/global.css");
+
 .language-switcher {
   position: relative;
 }

--- a/components/not-found/element.js
+++ b/components/not-found/element.js
@@ -4,7 +4,7 @@ import { LitElement, html } from "lit";
 import { L10nMixin } from "../../l10n/mixin.js";
 
 import styles from "./element.css?lit";
-import { pathToLocale } from "./utils.js";
+import { getEnglishDoc, pathToLocale } from "./utils.js";
 
 export class MDNNotFound extends L10nMixin(LitElement) {
   // Need location (not available server-side).
@@ -12,24 +12,8 @@ export class MDNNotFound extends L10nMixin(LitElement) {
 
   static styles = styles;
 
-  /** @type {Task<?,import("@rari").Doc|null>} */
   _fallback = new Task(this, {
-    task: async () => {
-      const url = location.pathname;
-      if (url && url.includes("/docs/") && !url.includes("/en-US/")) {
-        const enUSURL =
-          "/en-US/" + url.split("/").slice(2).join("/") + "/index.json";
-
-        const response = await fetch(enUSURL);
-        if (response.ok) {
-          /** @type {{ doc: import("@rari").Doc}} */
-          const { doc } = await response.json();
-          return doc;
-        }
-      }
-
-      return null;
-    },
+    task: async () => getEnglishDoc(location.pathname),
   });
 
   connectedCallback() {

--- a/components/not-found/utils.js
+++ b/components/not-found/utils.js
@@ -16,3 +16,25 @@ export function pathToLocale(pathname) {
 
   return "en-US";
 }
+
+/**
+ * @param {string} pathname
+ */
+export async function getEnglishDoc(pathname) {
+  if (
+    pathname &&
+    pathname.includes("/docs/") &&
+    !pathname.startsWith("/en-US/")
+  ) {
+    const enUSURL =
+      "/en-US/" + pathname.split("/").slice(2).join("/") + "/index.json";
+
+    const response = await fetch(enUSURL);
+    if (response.ok) {
+      /** @type {{ doc: import("@rari").Doc}} */
+      const { doc } = await response.json();
+      return doc;
+    }
+  }
+  return;
+}

--- a/server.js
+++ b/server.js
@@ -228,8 +228,9 @@ export async function startServer() {
           ) {
             // render 404 page
             res.statusCode = 404;
+            const locale = req.url?.match(/[^/]+/)?.[0] ?? "en-us";
             const notFoundRes = await fetch(
-              `http://localhost:8083/en-US/404/index.json`,
+              `http://localhost:8083/${locale}/404/index.json`,
             );
             const json = await notFoundRes.json();
             return serverRenderMiddleware(req, res, json);


### PR DESCRIPTION
Relates to: https://github.com/mdn/fred/issues/465

Deployed it to testing testing, alongside the related yari and rari changes: https://github.com/mdn/yari/actions/runs/16778636629

Can see it take effect on a page like: https://test.developer.allizom.org/fr/docs/Learn_web_development/Getting_started (you should see that the locales in which the page *does* exist are shown in the language switcher, and it no longer links you to the `${locale}/404` page as before).