### PR TITLE
fix(compat-table): hide preferences hint if browser has no pref_url

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -181,6 +181,7 @@ jobs:
               -o -path '*/en-us/mozilla/add-ons/webextensions/index.md' \
               -o -path '*/en-us/web/api/canvas_api/index.md' \
               -o -path '*/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md' \
+              -o -path '*/en-us/web/api/contactsmanager/index.md' \
               -o -path '*/en-us/web/api/fetch_api/index.md' \
               -o -path '*/en-us/web/api/geolocation_api/index.md' \
               -o -path '*/en-us/web/api/performance/index.md' \

--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -699,6 +699,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
               flag_name: name,
               has_value: Number(typeof value_to_set === "string"),
               flag_value: value_to_set,
+              has_pref_url: Number(typeof browser.pref_url === "string"),
               browser_name: browser.name,
               browser_pref_url: browser.pref_url,
             },

--- a/l10n/en-US.ftl
+++ b/l10n/en-US.ftl
@@ -108,8 +108,11 @@ compat-support-flags =
     [one] {" "}to <code data-l10n-name="value">{ $flag_value }</code>
     *[other] {""}
   }{"."}
-  { $flag_type ->
-    [preference] To change preferences in { $browser_name }, visit { $browser_pref_url }.
+  { NUMBER($has_pref_url) ->
+    [one] { $flag_type ->
+      [preference] To change preferences in { $browser_name }, visit { $browser_pref_url }.
+      *[other] {""}
+    }
     *[other] {""}
   }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Hides the "To change preferences … visit …" message for browsers that don't have a preference URL.

### Motivation

Fluent variable appeared in the UI.

### Additional details

See: https://fred-pr715.review.mdn.allizom.net/en-US/docs/Web/API/ContactsManager#browser_compatibility

#### Before

<img width="786" height="428" alt="image" src="https://github.com/user-attachments/assets/6bb4c3da-9c80-4591-b721-73e624f91698" />

#### After

<img width="786" height="413" alt="image" src="https://github.com/user-attachments/assets/992038a8-2697-4580-8cdb-900e07cc55ce" />

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/708.
