### PR TITLE
fix(compat-table-lazy): include global style 

### DIFF
--- a/components/compat-table-lazy/element.css
+++ b/components/compat-table-lazy/element.css
@@ -1,0 +1,1 @@
+@import url("../global/global.css");

--- a/components/compat-table-lazy/element.js
+++ b/components/compat-table-lazy/element.js
@@ -9,11 +9,15 @@ import {
 } from "../compat-table/constants.js";
 import { BCD_BASE_URL } from "../env/index.js";
 
+import styles from "./element.css?lit";
+
 /**
  * @typedef {{data: import("@bcd").Identifier, browsers: import("@bcd").Browsers}} Compat
  */
 
 export class MDNCompatTableLazy extends L10nMixin(LitElement) {
+  static styles = styles;
+
   static properties = {
     query: {},
     locale: {},

--- a/components/compat-table/index-global.css
+++ b/components/compat-table/index-global.css
@@ -1,6 +1,5 @@
 /* Compat (global) */
 
-@import url("../global/global.css");
 @import url("../external-link/global.css");
 @import url("../visually-hidden/global.css");
 

--- a/components/compat-table/index-global.css
+++ b/components/compat-table/index-global.css
@@ -1,5 +1,6 @@
 /* Compat (global) */
 
+@import url("../global/global.css");
 @import url("../external-link/global.css");
 @import url("../visually-hidden/global.css");
 


### PR DESCRIPTION
### Description

Import global styles into the `compat-table-lazy` component.

### Motivation

Links weren't properly styled.

### Additional details

Tested on: http://localhost:3000/en-US/docs/Web/CSS/caret-shape#browser_compatibility

#### Before

<img width="787" height="276" alt="image" src="https://github.com/user-attachments/assets/4cfb9584-0d1d-473e-a009-39f53ddd10b3" />

#### After

<img width="787" height="276" alt="image" src="https://github.com/user-attachments/assets/03e80be3-945e-4f99-b6fe-39e07b0f6d8c" />


### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/741.

