### PR TITLE
fix(sidebar-filter): increase contrast of matches

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -126,7 +126,7 @@
 
   mark {
     /* Sidebar filter highlight */
-    color: unset;
+    color: var(--color-area-link);
     background-color: var(--color-background-blue);
   }
 }

--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -126,8 +126,8 @@
 
   mark {
     /* Sidebar filter highlight */
-    color: var(--color-area-link);
-    background-color: var(--color-background-blue);
+    color: unset;
+    background-color: var(--color-background-yellow);
   }
 }
 

--- a/components/sidebar-filter/element.css
+++ b/components/sidebar-filter/element.css
@@ -95,11 +95,11 @@
 
     font-size: 0.7rem;
 
-    color: var(--color-area-link);
+    color: var(--color-text-secondary);
 
     white-space: nowrap;
 
-    background: var(--color-background-blue);
+    background: var(--color-background-yellow);
     border-radius: 1em;
   }
 }

--- a/components/sidebar-filter/element.css
+++ b/components/sidebar-filter/element.css
@@ -95,7 +95,7 @@
 
     font-size: 0.7rem;
 
-    color: var(--color-text-secondary);
+    color: var(--color-area-link);
 
     white-space: nowrap;
 

--- a/components/sidebar-filter/element.css
+++ b/components/sidebar-filter/element.css
@@ -99,7 +99,7 @@
 
     white-space: nowrap;
 
-    background: var(--color-background-yellow);
+    background-color: var(--color-background-yellow);
     border-radius: 1em;
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Increase the contrast of the sidebar filter matches by changing the background color (both of the matches, and the match count) to that of matches in the search dialog.

### Motivation

Improve accessibility with the dark theme.

### Additional details

Test URL: https://fred-pr598.review.mdn.allizom.net/en-US/docs/Web/HTML

| Before | After |
|--------|--------|
| <img width="569" height="564" alt="image" src="https://github.com/user-attachments/assets/211882ad-e8f3-41bd-88e2-06b2b5bb045a" /> | <img width="562" height="559" alt="image" src="https://github.com/user-attachments/assets/12d69c23-7e7a-4356-b935-575caa055334" /> |
| <img width="569" height="564" alt="image" src="https://github.com/user-attachments/assets/94c70b0b-4ead-426e-8874-c59d6ebbd700" /> | <img width="562" height="559" alt="image" src="https://github.com/user-attachments/assets/58e84886-c757-45d8-b036-aed1263d2f1b" /> |

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/572.
