### PR TITLE
chore(copy-button): add checkmark to copied indicator

### DIFF
--- a/components/copy-button/element.js
+++ b/components/copy-button/element.js
@@ -2,6 +2,7 @@ import { LitElement, html } from "lit";
 
 import { L10nMixin } from "../../l10n/mixin.js";
 import { MDNButton } from "../button/element.js";
+import check from "../icon/check.svg?lit";
 
 export class MDNCopyButton extends L10nMixin(LitElement) {
   static properties = {
@@ -12,6 +13,7 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
   constructor() {
     super();
     this.variant = "primary";
+    this.copiedSuccessfully = false;
     /** @type {Element | undefined} */
     this.copiesFrom = undefined;
   }
@@ -21,7 +23,7 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
    */
   async _copy({ target }) {
     if (target instanceof MDNButton) {
-      let copiedSuccessfully = true;
+      this.copiedSuccessfully = true;
       try {
         const text = this.copiesFrom?.textContent?.trim();
         if (text) {
@@ -32,24 +34,28 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
           "Error when trying to use navigator.clipboard.writeText()",
           error,
         );
-        copiedSuccessfully = false;
+        this.copiedSuccessfully = false;
       }
 
-      this._message = copiedSuccessfully
-        ? this.l10n`Copied ✔️`
+      this._message = this.copiedSuccessfully
+        ? this.l10n`Copied`
         : this.l10n`Copy failed!`;
 
       setTimeout(
         () => {
           this._message = undefined;
+          this.copiedSuccessfully = false;
         },
-        copiedSuccessfully ? 1000 : 3000,
+        this.copiedSuccessfully ? 1000 : 3000,
       );
     }
   }
 
   render() {
-    return html`<mdn-button @click=${this._copy} variant=${this.variant}
+    return html`<mdn-button
+      @click=${this._copy}
+      .icon=${this.copiedSuccessfully ? check : undefined}
+      variant=${this.variant}
       >${this._message ?? this.l10n`Copy`}</mdn-button
     >`;
   }

--- a/components/copy-button/element.js
+++ b/components/copy-button/element.js
@@ -24,11 +24,11 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
    */
   async _copy({ target }) {
     if (target instanceof MDNButton) {
-      this._copiedSuccessfully = true;
       try {
         const text = this.copiesFrom?.textContent?.trim();
         if (text) {
           await navigator.clipboard.writeText(text);
+          this._copiedSuccessfully = true;
         }
       } catch (error) {
         console.error(

--- a/components/copy-button/element.js
+++ b/components/copy-button/element.js
@@ -8,12 +8,13 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
   static properties = {
     variant: {},
     _message: { state: true },
+    _copiedSuccessfully: { state: true },
   };
 
   constructor() {
     super();
     this.variant = "primary";
-    this.copiedSuccessfully = false;
+    this._copiedSuccessfully = false;
     /** @type {Element | undefined} */
     this.copiesFrom = undefined;
   }
@@ -23,7 +24,7 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
    */
   async _copy({ target }) {
     if (target instanceof MDNButton) {
-      this.copiedSuccessfully = true;
+      this._copiedSuccessfully = true;
       try {
         const text = this.copiesFrom?.textContent?.trim();
         if (text) {
@@ -34,19 +35,19 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
           "Error when trying to use navigator.clipboard.writeText()",
           error,
         );
-        this.copiedSuccessfully = false;
+        this._copiedSuccessfully = false;
       }
 
-      this._message = this.copiedSuccessfully
+      this._message = this._copiedSuccessfully
         ? this.l10n`Copied`
         : this.l10n`Copy failed!`;
 
       setTimeout(
         () => {
           this._message = undefined;
-          this.copiedSuccessfully = false;
+          this._copiedSuccessfully = false;
         },
-        this.copiedSuccessfully ? 1000 : 3000,
+        this._copiedSuccessfully ? 1000 : 3000,
       );
     }
   }
@@ -54,7 +55,7 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
   render() {
     return html`<mdn-button
       @click=${this._copy}
-      .icon=${this.copiedSuccessfully ? check : undefined}
+      .icon=${this._copiedSuccessfully ? check : undefined}
       variant=${this.variant}
       >${this._message ?? this.l10n`Copy`}</mdn-button
     >`;

--- a/components/copy-button/element.js
+++ b/components/copy-button/element.js
@@ -36,7 +36,7 @@ export class MDNCopyButton extends L10nMixin(LitElement) {
       }
 
       this._message = copiedSuccessfully
-        ? this.l10n`Copied`
+        ? this.l10n`Copied ✔️`
         : this.l10n`Copy failed!`;
 
       setTimeout(


### PR DESCRIPTION
- fix https://github.com/mdn/fred/issues/612

### Description

To make it more apparent, it is suggested to add a check mark along with `Copied` text. The PR uses a heavy check mark emoji.

This is how it looks after the change:

https://github.com/user-attachments/assets/364d9142-de64-4517-b3ee-be81148d2989




