### PR TITLE
fix(homepage-hero): link to current locale

### DIFF
--- a/components/homepage-hero/server.js
+++ b/components/homepage-hero/server.js
@@ -19,17 +19,17 @@ export class HomepageHero extends ServerComponent {
           elements: {
             css: {
               tag: "a",
-              href: "/en-US/docs/Web/CSS",
+              href: `/${context.locale}/docs/Web/CSS`,
               "data-glean": "homepage_hero: css",
             },
             html: {
               tag: "a",
-              href: "/en-US/docs/Web/HTML",
+              href: `/${context.locale}/docs/Web/HTML`,
               "data-glean": "homepage_hero: html",
             },
             js: {
               tag: "a",
-              href: "/en-US/docs/Web/JavaScript",
+              href: `/${context.locale}/docs/Web/JavaScript`,
               "data-glean": "homepage_hero: js",
             },
           },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the hero links on the homepage to use the current locale.

### Motivation

Avoid confusion, as they currently point to `/en-US/` in all locales.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

