### PR TITLE
fix(play-runner): internal state could clobber runner state

### DIFF
--- a/components/env/index.js
+++ b/components/env/index.js
@@ -9,6 +9,7 @@ export const PLAYGROUND_BASE_HOST = parseString(
   "PLAYGROUND_BASE_HOST",
   "mdnplay.dev",
 );
+export const PLAYGROUND_LOCAL = parseBool("PLAYGROUND_LOCAL", false);
 
 export const FXA_SIGNIN_URL = parseString(
   "FXA_SIGNIN_URL",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -167,6 +167,7 @@ const clientAndSsrCommon = {
   plugins: [
     new rspack.DefinePlugin({
       "process.env": JSON.stringify({
+        FRED_PLAYGROUND_LOCAL: String(!isProd),
         ...Object.fromEntries(
           Object.entries(process.env).filter(([key]) =>
             key.startsWith("FRED_"),


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/606 (though you might have to trust me on that...)

I never came up with a way of reproducing the above issue locally organically. I did however figure out that the issue isn't `this._iframe.value?.contentWindow?.location.replace(src);` as this works even before the blank runner has loaded, when the iframe's src is `about:blank`.

The one way I was able to trigger - what I assume is the same issue - locally, was by artificially adding a random query param to the iframe's src on every render. This produced the same result, DOM state and network panel state as the bug on prod.

This fix avoids that problem, and thoroughly cleans up the code. We had some rather complex code here because we wanted to avoid adding to the browser history when updating the iframe's src. We used the `location.replace` approach to do this before, but we can just ensure the iframe gets removed and re-added to the DOM with the Lit `keyed` directive.

This means we can also remove the complexity around ensuring we `location.replace` on a non-`about:blank` page in Safari, [to ensure it sends a `Referer` header](https://github.com/mdn/yari/commit/bfb93f509e7df80efb282ab918ac243b698aafb4). Since we're just inserting a new iframe, the Referer is always sent.

Also updates the local server to allow running the playground on https: this was necessary for testing against safari (on another machine) locally.

Tested across latest release version of Firefox, Chromium and Safari.