### PR TITLE
fix(blog): layout distortion on wider viewports

### DIFF
--- a/components/blog-index/server.css
+++ b/components/blog-index/server.css
@@ -2,7 +2,6 @@
   --accent-color: var(--color-text-purple);
   --avatar-size: 3rem;
   --author-gap: 1rem;
-  max-width: min(80vw + 4rem, 1440px);
   padding-inline: var(--layout-side-padding);
   margin: 0 auto;
 }


### PR DESCRIPTION
Fix #562

<details>
<summary>Wide before/after</summary>

<img width="4126" height="2800" alt="wide-before" src="https://github.com/user-attachments/assets/6729b154-fd8b-4c64-b89c-0ae592a55b92" />
<img width="4126" height="2800" alt="wide-after" src="https://github.com/user-attachments/assets/8911c5be-f2eb-443a-b360-7507309f8eb2" />
</details>

<details>
<summary>Medium before/after</summary>

<img width="1124" height="1019" alt="mid-before" src="https://github.com/user-attachments/assets/8d2791a1-9806-4c28-bc2b-e487402cc49d" />
<img width="1124" height="1019" alt="mid-after" src="https://github.com/user-attachments/assets/706db37e-7d17-426b-ae94-70add0a910ef" />
</details>

<details>
<summary>Narrow before/after</summary>

<img width="450" height="997" alt="narrow-before" src="https://github.com/user-attachments/assets/20f42449-935b-4c14-a426-088d7f3e1f35" />
<img width="450" height="997" alt="narrow-after" src="https://github.com/user-attachments/assets/6592ee27-ee16-4906-9a3a-9a2a72ee2dd7" />
</details>