### PR TITLE
ci(npm-publish-simulation): test start script + expect port 5042

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -65,20 +65,20 @@ jobs:
         working-directory: mdn/content
         run: yarn fred-ssr
 
-      - name: (mdn/content) yarn start:fred
+      - name: (mdn/content) yarn start
         working-directory: mdn/content
-        run: yarn start:fred > /tmp/stdout.log 2> /tmp/stderr.log &
+        run: yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
 
       - name: Wait for Rari (localhost:8083)
         run: curl --retry-connrefused --retry 5 -I http://localhost:8083/en-US/
 
-      - name: Test Fred (localhost:3000)
+      - name: Test Fred (localhost:5042)
         run: |
-          curl --retry-connrefused --retry 5 -I http://localhost:3000
+          curl --retry-connrefused --retry 5 -I http://localhost:5042
 
           # Basically, test if it 200 OKs. If not, this'll exit non-zero.
-          curl --fail http://localhost:3000/en-US/ > /dev/null
-          curl --fail http://localhost:3000/en-US/docs/MDN/Kitchensink > /dev/null
+          curl --fail http://localhost:5042/en-US/ > /dev/null
+          curl --fail http://localhost:5042/en-US/docs/MDN/Kitchensink > /dev/null
 
       - name: Debug server's stdout and stderr if tests failed
         if: failure()


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `npm-publish-simulation` workflow to run the `start` script (not the `start:fred`) script, and to test port 5042 instead.

### Motivation

1. The `start:fred` in content was running on port 3000, but `start` was running on port 5042, and we're keeping this behavior.
2. The `start:fred` script is being deprecated in favor of `start`.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Blocked on:

- https://github.com/mdn/content/pull/40961

Part of https://github.com/mdn/fred/issues/667.

