### PR TITLE
chore(deps): bump @mozilla/glean from 5.0.5 to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@lit/task": "^1.0.3",
         "@mdn/rari": "0.1.49",
         "@mdn/watify": "^1.1.3",
-        "@mozilla/glean": "^5.0.5",
+        "@mozilla/glean": "^5.0.6",
         "codemirror": "^6.0.1",
         "compression": "^1.8.1",
         "concurrently": "^9.2.1",
@@ -4950,6 +4950,25 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@mdn/yari/node_modules/@mozilla/glean": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.5.tgz",
+      "integrity": "sha512-OvimNMd4X/HzP9i5UOpYKpi+nqm8GugwIVV/XA5dgDfIkH1MniXBpUbBtn7xZdoHPg3AXpdmESkSN6f0THQPOQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "fflate": "^0.8.0",
+        "tslib": "^2.3.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "glean": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=12.20.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@mdn/yari/node_modules/@types/express": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
@@ -5452,6 +5471,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@mdn/yari/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@module-federation/error-codes": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
@@ -5512,9 +5545,9 @@
       }
     },
     "node_modules/@mozilla/glean": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.5.tgz",
-      "integrity": "sha512-OvimNMd4X/HzP9i5UOpYKpi+nqm8GugwIVV/XA5dgDfIkH1MniXBpUbBtn7xZdoHPg3AXpdmESkSN6f0THQPOQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.6.tgz",
+      "integrity": "sha512-Oz4M+pxHmTcy82iCCmcARjEwwDCsMZCwidRhdZU0pYueEFJgDc5S+u48Y68SxEsExFAthuhzE2H4BcvwsRhYJg==",
       "license": "MPL-2.0",
       "dependencies": {
         "fflate": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lit/task": "^1.0.3",
     "@mdn/rari": "0.1.49",
     "@mdn/watify": "^1.1.3",
-    "@mozilla/glean": "^5.0.5",
+    "@mozilla/glean": "^5.0.6",
     "codemirror": "^6.0.1",
     "compression": "^1.8.1",
     "concurrently": "^9.2.1",

--- a/utils/glean.js
+++ b/utils/glean.js
@@ -12,5 +12,8 @@ import GleanMetrics from "@mozilla/glean/metrics";
 export function gleanClick(source) {
   GleanMetrics.recordElementClick({
     id: source,
+    url: globalThis.location.href,
+    referrer: document.referrer,
+    title: document.title,
   });
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Bumps `@mozilla/glean` to 5.0.6.

### Motivation

Includes an important change in that page URL/referrer/title are captured for automated click events, just like for automated page load events.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

