### PR TITLE
fix(observatory): score tooltip broken on chrome/safari

### DIFF
--- a/components/observatory-results/element.css
+++ b/components/observatory-results/element.css
@@ -98,6 +98,10 @@ code {
 .grade-trend {
   grid-area: grade;
   justify-self: start;
+
+  .overall {
+    position: relative;
+  }
 }
 
 .data {
@@ -117,8 +121,6 @@ mdn-observatory-rescan-button {
 }
 
 .info-tooltip {
-  position: relative;
-
   display: inline-block;
 
   cursor: pointer;
@@ -183,14 +185,13 @@ mdn-observatory-rescan-button {
 }
 
 .tooltip-popup {
-  --tooltip-offset: -6.3rem;
-
   --color-tooltip: light-dark(#b3b3b3, #696969);
   --color-tooltip-highlight: light-dark(#ffffff, #1b1b1b);
   --color-bg-tooltip: light-dark(#1b1b1b, #ffffff);
 
-  position: relative;
+  position: absolute;
   inset: unset;
+  left: 50%;
   z-index: 1;
 
   width: max-content;
@@ -211,7 +212,7 @@ mdn-observatory-rescan-button {
   border-width: 0;
   border-radius: var(--border-radius);
 
-  transform: translateX(var(--tooltip-offset));
+  transform: translateX(-50%);
 
   .arrow {
     position: absolute;

--- a/components/observatory-results/rating.js
+++ b/components/observatory-results/rating.js
@@ -6,6 +6,7 @@ import { Tooltip } from "./tooltip.js";
 import { Trend } from "./trend.js";
 
 import "../observatory-rescan-button/element.js";
+import "../dropdown/element.js";
 
 /**
  *
@@ -21,19 +22,21 @@ export function Rating({ result, host, rescan }) {
     <section class="scan-result">
       <section class="grade-trend">
         <div class="overall">
-          <button
-            popovertarget="grade-popover"
-            aria-label="show info tooltip"
-            class="info-tooltip"
-            tabindex="0"
-          >
-            <div
-              class=${`grade grade-${result.scan.grade?.[0]?.toLowerCase()}`}
+          <mdn-dropdown>
+            <button
+              slot="button"
+              aria-label="show info tooltip"
+              class="info-tooltip"
+              tabindex="0"
             >
-              ${formatMinus(result.scan.grade)}
-            </div>
+              <div
+                class=${`grade grade-${result.scan.grade?.[0]?.toLowerCase()}`}
+              >
+                ${formatMinus(result.scan.grade)}
+              </div>
+            </button>
             ${Tooltip(result)}
-          </button>
+          </mdn-dropdown>
         </div>
         ${Trend({ result })}
       </section>

--- a/components/observatory-results/tooltip.js
+++ b/components/observatory-results/tooltip.js
@@ -26,8 +26,8 @@ export function Tooltip(result) {
   });
 
   return html`
-    <span
-      popover
+    <div
+      slot="dropdown"
       id="grade-popover"
       aria-describedby="grade-table"
       class="tooltip-popup"
@@ -44,6 +44,6 @@ export function Tooltip(result) {
           ${rows}
         </tbody>
       </table>
-    </span>
+    </div>
   `;
 }


### PR DESCRIPTION
fixes https://github.com/mdn/fred/issues/569

popover was causing weird behaviour, switched to our generic dropdown component

Tested across Firefox, Chromium and WebKit:

<img width="1700" height="1185" alt="Screenshot_20250827_120041" src="https://github.com/user-attachments/assets/91bfc306-f9d6-4dfe-bb2a-8b8fbdf22712" />
