### PR TITLE
feat(writer-mode): reload when content edited

### DIFF
--- a/components/writer-reload/element.js
+++ b/components/writer-reload/element.js
@@ -1,6 +1,14 @@
 import { LitElement, nothing } from "lit";
 
+/**
+ * Custom element which reloads the page when the document has changed.
+ */
 export default class MDNWriterReload extends LitElement {
+  constructor() {
+    super();
+    this._state = "";
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this._pollForChanges();
@@ -33,7 +41,7 @@ export default class MDNWriterReload extends LitElement {
       if (document.visibilityState === "visible") {
         await this._reloadIfChanged();
       }
-      await wait(1000);
+      await timeout(1000);
     }
   }
 }
@@ -41,7 +49,7 @@ export default class MDNWriterReload extends LitElement {
 /**
  * @param {number} ms
  */
-async function wait(ms) {
+async function timeout(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/components/writer-reload/element.js
+++ b/components/writer-reload/element.js
@@ -1,0 +1,48 @@
+import { LitElement, nothing } from "lit";
+
+export default class MDNWriterReload extends LitElement {
+  connectedCallback() {
+    super.connectedCallback();
+    this._pollForChanges();
+  }
+
+  render() {
+    return nothing;
+  }
+
+  async _reloadIfChanged() {
+    const url = new URL(
+      "index.json",
+      new URL(location.pathname + "/", location.origin),
+    );
+    const res = await fetch(url);
+    if (res.ok) {
+      const state = await res.text();
+      if (!this._state) {
+        this._state = state;
+      } else if (this._state !== state) {
+        location.reload();
+      }
+    } else {
+      console.error("Failed to fetch document", res.status, res.statusText);
+    }
+  }
+
+  async _pollForChanges() {
+    while (true) {
+      if (document.visibilityState === "visible") {
+        await this._reloadIfChanged();
+      }
+      await wait(1000);
+    }
+  }
+}
+
+/**
+ * @param {number} ms
+ */
+async function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+customElements.define("mdn-writer-reload", MDNWriterReload);

--- a/components/writer-toolbar/server.js
+++ b/components/writer-toolbar/server.js
@@ -18,9 +18,12 @@ export class WriterToolbar extends ServerComponent {
         variant: "plain",
       })}
       ${context.localServer
-        ? html`<mdn-writer-open-editor
-            filepath=${`${folder}/${filename}`}
-          ></mdn-writer-open-editor>`
+        ? html`
+            <mdn-writer-open-editor
+              filepath=${`${folder}/${filename}`}
+            ></mdn-writer-open-editor>
+            <mdn-writer-reload></mdn-writer-reload>
+          `
         : nothing}
     </div>`;
   }

--- a/types/element-map.d.ts
+++ b/types/element-map.d.ts
@@ -58,6 +58,7 @@ declare global {
     "mdn-toggle-sidebar": import("../components/toggle-sidebar/element.js").MDNToggleSidebar;
     "mdn-user-menu": import("../components/user-menu/element.js").MDNUserMenu;
     "mdn-writer-open-editor": import("../components/writer-open-editor/element.js").MDNWriterOpenEditor;
+    "mdn-writer-reload": import("../components/writer-reload/element.js").MDNWriterReload;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/603

Uses [`document.visibilityState`](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState) to ensure we don't hammer rari when a user has multiple tabs open.

Uses two methods to avoid https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Too_much_recursion if recursively calling one.