### PR TITLE
enhance(interactive-examples): disable choice Reset until updated

### DIFF
--- a/components/interactive-example/with-choices.js
+++ b/components/interactive-example/with-choices.js
@@ -23,6 +23,7 @@ export const InteractiveExampleWithChoices = (Base) =>
     static properties = {
       __choiceSelected: { state: true },
       __choiceUnsupported: { state: true },
+      __choiceUpdated: { state: true },
     };
 
     /** @param {any[]} _args  */
@@ -32,6 +33,8 @@ export const InteractiveExampleWithChoices = (Base) =>
       this.__choiceSelected = -1;
       /** @type {boolean[]} */
       this.__choiceUnsupported = [];
+      /** @type {boolean} */
+      this.__choiceUpdated = false;
     }
 
     /** @param {MouseEvent} event  */
@@ -56,11 +59,13 @@ export const InteractiveExampleWithChoices = (Base) =>
         if (this.__choiceSelected === this.#getIndex(target)) {
           this.#selectChoice(target);
         }
+        this.__choiceUpdated = true;
       }
     }
 
     #resetChoices() {
       this.__choiceSelected = -1;
+      this.__choiceUpdated = false;
 
       const editorNodes = [
         ...(this.shadowRoot?.querySelectorAll("mdn-play-editor") || []),
@@ -108,7 +113,11 @@ export const InteractiveExampleWithChoices = (Base) =>
         <div class="template-choices">
           <header>
             <h4>${decode(this.name)}</h4>
-            <mdn-button id="reset" @click=${this._reset} variant="secondary"
+            <mdn-button
+              id="reset"
+              @click=${this._reset}
+              variant="secondary"
+              .disabled=${!this.__choiceUpdated}
               >${this.l10n`Reset`}</mdn-button
             >
           </header>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Disable the "Reset" button on the CSS interactive examples with value choices.

### Motivation

Avoids confusion, especially for screen reader users.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Extracted from https://github.com/mdn/fred/pull/542.

Related to https://github.com/mdn/fred/issues/522.

