### PR TITLE
feat(env): add runtime variables

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.release.outputs.release_created
         run: npm publish --access public
         env:
-          FRED_ALLOW_RUNTIME: true
+          FRED_ALLOW_RUNTIME_ENV: true
           # TODO: probably want to disable this, but it doesn't seem to work in content at the moment:
           FRED_LEGACY: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.release.outputs.release_created
         run: npm publish --access public
         env:
-          FRED_WRITER_MODE: true
+          FRED_ALLOW_RUNTIME: true
           # TODO: probably want to disable this, but it doesn't seem to work in content at the moment:
           FRED_LEGACY: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.release.outputs.release_created
         run: npm publish --access public
         env:
-          FRED_ALLOW_RUNTIME_ENV: true
+          FRED_RUNTIME_ENV: true
           # TODO: probably want to disable this, but it doesn't seem to work in content at the moment:
           FRED_LEGACY: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ MDN's next fr(ont)e(n)d.
 
 ## Development principles
 
+### Environment variables
+
+See [the environment variables README](./components/env/README.md).
+
 ### Inline JS
 
 We need to run some JS as soon as possible at page load, to avoid layout shifts and flashes.

--- a/components/env/README.md
+++ b/components/env/README.md
@@ -1,0 +1,25 @@
+# Environment Variables
+
+If a component or other part of Fred requires a variable set from the environment, you should define it in the [`./index.js`](./index.js) file, with a safe default value.
+
+## Defaults
+
+We set safe defaults for prod, unless the risk from doing - and having this set everywhere, across local dev etc. - outweighs the risk of it not being set on prod.
+
+E.g. we don't set `GLEAN_ENABLED` to the prod default, as we don't want to send telemetry pings for prod from other environments, and we'll notice in our telemetry if it's not set in prod.
+
+## Naming
+
+Within Fred, variables are unprefixed, however the environment variable name is prefixed with `FRED_` to avoid conflicts with other environment variables. For example, if you define a variable `MY_VAR` in Fred, the environment variable to set would be `FRED_MY_VAR`.
+
+## Secrets
+
+Rspack will bundle all environment variables prefixed with `FRED_` into the bundle, which is exposed client side. Therefore you should never set secrets through `FRED_` environment variables.
+
+As secrets can only be used in server-side components, you should simply set them through a non-`FRED_`-prefixed environment variable, and access them using the `process.env` object.
+
+## Build-time vs runtime
+
+By default, variables are baked into our bundle at build time. However, you can define variables as runtime environment variables, which can be changed when running a pre-built version of Fred.
+
+This is used in our npm package, so we can e.g. set `FRED_WRITER_MODE=true` in the `content` repo, without having to bake that into the npm package for all consumers.

--- a/components/env/README.md
+++ b/components/env/README.md
@@ -14,12 +14,15 @@ Within Fred, variables are unprefixed, however the environment variable name is 
 
 ## Secrets
 
-Rspack will bundle all environment variables prefixed with `FRED_` into the bundle, which is exposed client side. Therefore you should never set secrets through `FRED_` environment variables.
+Rspack will bundle **all** environment variables prefixed with `FRED_` into the bundle, which is exposed client side.
 
-As secrets can only be used in server-side components, you should simply set them through a non-`FRED_`-prefixed environment variable, and access them using the `process.env` object.
+> [!WARNING]
+> **Never set secrets** through `FRED_` environment variables.
+>
+> As secrets can only be used in server-side components, you should simply set them through a non-`FRED_`-prefixed environment variable, and access them using the `process.env` object.
 
 ## Build-time vs runtime
 
-By default, variables are baked into our bundle at build time. However, you can define variables as runtime environment variables, which can be changed when running a pre-built version of Fred.
+By default, variables are baked into our bundle at build time. However, you can define variables as runtime environment variables, which can be changed when running a version of Fred built with `FRED_RUNTIME_ENV=true`.
 
 This is used in our npm package, so we can e.g. set `FRED_WRITER_MODE=true` in the `content` repo, without having to bake that into the npm package for all consumers.

--- a/components/env/index.js
+++ b/components/env/index.js
@@ -5,6 +5,8 @@
  * everywhere, across local dev etc. - outweighs the risk of it not being set on prod.
  */
 
