### PR TITLE
fix(light-dark): fix colors and theme switcher when polyfilled

### DIFF
--- a/build/loaders/fix-light-dark.js
+++ b/build/loaders/fix-light-dark.js
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 
 /**
+ * Adds a per-file identifier to the CSS variables used by the light-dark polyfill,
+ * to avoid conflicts between CSS files.
  * @this {import("@rspack/core").LoaderContext}
  * @param {string} source
  */

--- a/build/loaders/fix-light-dark.js
+++ b/build/loaders/fix-light-dark.js
@@ -1,0 +1,21 @@
+import crypto from "node:crypto";
+
+/**
+ * @this {import("@rspack/core").LoaderContext}
+ * @param {string} source
+ */
+export default function postCssLightDarkFix(source) {
+  const id = hash(this.resourcePath);
+  return source.replaceAll(
+    "--csstools-light-dark-toggle--",
+    `--csstools-light-dark-toggle-${id}-`,
+  );
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function hash(str) {
+  return crypto.createHash("sha256").update(str).digest("hex").slice(0, 8);
+}

--- a/components/color-theme/controller.js
+++ b/components/color-theme/controller.js
@@ -23,7 +23,7 @@ export class ThemeController {
   /** @param {Event} [event] */
   _updateTheme(event) {
     let value = event instanceof CustomEvent && this._lightOrDark(event.detail);
-    value ||= this._lightOrDark(document.documentElement.style.colorScheme);
+    value ||= this._lightOrDark(document.documentElement.dataset.theme);
     value ||= this._matchMedia?.matches ? "dark" : "light";
     const oldValue = this.value;
     this.value = value;

--- a/components/color-theme/element.js
+++ b/components/color-theme/element.js
@@ -48,7 +48,6 @@ export class MDNColorTheme extends L10nMixin(LitElement) {
    */
   willUpdate(changedProperties) {
     if (changedProperties.has("_mode") && globalThis.document) {
-      document.documentElement.style.colorScheme = this._mode;
       document.documentElement.dataset.theme = this._mode;
       this.dispatchEvent(
         new CustomEvent("mdn-color-theme-update", {

--- a/components/color-theme/global.css
+++ b/components/color-theme/global.css
@@ -1,0 +1,7 @@
+html[data-theme="light"] {
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+}

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -74,7 +74,7 @@ export class OuterLayout extends ServerComponent {
       <!doctype html>
       <html
         lang=${context.locale}
-        style="color-scheme: light dark;"
+        data-theme="light dark"
         data-renderer=${context.renderer}
         data-nop=${ifDefined(WRITER_MODE ? "yes" : undefined)}
         data-current-area=${ifDefined(area)}

--- a/entry.inline.js
+++ b/entry.inline.js
@@ -1,5 +1,5 @@
 try {
-  document.documentElement.style.colorScheme =
+  document.documentElement.dataset.theme =
     localStorage.getItem("theme") || "light dark";
 } catch (error) {
   console.warn("Unable to set theme", error);

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -37,33 +37,38 @@ const OPTIMIZATIONS = {
 /**
  * @param {boolean} lit
  */
-const postcssLoader = (lit = false) => ({
-  loader: "postcss-loader",
-  options: {
-    postcssOptions: {
-      plugins: [
-        [
-          "@csstools/postcss-global-data",
-          {
-            files: [
-              "./components/media/index.css",
-              "./components/layout/global.css",
-            ],
-          },
+const postcssLoaders = (lit = false) => [
+  {
+    loader: "./build/loaders/fix-light-dark.js",
+  },
+  {
+    loader: "postcss-loader",
+    options: {
+      postcssOptions: {
+        plugins: [
+          [
+            "@csstools/postcss-global-data",
+            {
+              files: [
+                "./components/media/index.css",
+                "./components/layout/global.css",
+              ],
+            },
+          ],
+          ["postcss-custom-media"],
+          [
+            "postcss-preset-env",
+            {
+              stage: 2,
+              minimumVendorImplementations: 2,
+            },
+          ],
+          ...(isProd && lit ? [["cssnano"]] : []),
         ],
-        ["postcss-custom-media"],
-        [
-          "postcss-preset-env",
-          {
-            stage: 2,
-            minimumVendorImplementations: 2,
-          },
-        ],
-        ...(isProd && lit ? [["cssnano"]] : []),
-      ],
+      },
     },
   },
-});
+];
 
 /** @type {import("@rspack/core").RspackOptions} */
 const common = {
@@ -137,12 +142,12 @@ const common = {
             loader: "css-loader",
             options: {
               exportType: "string",
-              importLoaders: 1,
+              importLoaders: 2,
               // TODO: extract inline source map into external .map file in prod
               sourceMap: !isProd,
             },
           },
-          postcssLoader(true),
+          ...postcssLoaders(true),
         ],
       },
     ],
@@ -258,10 +263,10 @@ const clientAndLegacyCommon = {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 1,
+              importLoaders: 2,
             },
           },
-          postcssLoader(),
+          ...postcssLoaders(),
         ],
       },
     ],
@@ -466,11 +471,11 @@ const legacyConfig = merge(common, clientAndLegacyCommon, {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 3,
+              importLoaders: 4,
               exportType: "css-style-sheet",
             },
           },
-          postcssLoader(),
+          ...postcssLoaders(),
           "resolve-url-loader",
           {
             loader: "sass-loader",
@@ -489,10 +494,10 @@ const legacyConfig = merge(common, clientAndLegacyCommon, {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 3,
+              importLoaders: 4,
             },
           },
-          postcssLoader(),
+          ...postcssLoaders(),
           "resolve-url-loader",
           {
             loader: "sass-loader",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -39,6 +39,9 @@ const OPTIMIZATIONS = {
  */
 const postcssLoaders = (lit = false) => [
   {
+    // the light-dark polyfill incorrectly assumes
+    // it's operating on all css in the page,
+    // so requires fixing
     loader: "./build/loaders/fix-light-dark.js",
   },
   {


### PR DESCRIPTION
Tested against Firefox ESR 115.27.0 and Safari iOS 16.4, and release Firefox and Safari (to ensure no regressions).

A couple of issues here:
- The `light-dark` polyfill was stepping on its own toes, and generating overlapping variables when we combined css files from each server component
  - This is fixed by adding a hash into the variables
- The theme switcher wasn't working because it was setting `color-scheme` directly from javascript
  - This is fixed by only setting the `data-theme` attribute, and using that to set `color-scheme` in css: allowing the polyfill to access it

Before:

<img width="1286" height="1090" alt="Screenshot 2025-08-19 at 12-26-57 JavaScript" src="https://github.com/user-attachments/assets/342e3808-e9cd-4a77-a1b2-08bc756bc446" />

After:

<img width="1286" height="1090" alt="Screenshot 2025-08-19 at 12-27-44 JavaScript" src="https://github.com/user-attachments/assets/49592a4b-5e8b-44e7-bf39-3421a499934e" />


