### PR TITLE
fix(a11y): add breadcrumb & sidebar padding

### DIFF
--- a/components/blog-post/server.css
+++ b/components/blog-post/server.css
@@ -33,6 +33,8 @@
 
   max-height: calc(100vh - var(--sticky-header-height));
 
+  padding-left: 2px;
+
   overflow-y: auto;
 
   @media (--screen-layout-no-sidebar) {

--- a/components/breadcrumbs/server.css
+++ b/components/breadcrumbs/server.css
@@ -6,7 +6,7 @@
 
   min-width: 0;
 
-  padding: 0;
+  padding: 2px;
   margin: 0;
   margin-right: auto;
 

--- a/components/curriculum/toc.css
+++ b/components/curriculum/toc.css
@@ -1,5 +1,7 @@
 .curriculum-content-container {
   .curriculum-layout__toc {
+    padding: 2px;
+
     .document-toc {
       padding: 0;
       margin-bottom: 2rem;

--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -145,6 +145,7 @@
   padding-top: 0.5rem;
   padding-right: 0.5rem;
   padding-bottom: 2rem;
+  padding-left: 2px;
 
   background: linear-gradient(
     to bottom,

--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -131,6 +131,12 @@
   }
 }
 
+.left-sidebar__content {
+  > ol {
+    padding-left: 2px;
+  }
+}
+
 .left-sidebar__header {
   position: sticky;
   top: 0;

--- a/components/placement-sidebar/element.css
+++ b/components/placement-sidebar/element.css
@@ -1,3 +1,7 @@
+:host {
+  padding-left: 2px;
+}
+
 .sidebar-placement {
   display: flex;
 

--- a/components/placement-sidebar/element.css
+++ b/components/placement-sidebar/element.css
@@ -1,7 +1,3 @@
-:host {
-  padding-left: 2px;
-}
-
 .sidebar-placement {
   display: flex;
 

--- a/components/reference-layout/server.css
+++ b/components/reference-layout/server.css
@@ -66,6 +66,8 @@
 
     max-height: calc(100vh - var(--sticky-header-height));
 
+    padding-left: 2px;
+
     overflow-y: auto;
   }
 


### PR DESCRIPTION
### Description

Make enough room around breadcrumb items to allow for the `focus-visible` border to not be clipped.

### Motivation

The previous version was looking broken (while still functional), yari parity

### Additional details

#### Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/c6382010-f20c-408f-90dd-6cc1807fb541" />

#### After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/09e065e3-c899-4d92-b51a-d74d4869b1a7" />


### Related issues and pull requests

fixes #476 
fixes #490 