+import { parseBool, parseString } from "./utils.js";
+
 export const PLAYGROUND_BASE_HOST = parseString(
   "PLAYGROUND_BASE_HOST",
   "mdnplay.dev",
@@ -33,7 +35,7 @@ export const GLEAN_DEBUG = parseBool("GLEAN_DEBUG", false);
  */
 export const ROBOTS_GLOBAL_ALLOW = parseBool("ROBOTS_GLOBAL_ALLOW", true);
 
-export const WRITER_MODE = parseBool("WRITER_MODE", false);
+export const WRITER_MODE = parseBool("WRITER_MODE", false, true);
 
 export const BCD_BASE_URL = parseString(
   "BCD_BASE_URL",
@@ -44,25 +46,3 @@ export const OBSERVATORY_API_URL = parseString(
   "OBSERVATORY_API_URL",
   "https://observatory-api.mdn.mozilla.net",
 );
-
-/**
- * @param {string} name
- * @param {boolean} fallback
- */
-function parseBool(name, fallback) {
-  try {
-    return Boolean(
-      JSON.parse(process.env[`FRED_${name}`] || JSON.stringify(fallback)),
-    );
-  } catch {
-    return fallback;
-  }
-}
-
-/**
- * @param {string} name
- * @param {string} fallback
- */
-function parseString(name, fallback) {
-  return process.env[`FRED_${name}`] || fallback;
-}

--- a/components/env/index.js
+++ b/components/env/index.js
@@ -1,10 +1,3 @@
-/**
- * @file Retrieves environment variables, setting defaults, for other areas of the app.
- *
- * We set safe defaults for prod, unless the risk from doing - and having this set
- * everywhere, across local dev etc. - outweighs the risk of it not being set on prod.
- */
-
 import { parseBool, parseString } from "./utils.js";
 
 export const PLAYGROUND_BASE_HOST = parseString(
@@ -35,7 +28,7 @@ export const GLEAN_DEBUG = parseBool("GLEAN_DEBUG", false);
  */
 export const ROBOTS_GLOBAL_ALLOW = parseBool("ROBOTS_GLOBAL_ALLOW", true);
 
-export const WRITER_MODE = parseBool("WRITER_MODE", false, true);
+export const WRITER_MODE = parseBool("WRITER_MODE", false, { runtime: true });
 
 export const BCD_BASE_URL = parseString(
   "BCD_BASE_URL",

--- a/components/env/runtime.js
+++ b/components/env/runtime.js
@@ -3,4 +3,4 @@ import { parseBool } from "./utils.js";
 /** @type {string[]} */
 export const runtimeVariables = [];
 /** Overriden to prod default (false) in rspack config, set to true so it works in dev server by default. */
-export const ALLOW_RUNTIME_ENV = parseBool("ALLOW_RUNTIME_ENV", true);
+export const RUNTIME_ENV = parseBool("RUNTIME_ENV", true);

--- a/components/env/runtime.js
+++ b/components/env/runtime.js
@@ -3,4 +3,4 @@ import { parseBool } from "./utils.js";
 /** @type {string[]} */
 export const runtimeVariables = [];
 /** Overriden to prod default (false) in rspack config, set to true so it works in dev server by default. */
-export const ALLOW_RUNTIME = parseBool("ALLOW_RUNTIME", true);
+export const ALLOW_RUNTIME_ENV = parseBool("ALLOW_RUNTIME_ENV", true);

--- a/components/env/runtime.js
+++ b/components/env/runtime.js
@@ -1,0 +1,6 @@
+import { parseBool } from "./utils.js";
+
+/** @type {string[]} */
+export const runtimeVariables = [];
+/** Overriden to prod default (false) in rspack config, set to true so it works in dev server by default. */
+export const ALLOW_RUNTIME = parseBool("ALLOW_RUNTIME", true);

--- a/components/env/types.d.ts
+++ b/components/env/types.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  var __MDNEnv: Record<string, string> | undefined;
+}
+
+export {};

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -1,4 +1,4 @@
-import { ALLOW_RUNTIME_ENV, runtimeVariables } from "./runtime.js";
+import { RUNTIME_ENV, runtimeVariables } from "./runtime.js";
 
 /**
  * @typedef {object} Options
@@ -37,7 +37,7 @@ export function parseString(name, fallback, options) {
 function getEnv(name, options = {}) {
   const { runtime } = { runtime: false, ...options };
   name = `FRED_${name}`;
-  if (runtime && ALLOW_RUNTIME_ENV) {
+  if (runtime && RUNTIME_ENV) {
     runtimeVariables.push(name);
     return process.env[name] || getEnv(name);
   }

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -1,14 +1,19 @@
-import { ALLOW_RUNTIME, runtimeVariables } from "./runtime.js";
+import { ALLOW_RUNTIME_ENV, runtimeVariables } from "./runtime.js";
+
+/**
+ * @typedef {object} Options
+ * @property {boolean} [runtime] Allow setting this value at runtime
+ */
 
 /**
  * @param {string} name
  * @param {boolean} fallback
- * @param {boolean} runtime
+ * @param {Options} [options]
  */
-export function parseBool(name, fallback, runtime = false) {
+export function parseBool(name, fallback, options) {
   try {
     return Boolean(
-      JSON.parse(getEnv(name, runtime) || JSON.stringify(fallback)),
+      JSON.parse(getEnv(name, options) || JSON.stringify(fallback)),
     );
   } catch {
     return fallback;
@@ -18,20 +23,21 @@ export function parseBool(name, fallback, runtime = false) {
 /**
  * @param {string} name
  * @param {string} fallback
- * @param {boolean} runtime
+ * @param {Options} [options]
  */
-export function parseString(name, fallback, runtime = false) {
-  return getEnv(name, runtime) || fallback;
+export function parseString(name, fallback, options) {
+  return getEnv(name, options) || fallback;
 }
 
 /**
  * @param {string} name
- * @param {boolean} runtime
+ * @param {Options} [options]
  * @returns {string | undefined}
  */
-function getEnv(name, runtime = false) {
+function getEnv(name, options = {}) {
+  const { runtime } = { runtime: false, ...options };
   name = `FRED_${name}`;
-  if (runtime && ALLOW_RUNTIME) {
+  if (runtime && ALLOW_RUNTIME_ENV) {
     runtimeVariables.push(name);
     return process.env[name] || getEnv(name);
   }

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -1,0 +1,39 @@
+import { ALLOW_RUNTIME, runtimeVariables } from "./runtime.js";
+
+/**
+ * @param {string} name
+ * @param {boolean} fallback
+ * @param {boolean} runtime
+ */
+export function parseBool(name, fallback, runtime = false) {
+  try {
+    return Boolean(
+      JSON.parse(getEnv(name, runtime) || JSON.stringify(fallback)),
+    );
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * @param {string} name
+ * @param {string} fallback
+ * @param {boolean} runtime
+ */
+export function parseString(name, fallback, runtime = false) {
+  return getEnv(name, runtime) || fallback;
+}
+
+/**
+ * @param {string} name
+ * @param {boolean} runtime
+ * @returns {string | undefined}
+ */
+function getEnv(name, runtime = false) {
+  name = `FRED_${name}`;
+  if (runtime && ALLOW_RUNTIME) {
+    runtimeVariables.push(name);
+    return process.env[name] || getEnv(name);
+  }
+  return globalThis.__MDNEnv?.[name];
+}

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -5,7 +5,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import inlineScript from "../../entry.inline.js?source&csp=true";
 import { ROBOTS_GLOBAL_ALLOW, WRITER_MODE } from "../env/index.js";
-import { ALLOW_RUNTIME_ENV, runtimeVariables } from "../env/runtime.js";
+import { RUNTIME_ENV, runtimeVariables } from "../env/runtime.js";
 import Favicon from "../favicon/pure.js";
 import { asyncLocalStorage } from "../server/async-local-storage.js";
 import { ServerComponent } from "../server/index.js";
@@ -93,7 +93,7 @@ export class OuterLayout extends ServerComponent {
             content="width=device-width, initial-scale=1.0"
           />
           <title>${context.pageTitle || "MDN"}</title>
-          ${ALLOW_RUNTIME_ENV
+          ${RUNTIME_ENV
             ? unsafeHTML(`<script>process = {
   env: ${JSON.stringify(env)}
 };</script>`)

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -5,7 +5,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import inlineScript from "../../entry.inline.js?source&csp=true";
 import { ROBOTS_GLOBAL_ALLOW, WRITER_MODE } from "../env/index.js";
-import { ALLOW_RUNTIME, runtimeVariables } from "../env/runtime.js";
+import { ALLOW_RUNTIME_ENV, runtimeVariables } from "../env/runtime.js";
 import Favicon from "../favicon/pure.js";
 import { asyncLocalStorage } from "../server/async-local-storage.js";
 import { ServerComponent } from "../server/index.js";
@@ -93,7 +93,7 @@ export class OuterLayout extends ServerComponent {
             content="width=device-width, initial-scale=1.0"
           />
           <title>${context.pageTitle || "MDN"}</title>
-          ${ALLOW_RUNTIME
+          ${ALLOW_RUNTIME_ENV
             ? unsafeHTML(`<script>process = {
   env: ${JSON.stringify(env)}
 };</script>`)

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -5,6 +5,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import inlineScript from "../../entry.inline.js?source&csp=true";
 import { ROBOTS_GLOBAL_ALLOW, WRITER_MODE } from "../env/index.js";
+import { ALLOW_RUNTIME, runtimeVariables } from "../env/runtime.js";
 import Favicon from "../favicon/pure.js";
 import { asyncLocalStorage } from "../server/async-local-storage.js";
 import { ServerComponent } from "../server/index.js";
@@ -68,6 +69,12 @@ export class OuterLayout extends ServerComponent {
         ? "learn"
         : undefined;
 
+    const env = Object.fromEntries(
+      Object.entries(process.env).filter(([key]) =>
+        runtimeVariables.includes(key),
+      ),
+    );
+
     // if you want to put some script inline, put it in entry.inline.js
     // and you'll get CSP generation: see the README
     return html`
@@ -86,6 +93,11 @@ export class OuterLayout extends ServerComponent {
             content="width=device-width, initial-scale=1.0"
           />
           <title>${context.pageTitle || "MDN"}</title>
+          ${ALLOW_RUNTIME
+            ? unsafeHTML(`<script>process = {
+  env: ${JSON.stringify(env)}
+};</script>`)
+            : nothing}
           ${unsafeHTML(`<script>${inlineScript}</script>`)}
           ${styles.map(
             (path) =>

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -193,7 +193,7 @@ const clientAndSsrCommon = {
   plugins: [
     new rspack.DefinePlugin({
       "globalThis.__MDNEnv": JSON.stringify({
-        FRED_ALLOW_RUNTIME_ENV: String(!isProd),
+        FRED_RUNTIME_ENV: String(!isProd),
         FRED_PLAYGROUND_LOCAL: String(!isProd),
         ...Object.fromEntries(
           Object.entries(process.env).filter(([key]) =>

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -192,7 +192,8 @@ const notServiceWorkerCommon = {
 const clientAndSsrCommon = {
   plugins: [
     new rspack.DefinePlugin({
-      "process.env": JSON.stringify({
+      "globalThis.__MDNEnv": JSON.stringify({
+        FRED_ALLOW_RUNTIME: String(!isProd),
         FRED_PLAYGROUND_LOCAL: String(!isProd),
         ...Object.fromEntries(
           Object.entries(process.env).filter(([key]) =>

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -193,7 +193,7 @@ const clientAndSsrCommon = {
   plugins: [
     new rspack.DefinePlugin({
       "globalThis.__MDNEnv": JSON.stringify({
-        FRED_ALLOW_RUNTIME: String(!isProd),
+        FRED_ALLOW_RUNTIME_ENV: String(!isProd),
         FRED_PLAYGROUND_LOCAL: String(!isProd),
         ...Object.fromEntries(
           Object.entries(process.env).filter(([key]) =>


### PR DESCRIPTION
Partially fixes https://github.com/mdn/fred/issues/604

Making `WRITER_MODE` a runtime variable ensures that if the toolbar is being shown in the client, then the `_editor` API is enabled.

Tested locally with `npm pack`.