### PR TITLE
chore(deploy): enable Glean debug

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -235,6 +235,9 @@ jobs:
 
       - name: Render (fred)
         working-directory: mdn/fred
+        env:
+          FRED_GLEAN_ENABLED: true
+          FRED_GLEAN_DEBUG: true
         run: npm run ssr
 
       - name: Authenticate with GCP


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Enables Glean debug pings by default on review deployments.

### Motivation

Allows us to validate Glean measurements directly on the PR review deployment, without having to run the branch locally.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/fred/pull/739#pullrequestreview-3209811304.