### PR TITLE
fix(content-section): restrict fragment link style to dt

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -251,7 +251,7 @@
       margin: 1rem 0 2rem;
     }
 
-    a[href^="#"] {
+    dt a[href^="#"] {
       color: inherit;
 
       &:hover::before {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Restricts the fragment link style to `<dt>` elements (effectively excluding `<dd>`).

### Motivation

Makes fragment links in `<dd>` visible.

### Additional details

#### Before

<img width="793" height="579" alt="image" src="https://github.com/user-attachments/assets/1ed7b0ca-62b8-4334-8b22-d1a46841dce9" />


#### After

<img width="793" height="579" alt="image" src="https://github.com/user-attachments/assets/67e2ec4b-40be-453b-9dbf-d60346ca820a" />


### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/702.

