### PR TITLE
fix(code-example): add aria-label to "Play" button

### DIFF
--- a/components/code-example/element.js
+++ b/components/code-example/element.js
@@ -4,6 +4,8 @@ import { createRef, ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import "../copy-button/element.js";
+import { L10nMixin } from "../../l10n/mixin.js";
+
 import styles from "./element.css?lit";
 
 /**
@@ -12,7 +14,7 @@ import styles from "./element.css?lit";
 
 const LANGUAGE_CLASSES = new Set(["html", "js", "css", "wat"]);
 
-export class MDNCodeExample extends LitElement {
+export class MDNCodeExample extends L10nMixin(LitElement) {
   static styles = styles;
 
   static properties = {
@@ -78,7 +80,9 @@ export class MDNCodeExample extends LitElement {
                 href=${this.liveSample?.breakoutLink}
                 target="_blank"
                 rel="opener"
-                >Play</mdn-button
+                aria-label=${this.l10n("example-play-button-title")}
+                title=${this.l10n("example-play-button-title")}
+                >${this.l10n("example-play-button-label")}</mdn-button
               >`
             : nothing}
         </div>

--- a/components/live-sample-result/element.js
+++ b/components/live-sample-result/element.js
@@ -99,7 +99,9 @@ export class MDNLiveSampleResult extends L10nMixin(LitElement) {
                 href=${this.breakoutLink}
                 target="_blank"
                 rel="opener"
-                >${this.l10n`Play`}</mdn-button
+                aria-label=${this.l10n("example-play-button-title")}
+                title=${this.l10n("example-play-button-title")}
+                >${this.l10n("example-play-button-label")}</mdn-button
               >`
             : nothing}
         </div>

--- a/l10n/en-US.ftl
+++ b/l10n/en-US.ftl
@@ -146,3 +146,6 @@ pagination-goto = Go to page { $page }
 logout = Sign out
 login = Log in
 settings = My settings
+
+example-play-button-label = Play
+example-play-button-title = Run example in MDN Playground (opens in new tab)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds an `aria-label` to the <kbd>Play</kbd> button on runnable live examples.

### Motivation

Improves accessibility, avoids surprise that clicking the button opens a new tab.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/519.

