### PR TITLE
fix(live-samples): avoid handling code examples twice

### DIFF
--- a/hooks/live-samples.js
+++ b/hooks/live-samples.js
@@ -11,8 +11,9 @@ for (const iframe of document.querySelectorAll("iframe[data-live-id]")) {
       /** @type {MDNCodeExample[]} */
       const codeExamples = [];
 
+      const escapedId = liveId.replaceAll(".", String.raw`\.`);
       for (const element of document.querySelectorAll(
-        `.live-sample___${liveId}, .live-sample---${liveId}`,
+        `.live-sample___${escapedId}, .live-sample---${escapedId}`,
       )) {
         const { MDNCodeExample, upgradePre } = await import(
           "../components/code-example/element.js"

--- a/hooks/live-samples.js
+++ b/hooks/live-samples.js
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/prefer-query-selector */
 /**
  * @import { MDNCodeExample } from "../components/code-example/element.js";
  */
@@ -12,12 +11,9 @@ for (const iframe of document.querySelectorAll("iframe[data-live-id]")) {
       /** @type {MDNCodeExample[]} */
       const codeExamples = [];
 
-      for (const element of [
-        // use getElementsByClassName as liveId can contain dots,
-        // which breaks querySelectorAll
-        ...document.getElementsByClassName(`live-sample___${liveId}`),
-        ...document.getElementsByClassName(`live-sample---${liveId}`),
-      ]) {
+      for (const element of document.querySelectorAll(
+        `.live-sample___${liveId}, .live-sample---${liveId}`,
+      )) {
         const { MDNCodeExample, upgradePre } = await import(
           "../components/code-example/element.js"
         );


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Reverts https://github.com/mdn/fred/pull/637, and escapes the live id.

### Motivation

- Some code examples had both classes, so they were handled twice, and output appeared twice.
- Deduplication seemed like an option, but is overall more complex than just escaping.

### Additional details

Tested on the following pages:

- http://localhost:3000/en-US/docs/Learn_web_development/Core/Styling_basics/Overflow#css_tries_to_avoid_data_loss (from #651)
- http://localhost:3000/en-US/docs/Web/API/URL/parse_static#examples (from #590)

### Related issues and pull requests

Fixes #651.

