### PR TITLE
fix(content-section): move dt/dd in dt closer together

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -245,6 +245,11 @@
 
     dd {
       margin-left: 1rem;
+
+      /* Move description closer to term. */
+      p:first-child {
+        margin-top: 0.5rem;
+      }
     }
 
     ul {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Moves terms (`<dt>`) and corresponding description (`<dd>`) closer together in description lists (`<dl>`).

### Motivation

Make it easier to distinguish individual terms.

### Additional details

#### Before

<img width="793" height="564" alt="image" src="https://github.com/user-attachments/assets/b4e0a11d-983b-4693-a5ea-651fa30a811c" />

#### After

<img width="793" height="564" alt="image" src="https://github.com/user-attachments/assets/aba1e5c5-f759-414f-b679-d310c530731e" />


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

