### PR TITLE
fix(doc): use pageTitle as `<title>`

### DIFF
--- a/components/doc/server.js
+++ b/components/doc/server.js
@@ -6,7 +6,7 @@ export class Doc extends ServerComponent {
   /**
    * @param {import("@fred").Context<import("@rari").DocPage>} context
    */ render(context) {
-    context.pageTitle = context.doc.title;
+    context.pageTitle = context.doc.pageTitle;
     return PageLayout.render(context, ReferenceLayout.render(context));
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes the `<title>` to use `doc.pageTitle`, not `doc.title`.

### Motivation

Consistency with yari.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

