### PR TITLE
fix(homepage-contributor-spotlight): preserve image aspect ratio

### DIFF
--- a/components/homepage-contributor-spotlight/server.css
+++ b/components/homepage-contributor-spotlight/server.css
@@ -77,8 +77,11 @@
 
   img {
     place-self: center;
+
     width: max-content;
     max-height: 8rem;
+
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Add object-fit: contain to .homepage-contributor-spotlight__logo img to prevent the 'MDN its the web' image from being stretched on Safari.

### Motivation

Help the Open source web!
<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

The fix removed the stretching on Safari
<img width="962" height="256" alt="Screenshot 2025-08-24 at 8 27 52 AM" src="https://github.com/user-attachments/assets/127e9c43-4933-44eb-afed-d79225e73af3" />

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #613
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

