### PR TITLE
fix(types): update to match fixed rari types

### DIFF
--- a/components/blog-post/server.js
+++ b/components/blog-post/server.js
@@ -53,7 +53,8 @@ function RenderToc(context) {
  */
 function RenderBlogContent(context, { doc }) {
   return html`
-    ${doc.body.map((section) => ContentSection.render(context, section))}
+    ${doc.body?.map((section) => ContentSection.render(context, section)) ??
+    nothing}
   `;
 }
 

--- a/components/breadcrumbs-bar/server.js
+++ b/components/breadcrumbs-bar/server.js
@@ -64,7 +64,7 @@ export class BreadcrumbsBar extends ServerComponent {
         : "doc" in context && "other_translations" in context.doc
           ? context.doc.other_translations
           : [];
-    const native = translations.find(
+    const native = translations?.find(
       (t) => t.locale === context.locale,
     )?.native;
 

--- a/components/breadcrumbs/server.js
+++ b/components/breadcrumbs/server.js
@@ -2,58 +2,18 @@ import { html, nothing } from "lit";
 
 import { ServerComponent } from "../server/index.js";
 
-// Some type wrangling to cover parents = context.doc.parents | no parents at all | doc.parents
-
-/**
- * @typedef {import("@rari").Parent} Parent
- */
-
-/**
- * @typedef {object} DocParentsContext
- * @property {string} renderer The renderer to use
- * @property {{parents: Parent[]}} doc The document to render
- */
-
-/**
- * @typedef {object} DirectParentsContext
- * @property {string} renderer The renderer to use
- * @property {Parent[]} parents The parents to render
- */
-
-/**
- * @typedef {DocParentsContext | DirectParentsContext} BreadcrumbContext
- */
-
-/**
- * Type predicate to check if context has doc.parents
- * @param {BreadcrumbContext} context
- * @returns {context is DocParentsContext}
- */
-function hasDocParents(context) {
-  return "doc" in context && "parents" in context.doc;
-}
-
-/**
- * Type predicate to check if context has direct parents
- * @param {BreadcrumbContext} context
- * @returns {context is DirectParentsContext}
- */
-function hasDirectParents(context) {
-  return "parents" in context;
-}
-
 export class Breadcrumbs extends ServerComponent {
   /**
-   * @param {BreadcrumbContext} context
+   * @param {import("@fred").Context} context
    */
   render(context) {
-    /** @type {Parent[]} */
     let parents;
-    if (hasDocParents(context)) {
+    if ("doc" in context && "parents" in context.doc) {
       parents = context.doc.parents;
-    } else if (hasDirectParents(context)) {
+    } else if ("parents" in context) {
       parents = context.parents;
-    } else {
+    }
+    if (!parents) {
       return nothing;
     }
 

--- a/components/curriculum-landing/server.js
+++ b/components/curriculum-landing/server.js
@@ -29,7 +29,7 @@ export class CurriculumLanding extends ServerComponent {
 
     /** @type {(import("@lit").TemplateResult | nothing)[]} */
     const content = [];
-    for (const [i, section] of doc.body.entries()) {
+    for (const [i, section] of doc.body?.entries() || []) {
       if (i === 0) {
         // Render the header section
         content.push(this.renderHeader(context, section));
@@ -188,7 +188,7 @@ export class CurriculumLanding extends ServerComponent {
    * Renders the ModulesListList structure, including the tab labels and the selected modules list.
    * On the server, this defaults to rendering the 'Core modules' list (index 1) content.
    * @param {import("@fred").Context<import("@rari").CurriculumPage>} context
-   * @param {import("@rari").CurriculumIndexEntry[]} modules - Array of module list groups (e.g., Started, Core, Extensions).
+   * @param {import("@rari").CurriculumIndexEntry[]} [modules] - Array of module list groups (e.g., Started, Core, Extensions).
    * @returns {import("@lit").TemplateResult | import("@lit").nothing} The Lit HTML template for the module list list, or undefined if no modules.
    */
   renderModulesListList(context, modules) {

--- a/components/curriculum/utils.js
+++ b/components/curriculum/utils.js
@@ -305,7 +305,11 @@ export function renderModulesList(context, modules) {
     <ol class="modules-list">
       ${modules.map(
         (module) => html`
-          <li class="module-list-item topic-${topic2css(module.topic)}">
+          <li
+            class="module-list-item ${module.topic
+              ? `topic-${topic2css(module.topic)}`
+              : ""}"
+          >
             <a href=${module.url}>
               <header>
                 ${module.topic

--- a/components/observatory-results/server.js
+++ b/components/observatory-results/server.js
@@ -10,7 +10,7 @@ export class ObservatoryResults extends ServerComponent {
    * @param {import("@fred").Context<import("@rari").SPAPage>} context
    */
   render(context) {
-    if (context.parents.length > 0) {
+    if (context.parents !== undefined && context.parents.length > 0) {
       const lastParent = context.parents.at(-1);
       if (lastParent) {
         lastParent.uri = "#";

--- a/components/reference-layout/server.js
+++ b/components/reference-layout/server.js
@@ -16,9 +16,8 @@ export class ReferenceLayout extends ServerComponent {
    */
   render(context) {
     const { doc } = context;
-    const [description, ...sections] = doc.body.map((section) =>
-      ContentSection.render(context, section),
-    );
+    const [description, ...sections] =
+      doc.body?.map((section) => ContentSection.render(context, section)) || [];
 
     return html`
       <div class="reference-layout">


### PR DESCRIPTION
Opening as draft because this depends on https://github.com/mdn/rari/pull/314 and should be merged once that's published to npm and updated in fred.

This can be tested by doing:
1. Checking out that rari branch
2. Running:
3. `cargo run export-schema`
4. `cd rari-npm`
5. `cp ../schema.json schema.json`
6. `npm run generate-types`
7. `cd ../../fred`
8. `npm install ../rari/rari-npm`
9. `npm run tsc`