### PR TITLE
fix(interactive-example): add title to Run/Reset + console

### DIFF
--- a/components/interactive-example/with-console.js
+++ b/components/interactive-example/with-console.js
@@ -51,14 +51,21 @@ export const InteractiveExampleWithConsole = (Base) =>
                 id="execute"
                 @click=${this._run}
                 variant="secondary"
-                aria-controls="console,runner"
+                title=${this.l10n`Run example, and show console output`}
                 >${this.l10n`Run`}</mdn-button
               >
-              <mdn-button id="reset" @click=${this._reset} variant="secondary"
+              <mdn-button
+                id="reset"
+                @click=${this._reset}
+                variant="secondary"
+                title=${this.l10n`Reset example, and clear console output`}
                 >${this.l10n`Reset`}</mdn-button
               >
             </div>
-            <mdn-play-console id="console"></mdn-play-console>
+            <mdn-play-console
+              id="console"
+              title=${this.l10n`Console output`}
+            ></mdn-play-console>
             <mdn-play-runner
               id="runner"
               defaults=${ifDefined(

--- a/components/interactive-example/with-console.js
+++ b/components/interactive-example/with-console.js
@@ -47,7 +47,11 @@ export const InteractiveExampleWithConsole = (Base) =>
                   )}
                 </mdn-ix-tab-wrapper>`}
             <div class="buttons">
-              <mdn-button id="execute" @click=${this._run} variant="secondary"
+              <mdn-button
+                id="execute"
+                @click=${this._run}
+                variant="secondary"
+                aria-controls="console,runner"
                 >${this.l10n`Run`}</mdn-button
               >
               <mdn-button id="reset" @click=${this._reset} variant="secondary"
@@ -56,6 +60,7 @@ export const InteractiveExampleWithConsole = (Base) =>
             </div>
             <mdn-play-console id="console"></mdn-play-console>
             <mdn-play-runner
+              id="runner"
               defaults=${ifDefined(
                 this._languages.includes("wat") ? "ix-wat" : undefined,
               )}

--- a/components/interactive-example/with-console.js
+++ b/components/interactive-example/with-console.js
@@ -67,7 +67,6 @@ export const InteractiveExampleWithConsole = (Base) =>
               title=${this.l10n`Console output`}
             ></mdn-play-console>
             <mdn-play-runner
-              id="runner"
               defaults=${ifDefined(
                 this._languages.includes("wat") ? "ix-wat" : undefined,
               )}

--- a/components/play-console/element.css
+++ b/components/play-console/element.css
@@ -25,7 +25,7 @@ li {
   padding: 0 0.5em;
 
   &::before {
-    content: ">";
+    content: "> ";
   }
 }
 

--- a/components/play-console/element.js
+++ b/components/play-console/element.js
@@ -115,13 +115,9 @@ export class MDNPlayConsole extends LitElement {
   render() {
     return html`
       <ul>
-        ${this._messages.map((message) => {
-          return html`
-            <li>
-              <code>${message}</code>
-            </li>
-          `;
-        })}
+        ${this._messages.map(
+          (message) => html`<li><code tabindex="0">${message}</code></li>`,
+        )}
       </ul>
     `;
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

1. Adds `title` to the <kbd>Run</kbd> / <kbd>Reset</kbd> buttons on interactive examples, and to the console output.
2. Makes the console output lines tabbable.

### Motivation

Improve accessibility.

### Additional details

PS: I tried to use `aria-controls`, but it had no observable effect to me with VoiceOver.

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/520.
