### PR TITLE
fix(glean): trigger gleanClick for clicks in Shadow DOMs

### DIFF
--- a/hooks/glean-init.js
+++ b/hooks/glean-init.js
@@ -6,6 +6,7 @@ import {
   GLEAN_DEBUG,
   GLEAN_ENABLED,
 } from "../components/env/index.js";
+import { gleanClick } from "../utils/glean.js";
 
 const FIRST_PARTY_DATA_OPT_OUT_COOKIE_NAME = "moz-1st-party-data-opt-out";
 const GLEAN_APP_ID = "mdn-fred";
@@ -25,4 +26,17 @@ Glean.initialize(GLEAN_APP_ID, uploadEnabled, {
   enableAutoPageLoadEvents: true,
   enableAutoElementClickEvents: true,
   channel: GLEAN_CHANNEL,
+});
+
+document.addEventListener("click", (event) => {
+  const composedTarget = event.composedPath()?.[0];
+  if (composedTarget !== event.target && composedTarget instanceof Element) {
+    const taggedElement = composedTarget.closest("[data-glean-id]");
+    if (taggedElement instanceof HTMLElement) {
+      const gleanId = taggedElement.dataset.gleanId;
+      if (gleanId) {
+        gleanClick(gleanId);
+      }
+    }
+  }
 });


### PR DESCRIPTION
Relates to https://github.com/mdn/fred/issues/752

Fix locally before we fix upstream.

Tested locally:
- we get pings in shadow roots: e.g. https://debug-ping-preview.firebaseapp.com/pings/mdn-dev/4721d6b1-38ee-4cd8-9375-c42531547c0c
- we don't get double pings outside of shadow roots

We'll need to revert this once it's fixed and released upstream.