### PR TITLE
fix(playground): set auto run on clear

### DIFF
--- a/components/play-controller/element.js
+++ b/components/play-controller/element.js
@@ -102,6 +102,7 @@ export class MDNPlayController extends LitElement {
   }
 
   clear() {
+    this.runOnChange = true;
     this.initialCode = undefined;
     this.srcPrefix = "";
     this.reset();

--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -80,6 +80,7 @@ export class MDNPlayground extends L10nMixin(LitElement) {
       controller
     ) {
       controller.clear();
+      this._autoRun = true;
       this._storeSession();
       this.requestUpdate();
       const urlWithoutSearch = new URL(location.href);


### PR DESCRIPTION
- Fix https://github.com/mdn/fred/issues/663

### Issues

The PR addresses the following issues in the playground:

1. In a freshly loaded playground, after clearing, it doesn't auto-run the code.

~2. After clearing, the report message(`Seeing something inappropriate?`) toast doesn't go away.~
~3. The report message doesn't go away after closing the report dialog.~
~4. There is no close/dismiss button on the report toast/banner.~

### Solution

- For the first issue, when the clear button is clicked, set the `_autoRun` and `runOnChange` variables.
~- For the second issue, use `${this._gistId && this._showReportToast` condition and hide the toast message on clear button click.~
~- For the third and fourth issues, define a new toast element named MDNToast to show dismissable messages. [Toasts are lightweight, dismissible notifications](https://getbootstrap.com/docs/5.0/components/toasts/).~

### Related issues and pull requests

Fix #663 
