### PR TITLE
feat(env): add FRED_PORT variable

### DIFF
--- a/components/env/index.js
+++ b/components/env/index.js
@@ -1,10 +1,15 @@
-import { parseBool, parseString } from "./utils.js";
+import { parseBool, parseInt, parseString } from "./utils.js";
 
 export const PLAYGROUND_BASE_HOST = parseString(
   "PLAYGROUND_BASE_HOST",
   "mdnplay.dev",
 );
 export const PLAYGROUND_LOCAL = parseBool("PLAYGROUND_LOCAL", false);
+
+export const PORT = parseInt("PORT", 3000, { runtime: true });
+export const PLAYGROUND_PORT = parseInt("PLAYGROUND_PORT", PORT + 1, {
+  runtime: true,
+});
 
 export const FXA_SIGNIN_URL = parseString(
   "FXA_SIGNIN_URL",

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -31,6 +31,16 @@ export function parseString(name, fallback, options) {
 
 /**
  * @param {string} name
+ * @param {number} fallback
+ * @param {Options} [options]
+ */
+export function parseInt(name, fallback, options) {
+  const value = getEnv(name, options);
+  return value && /^\d+$/.test(value) ? Number(value) : fallback;
+}
+
+/**
+ * @param {string} name
  * @param {Options} [options]
  * @returns {string | undefined}
  */

--- a/components/play-runner/element.js
+++ b/components/play-runner/element.js
@@ -5,7 +5,12 @@ import { keyed } from "lit/directives/keyed.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
 import { ThemeController } from "../color-theme/controller.js";
-import { PLAYGROUND_BASE_HOST, PLAYGROUND_LOCAL } from "../env/index.js";
+import {
+  PLAYGROUND_BASE_HOST,
+  PLAYGROUND_LOCAL,
+  PLAYGROUND_PORT,
+  PORT,
+} from "../env/index.js";
 import { compressAndBase64Encode } from "../playground/utils.js";
 
 import styles from "./element.css?lit";
@@ -101,7 +106,7 @@ export class MDNPlayRunner extends LitElement {
       const url = new URL(
         `${prefix}/runner.html`,
         PLAYGROUND_LOCAL
-          ? location.origin.replace("3000", "3001")
+          ? location.origin.replace(String(PORT), String(PLAYGROUND_PORT))
           : `${location.protocol}//${this._subdomain}.${PLAYGROUND_BASE_HOST}`,
       );
       // pass the uuid for postMessage isolation

--- a/server.js
+++ b/server.js
@@ -8,10 +8,11 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import openEditor from "open-editor";
 
 import { FRED_BUILD_ROOT } from "./build/env.js";
-import { WRITER_MODE } from "./components/env/index.js";
+import { PLAYGROUND_PORT, PORT, WRITER_MODE } from "./components/env/index.js";
 import { handleRunner } from "./vendor/yari/libs/play/index.js";
 
 import "source-map-support/register.js";
+
 /**
  * @import { Request, Response } from "express";
  * @import { Stats } from "@rspack/core";
@@ -322,14 +323,14 @@ export async function startServer() {
     );
   }
 
-  const httpServer = app.listen(3000, () => {
+  const httpServer = app.listen(PORT, () => {
     console.log(
-      `Server started at ${http2 ? "https" : "http"}://localhost:3000`,
+      `Server started at ${http2 ? "https" : "http"}://localhost:${PORT}`,
     );
   });
 
-  const playServer = play.listen(3001, () => {
-    console.log(`Play server started at http://localhost:3001`);
+  const playServer = play.listen(PLAYGROUND_PORT, () => {
+    console.log(`Play server started at http://localhost:${PLAYGROUND_PORT}`);
   });
 
   return {


### PR DESCRIPTION
### Description

Adds environment variables to specify the ports that the Fred server listens to:

- `FRED_PORT` for the main server.
- `FRED_PLAYGROUND_PORT` for the Playground runner.

### Motivation

1. Allows running fred on port 5042 in content.
2. Allows running two fred instances in parallel.
3. Allows running fred when another app already runs on port 3000.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of #667.
