### PR TITLE
fix(build): correctly parse the import path on Windows

### DIFF
--- a/build/render.js
+++ b/build/render.js
@@ -1,11 +1,14 @@
 import { readFile } from "node:fs/promises";
-
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { FRED_BUILD_ROOT } from "./env.js";
 
 const { render: distRender } = /** @type {import("../entry.ssr.js")} */ (
-  await import(path.resolve(FRED_BUILD_ROOT, "static", "ssr", "index.js"))
+  await import(
+    pathToFileURL(path.resolve(FRED_BUILD_ROOT, "static", "ssr", "index.js"))
+      .href
+  )
 );
 
 /** @type {import("@rspack/core").StatsCompilation} */


### PR DESCRIPTION
### Description

Correctly parse the import path on Windows.

### Motivation

The `path.resolve()` function returns an absolute path (not a URL), which on Windows environment usually starts with the name of the local disk (e.g., `C:`, `D:`). And such a path is not supported by `import`, which will throw an error (an example output with Node.js v22.14.0, when run `yarn start` in mdn content folder):

```plain
Error: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:209:11)
    at defaultLoad (node:internal/modules/esm/load:107:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:701:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:514:43)
    at ModuleLoader.#createModuleJob (node:internal/modules/esm/loader:538:36)
    at ModuleLoader.#getJobFromResolveResult (node:internal/modules/esm/loader:306:34)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:274:41)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:577:25)
```

### Additional details

https://stackoverflow.com/a/70057245
