### PR TITLE
fix(scrim-inline): add missing style

### DIFF
--- a/components/scrim-inline/element.css
+++ b/components/scrim-inline/element.css
@@ -2,6 +2,13 @@
 
 :host {
   display: block;
+
+  width: 100%;
+  max-width: 36rem;
+  aspect-ratio: 1.5;
+
+  margin: 0.5rem auto;
+
   overflow: hidden;
 }
 

--- a/components/scrim-inline/global.css
+++ b/components/scrim-inline/global.css
@@ -7,13 +7,3 @@
     url("./assets/BarlowCondensed-SemiBold.woff2") format("woff2");
   font-display: block;
 }
-
-mdn-scrim-inline {
-  display: block;
-
-  width: 100%;
-  max-width: 36rem;
-  aspect-ratio: 1.5;
-
-  margin: 0.5rem auto;
-}

--- a/components/scrim-inline/global.css
+++ b/components/scrim-inline/global.css
@@ -7,3 +7,13 @@
     url("./assets/BarlowCondensed-SemiBold.woff2") format("woff2");
   font-display: block;
 }
+
+mdn-scrim-inline {
+  display: block;
+
+  width: 100%;
+  max-width: 36rem;
+  aspect-ratio: 1.5;
+
+  margin: 0.5rem auto;
+}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add missing styles for `<mdn-scrim-inline>` elements.

### Motivation

Ensures that the scrims are shown again.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/686 (together with https://github.com/mdn/content/pull/41024).

