### PR TITLE
fix(glean): make click measurements backward compatible

### DIFF
--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -210,7 +210,7 @@ export class BaselineIndicator extends ServerComponent {
           <li>
             <a
               href=${`/${context.locale}/docs/Glossary/Baseline/Compatibility`}
-              data-glean="baseline_link_learn_more"
+              data-glean-id="baseline_link_learn_more"
               target="_blank"
               class="learn-more"
             >
@@ -218,14 +218,14 @@ export class BaselineIndicator extends ServerComponent {
             </a>
           </li>
           <li>
-            <a href=${bcdLink} data-glean="baseline_link_bcd_table">
+            <a href=${bcdLink} data-glean-id="baseline_link_bcd_table">
               ${context.l10n`See full compatibility`}
             </a>
           </li>
           <li>
             <a
               href=${feedbackLink}
-              data-glean="baseline_link_feedback"
+              data-glean-id="baseline_link_feedback"
               class="feedback-link"
               target="_blank"
               rel="noreferrer"

--- a/components/compat-table/constants.js
+++ b/components/compat-table/constants.js
@@ -1,9 +1,6 @@
 // [libs/constants]
 export const DEFAULT_LOCALE = "en-US";
 
-// [client/telemetry]
-export const BCD_TABLE = "bcd";
-
 export const ISSUE_METADATA_TEMPLATE = `
 <!-- Do not make changes below this line -->
 <details>

--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -4,11 +4,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { L10nMixin } from "../../l10n/mixin.js";
 
-import {
-  BCD_TABLE,
-  DEFAULT_LOCALE,
-  ISSUE_METADATA_TEMPLATE,
-} from "./constants.js";
+import { DEFAULT_LOCALE, ISSUE_METADATA_TEMPLATE } from "./constants.js";
 import styles from "./element.css?lit";
 import {
   getSupportBrowserReleaseDate,
@@ -393,7 +389,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
         titleNode = html`<a
           href=${href}
           class="bc-table-row-header"
-          data-glean-id=${`${BCD_TABLE}: link -> ${href}`}
+          data-glean-id=${`bcd: link -> ${href}`}
         >
           ${titleContent}
         </a>`;

--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -393,7 +393,7 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
         titleNode = html`<a
           href=${href}
           class="bc-table-row-header"
-          data-glean=${`${BCD_TABLE}: link -> ${href}`}
+          data-glean-id=${`${BCD_TABLE}: link -> ${href}`}
         >
           ${titleContent}
         </a>`;

--- a/components/content-feedback/element.js
+++ b/components/content-feedback/element.js
@@ -61,16 +61,13 @@ export class MDNContentFeedback extends L10nMixin(LitElement) {
         this._view = "feedback";
       }
       // Reusing Thumbs' key to be able to reuse queries.
-      gleanClick("thumbs", {
-        type: "article-footer",
-        label: vote === "yes" ? "1" : "0",
-      });
+      gleanClick(`thumbs: article-footer" -> ${vote === "yes" ? "1" : "0"}`);
     }
   }
 
   _handleFeedback() {
     this._view = "thanks";
-    gleanClick("article-footer", { type: "feedback", label: this._reason });
+    gleanClick(`article_footer: feedback -> ${this._reason}`);
   }
 
   _renderVote() {

--- a/components/interactive-example/element.js
+++ b/components/interactive-example/element.js
@@ -102,7 +102,7 @@ export class InteractiveExampleBase extends LitElement {
     ) {
       action = `click@${ev.target.id}`;
     }
-    gleanClick("interactive-example", { type: "action", label: action });
+    gleanClick(`interactive-example: ${action}`);
   }
 
   connectedCallback() {

--- a/components/placement-bottom/element.js
+++ b/components/placement-bottom/element.js
@@ -50,7 +50,7 @@ export class MDNPlacementBottom extends PlacementMixin(LitElement) {
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean-id="pong: pong-&gt;click top-banner"
+          data-glean-id=${`pong: pong->click top-banner`}
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored noreferrer"

--- a/components/placement-bottom/element.js
+++ b/components/placement-bottom/element.js
@@ -50,7 +50,7 @@ export class MDNPlacementBottom extends PlacementMixin(LitElement) {
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean="pong: pong-&gt;click top-banner"
+          data-glean-id="pong: pong-&gt;click top-banner"
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored noreferrer"

--- a/components/placement-hp-main/element.js
+++ b/components/placement-hp-main/element.js
@@ -50,7 +50,7 @@ export class MDNPlacementHpMain extends PlacementMixin(LitElement) {
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean-id="pong: pong-&gt;click top-banner"
+          data-glean-id=${`pong: pong->click top-banner`}
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored noreferrer"

--- a/components/placement-hp-main/element.js
+++ b/components/placement-hp-main/element.js
@@ -50,7 +50,7 @@ export class MDNPlacementHpMain extends PlacementMixin(LitElement) {
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean="pong: pong-&gt;click top-banner"
+          data-glean-id="pong: pong-&gt;click top-banner"
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored noreferrer"

--- a/components/placement-no/element.js
+++ b/components/placement-no/element.js
@@ -45,7 +45,7 @@ class MDNPlacementNo extends L10nMixin(LitElement) {
           return showNoAds
             ? html`<a
                 class="placement-no"
-                data-glean=${"pong: " +
+                data-glean-id=${"pong: " +
                 (user?.isSubscriber ? "pong->settings" : "pong->plus")}
                 href=${user?.isSubscriber
                   ? "/en-US/plus/settings?ref=nope"

--- a/components/placement-note/element.js
+++ b/components/placement-note/element.js
@@ -11,7 +11,7 @@ class MDNPlacementNote extends L10nMixin(LitElement) {
     return html`<a
       href="/en-US/advertising"
       class="placement-note"
-      data-glean="pong: pong-&gt;about"
+      data-glean-id="pong: pong-&gt;about"
       target="_blank"
       rel="noreferrer"
       >${this.l10n("placement-note")}</a

--- a/components/placement-note/element.js
+++ b/components/placement-note/element.js
@@ -11,7 +11,7 @@ class MDNPlacementNote extends L10nMixin(LitElement) {
     return html`<a
       href="/en-US/advertising"
       class="placement-note"
-      data-glean-id="pong: pong-&gt;about"
+      data-glean-id=${`pong: pong->about`}
       target="_blank"
       rel="noreferrer"
       >${this.l10n("placement-note")}</a

--- a/components/placement-sidebar/element.js
+++ b/components/placement-sidebar/element.js
@@ -75,7 +75,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
           >
             <a
               class="placement-link"
-              data-glean-id="pong: pong-&gt;click side"
+              data-glean-id=${`pong: pong->click side`}
               href=${this.clickLink(click, version)}
               target="_blank"
               rel="sponsored noreferrer"
@@ -101,7 +101,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
           >
             <a
               class="placement-link"
-              data-glean-id="pong: pong-&gt;click side"
+              data-glean-id=${`pong: pong->click side`}
               href=${this.clickLink(click, version)}
               target="_blank"
               rel="sponsored noreferrer"

--- a/components/placement-sidebar/element.js
+++ b/components/placement-sidebar/element.js
@@ -75,7 +75,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
           >
             <a
               class="placement-link"
-              data-glean="pong: pong-&gt;click side"
+              data-glean-id="pong: pong-&gt;click side"
               href=${this.clickLink(click, version)}
               target="_blank"
               rel="sponsored noreferrer"
@@ -101,7 +101,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
           >
             <a
               class="placement-link"
-              data-glean="pong: pong-&gt;click side"
+              data-glean-id="pong: pong-&gt;click side"
               href=${this.clickLink(click, version)}
               target="_blank"
               rel="sponsored noreferrer"

--- a/components/placement-top/element.js
+++ b/components/placement-top/element.js
@@ -37,7 +37,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             href="https://scrimba.com/learn/frontend?via=mdn"
             target="_blank"
             rel="noreferrer"
-            data-glean-id="pong: pong-&gt;click fallback-scrimba"
+            data-glean-id=${`pong: pong->click fallback-scrimba`}
           >
             Scrimba
           </a>
@@ -115,7 +115,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             <div class="placement-inner">
               <a
                 class="placement-link"
-                data-glean-id="pong: pong-&gt;click top-banner"
+                data-glean-id=${`pong: pong->click top-banner`}
                 href=${this.clickLink(click, version)}
                 target="_blank"
                 rel="sponsored noreferrer"
@@ -142,7 +142,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             <div class="placement-inner">
               <a
                 class="placement-link"
-                data-glean-id="pong: pong-&gt;click top-banner"
+                data-glean-id=${`pong: pong->click top-banner`}
                 href=${this.clickLink(click, version)}
                 target="_blank"
                 rel="sponsored noreferrer"

--- a/components/placement-top/element.js
+++ b/components/placement-top/element.js
@@ -37,7 +37,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             href="https://scrimba.com/learn/frontend?via=mdn"
             target="_blank"
             rel="noreferrer"
-            data-glean="pong: pong-&gt;click fallback-scrimba"
+            data-glean-id="pong: pong-&gt;click fallback-scrimba"
           >
             Scrimba
           </a>
@@ -115,7 +115,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             <div class="placement-inner">
               <a
                 class="placement-link"
-                data-glean="pong: pong-&gt;click top-banner"
+                data-glean-id="pong: pong-&gt;click top-banner"
                 href=${this.clickLink(click, version)}
                 target="_blank"
                 rel="sponsored noreferrer"
@@ -142,7 +142,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             <div class="placement-inner">
               <a
                 class="placement-link"
-                data-glean="pong: pong-&gt;click top-banner"
+                data-glean-id="pong: pong-&gt;click top-banner"
                 href=${this.clickLink(click, version)}
                 target="_blank"
                 rel="sponsored noreferrer"

--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -239,7 +239,7 @@ ${"```"}`,
     permalink.search = new URLSearchParams({ id }).toString();
     this._permalink = permalink.toString();
 
-    gleanClick("playground", { type: "load-shared" });
+    gleanClick("play_action: load-shared");
     const code = await response.json();
     return stateToSession(code);
   }

--- a/components/recent-contributions/server.js
+++ b/components/recent-contributions/server.js
@@ -18,7 +18,7 @@ export class RecentContributions extends ServerComponent {
               <a
                 class="external"
                 href=${contribution.repo.url}
-                data-glean=${`homepage: contribution_repo ${index + 1}`}
+                data-glean-id=${`homepage: contribution_repo ${index + 1}`}
                 >${contribution.repo.name}</a
               >
             </span>

--- a/components/scrim-inline/element.js
+++ b/components/scrim-inline/element.js
@@ -89,7 +89,7 @@ export class MDNScrimInline extends LitElement {
               target="_blank"
               rel="origin noreferrer"
               class="external"
-              data-glean="curriculum: scrim link id:${this._scrimId}"
+              data-glean-id="curriculum: scrim link id:${this._scrimId}"
             >
               <div class="scrim-link"></div>
               <span class="visually-hidden">Open on Scrimba</span>
@@ -123,7 +123,7 @@ export class MDNScrimInline extends LitElement {
                   <button
                     @click=${this.#open}
                     class="open"
-                    data-glean=${`curriculum: scrim engage id:${this._scrimId}`}
+                    data-glean-id=${`curriculum: scrim engage id:${this._scrimId}`}
                   >
                     ${playSvg}
                     <span class="visually-hidden">

--- a/utils/glean.js
+++ b/utils/glean.js
@@ -7,15 +7,10 @@ import GleanMetrics from "@mozilla/glean/metrics";
  * Use only if automatic click events are not an option.
  * See: https://mozilla.github.io/glean.js/automatic_instrumentation/click_events/
  *
- * @param {string} id
- * @param {object} options
- * @param {string=} options.type
- * @param {string=} options.label
+ * @param {string} source
  */
-export function gleanClick(id, { type, label }) {
+export function gleanClick(source) {
   GleanMetrics.recordElementClick({
-    id,
-    type,
-    label,
+    id: source,
   });
 }


### PR DESCRIPTION
### Description

1. Remove `gleanClick` options, accepting a single `id` (equivalent to `source` in yari).
2. Align measurement IDs with yari.
3. Replace `data-glean` attributes (no effect in fred) with `data-glean-id`.

### Motivation

Make the Fred click measurements work, and backward compatible with yari click measurements.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/647 and https://github.com/mdn/fred/issues/713.
