### PR TITLE
fix(search-modal): handle modifier keys

### DIFF
--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -78,6 +78,27 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
         event.preventDefault();
         this._select(this._selected + 1);
         break;
+
+      case "Enter": {
+        const { ctrlKey, shiftKey, altKey, metaKey } = event;
+        const item = this._getSelectedItem();
+        if (item instanceof HTMLElement) {
+          event.preventDefault();
+          item.dispatchEvent(
+            new MouseEvent("click", {
+              bubbles: true,
+              // we attempt to pass modifier keys through
+              // but browser support is incredibly varied:
+              ctrlKey,
+              shiftKey,
+              altKey,
+              metaKey,
+            }),
+          );
+        }
+        break;
+      }
+
       default:
         return;
     }


### PR DESCRIPTION
Allows opening search results in new tabs.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add support for opening quicksearch results with modifier keys.

### Motivation

Allows opening results in a new tab.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/583.
