### PR TITLE
fix(env): remove inline script if no runtime variables are set

### DIFF
--- a/components/env/README.md
+++ b/components/env/README.md
@@ -26,3 +26,5 @@ Rspack will bundle **all** environment variables prefixed with `FRED_` into the 
 By default, variables are baked into our bundle at build time. However, you can define variables as runtime environment variables, which can be changed when running a version of Fred built with `FRED_RUNTIME_ENV=true`.
 
 This is used in our npm package, so we can e.g. set `FRED_WRITER_MODE=true` in the `content` repo, without having to bake that into the npm package for all consumers.
+
+Runtime environment variables fall back to their build-time values if not set, and then to the default defined in code.

--- a/components/env/utils.js
+++ b/components/env/utils.js
@@ -50,7 +50,8 @@ function getEnv(name, options = {}) {
   const fullName = `FRED_${name}`;
   if (runtime && RUNTIME_ENV) {
     runtimeVariables.push(fullName);
-    return process.env[fullName] || getEnv(name);
+    // safely navigate if process is not defined
+    return globalThis.process?.env[fullName] || getEnv(name);
   }
   return globalThis.__MDNEnv?.[fullName];
 }

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -69,10 +69,8 @@ export class OuterLayout extends ServerComponent {
         ? "learn"
         : undefined;
 
-    const env = Object.fromEntries(
-      Object.entries(process.env).filter(([key]) =>
-        runtimeVariables.includes(key),
-      ),
+    const runtimeEnvEntries = Object.entries(process.env).filter(
+      ([key]) => key.startsWith("FRED_") && runtimeVariables.includes(key),
     );
 
     // if you want to put some script inline, put it in entry.inline.js
@@ -93,9 +91,9 @@ export class OuterLayout extends ServerComponent {
             content="width=device-width, initial-scale=1.0"
           />
           <title>${context.pageTitle || "MDN"}</title>
-          ${RUNTIME_ENV
+          ${RUNTIME_ENV && runtimeEnvEntries.length > 0
             ? unsafeHTML(`<script>process = {
-  env: ${JSON.stringify(env)}
+  env: ${JSON.stringify(Object.fromEntries(runtimeEnvEntries))}
 };</script>`)
             : nothing}
           ${unsafeHTML(`<script>${inlineScript}</script>`)}


### PR DESCRIPTION
https://github.com/mdn/content/pull/40961/files#r2314389165

Making FRED_RUNTIME_ENV itself a runtime variable got a bit too... weird for my liking, so this is an alternative fix which should avoid errors if FRED_RUNTIME_ENV was set at build, but no variables were set at runtime.