### PR TITLE
fix(placement): fallback rendering on home page

### DIFF
--- a/components/placement-top/element.css
+++ b/components/placement-top/element.css
@@ -224,14 +224,21 @@
 
   align-items: center;
   justify-content: center;
+
+  background-color: var(--color-background-secondary);
+  border-bottom: 1px solid var(--color-border-primary);
 }
 
-.fallback-copy {
+.fallback__copy {
   margin: 0 auto;
-  font-size: 1rem;
+
+  font-size: var(--font-size-normal);
+
   line-height: var(--top-banner-height);
 
-  a:not(.button) {
+  color: var(--color-text-secondary);
+
+  a {
     color: var(--color-link-normal);
   }
 }


### PR DESCRIPTION
### Description

Fixed the color-scheme awareness for the homepage top zone in the fallback case, improved styling to be in line with other placements.

### Motivation

Fixes #578 

### Additional details

<img width="300" alt="image" src="https://github.com/user-attachments/assets/341386fe-6ef4-4b0d-8352-e9df8a0eeb36" />
