### PR TITLE
enhance(play-runner): set allow-modals by default

### DIFF
--- a/components/play-runner/element.js
+++ b/components/play-runner/element.js
@@ -146,6 +146,7 @@ export class MDNPlayRunner extends LitElement {
               "allow-scripts",
               "allow-same-origin",
               "allow-forms",
+              "allow-modals",
               ...(this.sandbox?.split(" ") || []),
             ]),
           ].join(" ")}


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/633

Tested locally with https://github.com/mdn/content/pull/40650:

<img width="1219" height="1248" alt="Screenshot_20250826_094047" src="https://github.com/user-attachments/assets/78695dc2-60a2-40ff-b1ca-e515e09e8ae7" />