### PR TITLE
fix(baseline-indicator): remove asterisk artifact

### DIFF
--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -204,7 +204,7 @@ export class BaselineIndicator extends ServerComponent {
               </p>`
             : html`<p>${context.l10n("baseline-not-extra")}</p>`}
         ${status.asterisk
-          ? html`<p>{"* "}${context.l10n("baseline-asterisk")}</p>`
+          ? html`<p>* ${context.l10n("baseline-asterisk")}</p>`
           : nothing}
         <ul>
           <li>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes the asterisk copy of the Baseline banner.

### Motivation

It contained some unexpected curly braces and quotes.

### Additional details

#### Before

<img width="797" height="374" alt="image" src="https://github.com/user-attachments/assets/a17546d5-1b98-49fe-8e67-6a6d4e086258" />

#### After
<img width="797" height="374" alt="image" src="https://github.com/user-attachments/assets/3405a74f-9ced-4f17-a970-23491fe0cd61" />


### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/591.
