### PR TITLE
fix(server-component): exclude empty components from used set

### DIFF
--- a/components/advertising/server.js
+++ b/components/advertising/server.js
@@ -36,7 +36,6 @@ const STATS = [
 export class Advertising extends ServerComponent {
   /**
    * @param {import("@fred").Context<import("@rari").SPAPage>} context
-   * @returns {import("@lit").TemplateResult}
    */
   render(context) {
     // Set the document title

--- a/components/blog-index/server.js
+++ b/components/blog-index/server.js
@@ -76,7 +76,6 @@ export class BlogIndex extends ServerComponent {
   /**
    *
    * @param {import("@fred").Context<import("@rari").BlogPostPage>} context
-   * @returns {import("@lit").TemplateResult}
    */
   render(context) {
     return PageLayout.render(

--- a/components/blog-post/server.js
+++ b/components/blog-post/server.js
@@ -61,7 +61,6 @@ export class BlogPost extends ServerComponent {
   /**
    *
    * @param {import("@fred").Context<import("@rari").BlogPostPage>} context
-   * @returns {import("@lit").TemplateResult}
    */
   render(context) {
     const { blogMeta, doc } = context;

--- a/components/curriculum-landing/server.js
+++ b/components/curriculum-landing/server.js
@@ -23,7 +23,6 @@ const SCRIM_TITLE = "MDN + Scrimba partnership announcement scrim";
 export class CurriculumLanding extends ServerComponent {
   /**
    * @param {import("@fred").Context<import("@rari").CurriculumPage>} context
-   * @returns {import("@lit").TemplateResult}
    */
   render(context) {
     const doc = context.doc;

--- a/components/observatory-landing/server.js
+++ b/components/observatory-landing/server.js
@@ -16,7 +16,6 @@ import { ServerComponent } from "../server/index.js";
 export class ObservatoryLanding extends ServerComponent {
   /**
    * @param {import("@fred").Context<import("@rari").SPAPage>} context
-   * @returns {import("@lit").TemplateResult}
    */
   render(context) {
     return PageLayout.render(

--- a/components/observatory-results/server.js
+++ b/components/observatory-results/server.js
@@ -8,7 +8,6 @@ import { ServerComponent } from "../server/index.js";
 export class ObservatoryResults extends ServerComponent {
   /**
    * @param {import("@fred").Context<import("@rari").SPAPage>} context
-   * @returns {import("@lit").TemplateResult}
    */
   render(context) {
     if (context.parents.length > 0) {

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -19,7 +19,7 @@ import {
 export class OuterLayout extends ServerComponent {
   /**
    * @param {import("@fred").Context} context
-   * @param {import("lit-html").TemplateResult} markup
+   * @param {import("lit-html").TemplateResult | import("lit").nothing} markup
    */
   render(context, markup) {
     const {

--- a/components/server/index.js
+++ b/components/server/index.js
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 
 import { stylesForComponents } from "../outer-layout/utils.js";
 
@@ -12,11 +12,12 @@ export class ServerComponent {
    * @template {typeof ServerComponent} T
    * @this {T}
    * @param {Parameters<InstanceType<T>["render"]>} args
-   * @returns {ReturnType<InstanceType<T>["render"]> | import("@lit").TemplateResult}
+   * @returns {ReturnType<InstanceType<T>["render"]> | import("@lit").TemplateResult | import("@lit").nothing }
    */
   static render(...args) {
     const { componentsUsed, componentsWithStylesInHead, compilationStats } =
       asyncLocalStorage.getStore() || {};
+    const componentUsedBefore = componentsUsed?.has(this.name);
     componentsUsed?.add(this.name);
     if (this.stylesInHead) {
       componentsWithStylesInHead?.add(this.name);
@@ -26,6 +27,14 @@ export class ServerComponent {
     }
 
     const res = new this().render(...args);
+
+    if (!res || res === nothing) {
+      if (!componentUsedBefore) {
+        componentsUsed?.delete(this.name);
+        componentsWithStylesInHead?.delete(this.name);
+      }
+      return nothing;
+    }
 
     if (!this.stylesInHead && compilationStats) {
       const styles = stylesForComponents([this.name], compilationStats.client);


### PR DESCRIPTION
Noticed this while working on inlining the baseline sticky code in its component.

We still add a component rendering nothing to the used set, which means we load its CSS (and potentially inline JS depending on how I implement that) - when there's no reason to. This changes our server component logic to remove the component from the sets tracking its use if it renders nothing.

The tangible effect of this is, e.g.
- On pages without a Baseline banner we don't load the banner css
- On en-US pages we don't load the translated content banner css

