### PR TITLE
fix(playground): dispatch editor changes to support undo

### DIFF
--- a/components/play-editor/element.js
+++ b/components/play-editor/element.js
@@ -53,13 +53,14 @@ export class MDNPlayEditor extends LitElement {
   set value(value) {
     this._value = value;
     if (this._editor) {
-      let state = EditorState.create({
-        doc: value,
-        extensions: this._extensions(),
+      this._editor.dispatch({
+        changes: {
+          from: 0,
+          to: this._editor.state.doc.length,
+          insert: value,
+        },
       });
-      this._editor.setState(state);
     }
-    this.dispatchEvent(new Event("update", { bubbles: true, composed: true }));
   }
 
   get value() {


### PR DESCRIPTION
Discovered while reviewing https://github.com/mdn/fred/pull/549, which removed the update `dispatchEvent` on line 62, which I was concerned about.

I [added this line when doing my initial implementation of the playground in fred](https://github.com/mdn/fred/pull/149/files#diff-bad3a7f6d503bb912cd51c86a058b635eeca2b9a86d4ea36d2f0cb99b2709a41R62), in order to ensure that the state got saved after formatting the code.

We were completely resetting the state to do this: this is why the update event wasn't being dispatched in the same way it is when a user edits the code. This also breaks undoing.

Simply updating the state of the editor ensures the event is dispatched in the normal way, and undo works after formatting.