### PR TITLE
chore(placement): remove `rel="noreferrer"`

### DIFF
--- a/components/placement-bottom/element.js
+++ b/components/placement-bottom/element.js
@@ -53,7 +53,7 @@ export class MDNPlacementBottom extends PlacementMixin(LitElement) {
           data-glean-id=${`pong: pong->click top-banner`}
           href=${this.clickLink(click, version)}
           target="_blank"
-          rel="sponsored noreferrer"
+          rel="sponsored"
         >
           <img
             src=${this.imgLink(image)}

--- a/components/placement-hp-main/element.js
+++ b/components/placement-hp-main/element.js
@@ -53,7 +53,7 @@ export class MDNPlacementHpMain extends PlacementMixin(LitElement) {
           data-glean-id=${`pong: pong->click top-banner`}
           href=${this.clickLink(click, version)}
           target="_blank"
-          rel="sponsored noreferrer"
+          rel="sponsored"
         >
           <img
             src=${this.imgLink(image)}

--- a/components/placement-sidebar/element.js
+++ b/components/placement-sidebar/element.js
@@ -78,7 +78,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
               data-glean-id=${`pong: pong->click side`}
               href=${this.clickLink(click, version)}
               target="_blank"
-              rel="sponsored noreferrer"
+              rel="sponsored"
               ><img
                 src=${this.imgLink(image)}
                 aria-hidden=${!alt}
@@ -104,7 +104,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
               data-glean-id=${`pong: pong->click side`}
               href=${this.clickLink(click, version)}
               target="_blank"
-              rel="sponsored noreferrer"
+              rel="sponsored"
               ><img
                 src=${this.imgLink(image)}
                 aria-hidden=${!alt}

--- a/components/placement-top/element.js
+++ b/components/placement-top/element.js
@@ -118,7 +118,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
                 data-glean-id=${`pong: pong->click top-banner`}
                 href=${this.clickLink(click, version)}
                 target="_blank"
-                rel="sponsored noreferrer"
+                rel="sponsored"
                 ><div class="placement-content">
                   <img
                     src=${this.imgLink(image)}
@@ -145,7 +145,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
                 data-glean-id=${`pong: pong->click top-banner`}
                 href=${this.clickLink(click, version)}
                 target="_blank"
-                rel="sponsored noreferrer"
+                rel="sponsored"
                 ><div class="placement-content">
                   <img
                     src=${this.imgLink(image)}


### PR DESCRIPTION
The `/pong/click/` endpoint will send `Referrer-Policy: no-referrer`, so the redirect location will still not see any referrer.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Remove `rel="noreferrer"` from the placement links.

### Motivation

Being able to see on what page placement clicks originated.

### Additional details

In https://github.com/mdn/yari/pull/13496, we prevent the `Referrer` from being passed to the target location.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

