### PR TITLE
feat(server): allow specifiying port from env var

### DIFF
--- a/components/env/index.js
+++ b/components/env/index.js
@@ -4,7 +4,13 @@ export const PLAYGROUND_BASE_HOST = parseString(
   "PLAYGROUND_BASE_HOST",
   "mdnplay.dev",
 );
-export const PLAYGROUND_LOCAL = parseBool("PLAYGROUND_LOCAL", false);
+export const PLAYGROUND_LOCAL = parseBool("PLAYGROUND_LOCAL", false, {
+  runtime: true,
+});
+export const PORT = parseString("PORT", "3000", { runtime: true });
+export const PLAY_PORT = parseString("PLAY_PORT", "3001", {
+  runtime: true,
+});
 
 export const FXA_SIGNIN_URL = parseString(
   "FXA_SIGNIN_URL",

--- a/components/env/index.js
+++ b/components/env/index.js
@@ -1,4 +1,4 @@
-import { parseBool, parseString } from "./utils.js";
+import { parseBool, parseInt, parseString } from "./utils.js";
 
 export const PLAYGROUND_BASE_HOST = parseString(
   "PLAYGROUND_BASE_HOST",
@@ -7,8 +7,8 @@ export const PLAYGROUND_BASE_HOST = parseString(
 export const PLAYGROUND_LOCAL = parseBool("PLAYGROUND_LOCAL", false, {
   runtime: true,
 });
-export const PORT = parseString("PORT", "3000", { runtime: true });
-export const PLAY_PORT = parseString("PLAY_PORT", "3001", {
+export const PORT = parseInt("PORT", 3000, { runtime: true });
+export const PLAYGROUND_PORT = parseInt("PLAYGROUND_PORT", 3001, {
   runtime: true,
 });
 

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -22,6 +22,17 @@ export function parseBool(name, fallback, options) {
 
 /**
  * @param {string} name
+ * @param {number} fallback
+ * @param {Options} [options]
+ */
+export function parseInt(name, fallback, options) {
+  const stringValue = getEnv(name, options);
+  const numberValue = stringValue ? Number.parseInt(stringValue, 10) : fallback;
+  return Number.isNaN(numberValue) ? fallback : numberValue;
+}
+
+/**
+ * @param {string} name
  * @param {string} fallback
  * @param {Options} [options]
  */
@@ -36,10 +47,10 @@ export function parseString(name, fallback, options) {
  */
 function getEnv(name, options = {}) {
   const { runtime } = { runtime: false, ...options };
-  const envName = `FRED_${name}`;
+  const fullName = `FRED_${name}`;
   if (runtime && RUNTIME_ENV) {
-    runtimeVariables.push(envName);
-    return process.env[envName] || getEnv(name);
+    runtimeVariables.push(fullName);
+    return process.env[fullName] || getEnv(name);
   }
-  return globalThis.__MDNEnv?.[envName];
+  return globalThis.__MDNEnv?.[fullName];
 }

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -36,10 +36,10 @@ export function parseString(name, fallback, options) {
  */
 function getEnv(name, options = {}) {
   const { runtime } = { runtime: false, ...options };
-  name = `FRED_${name}`;
+  const envName = `FRED_${name}`;
   if (runtime && RUNTIME_ENV) {
-    runtimeVariables.push(name);
-    return process.env[name] || getEnv(name);
+    runtimeVariables.push(envName);
+    return process.env[envName] || getEnv(name);
   }
-  return globalThis.__MDNEnv?.[name];
+  return globalThis.__MDNEnv?.[envName];
 }

--- a/components/play-runner/element.js
+++ b/components/play-runner/element.js
@@ -5,7 +5,12 @@ import { keyed } from "lit/directives/keyed.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
 import { ThemeController } from "../color-theme/controller.js";
-import { PLAYGROUND_BASE_HOST, PLAYGROUND_LOCAL } from "../env/index.js";
+import {
+  PLAYGROUND_BASE_HOST,
+  PLAYGROUND_LOCAL,
+  PLAY_PORT,
+  PORT,
+} from "../env/index.js";
 import { compressAndBase64Encode } from "../playground/utils.js";
 
 import styles from "./element.css?lit";
@@ -101,7 +106,7 @@ export class MDNPlayRunner extends LitElement {
       const url = new URL(
         `${prefix}/runner.html`,
         PLAYGROUND_LOCAL
-          ? location.origin.replace("3000", "3001")
+          ? location.origin.replace(PORT, PLAY_PORT)
           : `${location.protocol}//${this._subdomain}.${PLAYGROUND_BASE_HOST}`,
       );
       // pass the uuid for postMessage isolation

--- a/components/play-runner/element.js
+++ b/components/play-runner/element.js
@@ -8,7 +8,7 @@ import { ThemeController } from "../color-theme/controller.js";
 import {
   PLAYGROUND_BASE_HOST,
   PLAYGROUND_LOCAL,
-  PLAY_PORT,
+  PLAYGROUND_PORT,
   PORT,
 } from "../env/index.js";
 import { compressAndBase64Encode } from "../playground/utils.js";
@@ -106,7 +106,7 @@ export class MDNPlayRunner extends LitElement {
       const url = new URL(
         `${prefix}/runner.html`,
         PLAYGROUND_LOCAL
-          ? location.origin.replace(PORT, PLAY_PORT)
+          ? location.origin.replace(PORT.toString(), PLAYGROUND_PORT.toString())
           : `${location.protocol}//${this._subdomain}.${PLAYGROUND_BASE_HOST}`,
       );
       // pass the uuid for postMessage isolation

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import openEditor from "open-editor";
 
 import { FRED_BUILD_ROOT } from "./build/env.js";
-import { WRITER_MODE } from "./components/env/index.js";
+import { PLAY_PORT, PORT, WRITER_MODE } from "./components/env/index.js";
 import { handleRunner } from "./vendor/yari/libs/play/index.js";
 
 import "source-map-support/register.js";
@@ -322,14 +322,14 @@ export async function startServer() {
     );
   }
 
-  const httpServer = app.listen(3000, () => {
+  const httpServer = app.listen(PORT, () => {
     console.log(
-      `Server started at ${http2 ? "https" : "http"}://localhost:3000`,
+      `Server started at ${http2 ? "https" : "http"}://localhost:${PORT}`,
     );
   });
 
-  const playServer = play.listen(3001, () => {
-    console.log(`Play server started at http://localhost:3001`);
+  const playServer = play.listen(PLAY_PORT, () => {
+    console.log(`Playground server started on port ${PLAY_PORT}`);
   });
 
   return {

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import openEditor from "open-editor";
 
 import { FRED_BUILD_ROOT } from "./build/env.js";
-import { PLAY_PORT, PORT, WRITER_MODE } from "./components/env/index.js";
+import { PLAYGROUND_PORT, PORT, WRITER_MODE } from "./components/env/index.js";
 import { handleRunner } from "./vendor/yari/libs/play/index.js";
 
 import "source-map-support/register.js";
@@ -328,8 +328,8 @@ export async function startServer() {
     );
   });
 
-  const playServer = play.listen(PLAY_PORT, () => {
-    console.log(`Playground server started on port ${PLAY_PORT}`);
+  const playServer = play.listen(PLAYGROUND_PORT, () => {
+    console.log(`Playground backend started on port ${PLAYGROUND_PORT}`);
   });
 
   return {


### PR DESCRIPTION
### Description

Allow specifying ports for server from environment variable

### Motivation

Good practice, allows running multiple fred servers at once. Necessary for content to maintain 5042 port.

### Additional details

Also fixes a bug where a runtime variable would fallback to a double prefixed variable, e.g. `FRED_FOO` would fall back to `FRED_FRED_FOO`.
Also modifies the server output to not output a link to the playground server: you wouldn't want to click on it, so it's potentially confusing.


Part of https://github.com/mdn/fred/issues/667.