### PR TITLE
chore(compat-table): hide Bun for now

### DIFF
--- a/components/compat-table/utils.js
+++ b/components/compat-table/utils.js
@@ -2,7 +2,7 @@
  * A list of browsers to be hidden.
  * @constant {string[]}
  */
-export const HIDDEN_BROWSERS = ["ie"];
+export const HIDDEN_BROWSERS = ["bun", "ie"];
 
 /**
  * Gets the first element of an array or returns the value itself.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Hide Bun in browser compatibility tables.

### Motivation

- This requires a bit more work (Deno/Node.js have special handling).
- This needs some discussion. For example, the BCD table already overflows occasionally on features that are in preview releases (Nightly), and adding another column might cause more overflows.

Overall, hiding is the best option we have right now, but we will follow up soon.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

