### PR TITLE
fix(ssr): block some components from unnecessarily SSRing

### DIFF
--- a/components/placement/mixin.js
+++ b/components/placement/mixin.js
@@ -19,6 +19,7 @@ import "../placement-no/element.js";
  */
 export const PlacementMixin = (Base) =>
   class PlacementElement extends Base {
+    static ssr = false;
     _placementRef = createRef();
 
     _dataTask = new Task(this, {

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -10,6 +10,7 @@ import exitIcon from "../icon/cancel.svg?lit";
 import styles from "./element.css?lit";
 
 export class MDNSearchModal extends L10nMixin(LitElement) {
+  static ssr = false;
   static styles = styles;
 
   static properties = {

--- a/components/user-menu/element.js
+++ b/components/user-menu/element.js
@@ -15,6 +15,7 @@ import { getLinks } from "./links.js";
 import "../button/element.js";
 
 export class MDNUserMenu extends L10nMixin(LitElement) {
+  static ssr = false;
   static styles = styles;
 
   static properties = {


### PR DESCRIPTION
Don't SSR these web components:
- placement components because they render an empty div before the fetch happens
- user menu for the same reason, renders nothing until whoami fetch happens
- search modal because the wrapping element is a `<dialog>` which requires JS to show

Doing this saves a bunch of bytes on our rendered pages, from avoiding the inlined CSS:

```
ls -lh out/index.html out/index-main.html                                         
-rw-r--r-- 1 leo leo 187K Sep 17 18:51 out/index-main.html
-rw-r--r-- 1 leo leo 150K Sep 17 19:19 out/index.html
ls -lh out/index.html.br out/index-main.html.br
-rw-r--r-- 1 leo leo 22K Sep 17 18:51 out/index-main.html.br
-rw-r--r-- 1 leo leo 19K Sep 17 19:19 out/index.html.br
```

That's on the kitchensink page: 37K saving uncompressed and 3K saving after brotli is nothing to sniff at.
