### PR TITLE
chore(menu): update missing docs

### DIFF
--- a/components/menu/constants.js
+++ b/components/menu/constants.js
@@ -100,7 +100,7 @@ export const MISSING_DOCS = {
     "Web/Privacy",
     "Web/WebDriver",
   ],
-  "zh-CN": ["Web/CSS/Properties", "Web/HTML/Guides"],
+  "zh-CN": ["Web/CSS/Properties"],
   "zh-TW": [
     "Learn_web_development/Core/CSS_layout/Flexbox",
     "Learn_web_development/Core/Structuring_content/HTML_video_and_audio",


### PR DESCRIPTION
### Description

Updates the missing docs (translations) data.

### Motivation

Ensure Web/HTML/Guides is linked to in zh-CN.

### Additional details

All other listed translations are still missing. (Ran `node components/menu/check-missing-docs.js`).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

