### PR TITLE
fix(switch): remove closing input tag

### DIFF
--- a/components/switch/element.js
+++ b/components/switch/element.js
@@ -30,7 +30,7 @@ export class MDNSwitch extends LitElement {
         ?checked=${this.checked}
         ?disabled=${this.disabled}
         @change=${this._toggle}
-      ></input>
+      />
       <slot></slot>
     </label>`;
   }


### PR DESCRIPTION
### Description

Removing the closing `</input>` tag

### Motivation

It's not necessary / compliant
