### PR TITLE
feat(glean): measure search usage

### DIFF
--- a/components/homepage-search/element.js
+++ b/components/homepage-search/element.js
@@ -22,6 +22,7 @@ export class MDNHomepageSearch extends L10nMixin(LitElement) {
       class="mdn-homepage-search"
       title=${this.l10n`Search the site`}
       @click=${this._showModal}
+      data-glean-id="quick-search-open: homepage"
     >
       ${this.l10n`Search`}
     </button>`;

--- a/components/search-button/element.js
+++ b/components/search-button/element.js
@@ -23,6 +23,7 @@ export class MDNSearchButton extends L10nMixin(LitElement) {
       class="mdn-search-button"
       title=${this.l10n`Search the site`}
       @click=${this._showModal}
+      data-glean-id="quick-search-open: menu"
     >
       ${searchIcon}
     </button>`;

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -15,7 +15,6 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
   static styles = styles;
 
   static properties = {
-    _hasChanged: { state: true },
     _index: { state: true },
     _query: { state: true },
     _selected: { state: true },
@@ -29,6 +28,8 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
     this._query = "";
     this._selected = 0;
     this._shiftFocus = false;
+    /** Capture whether user has engaged with the search. */
+    this._hasEngaged = false;
   }
 
   async _loadIndex() {
@@ -66,8 +67,8 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
   _input({ inputType, target }) {
     if (target instanceof HTMLInputElement) {
       this._query = target.value;
-      if (!this._hasChanged && inputType.startsWith("insert")) {
-        this._hasChanged = true;
+      if (!this._hasEngaged && inputType.startsWith("insert")) {
+        this._hasEngaged = true;
         gleanClick(
           `quick-search-change: ${inputType === "insertFromPaste" ? "paste" : "type"}`,
         );

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -104,6 +104,9 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
               metaKey,
             }),
           );
+          // Workaround: For some reason, the dispatched click
+          // does not cause Glean.js to capture it via `data-glean-id`.
+          gleanClick(`quick-search: keyboard -> ${this._query}`);
         }
         break;
       }
@@ -262,7 +265,7 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
                   <li ?data-selected=${this._selected === i} data-result=${i}>
                     <a
                       href=${url}
-                      data-glean-id=${`quick-search: modal -> ${this._query}`}
+                      data-glean-id=${`quick-search: click -> ${this._query}`}
                       ><span class="slug"
                         >${mdnUrl2Breadcrumb(url, this.locale)}</span
                       >

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -107,7 +107,9 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
           );
           // Workaround: For some reason, the dispatched click
           // does not cause Glean.js to capture it via `data-glean-id`.
-          gleanClick(`quick-search: keyboard -> ${this._query}`);
+          if (item.dataset.gleanId) {
+            gleanClick(item.dataset.gleanId);
+          }
         }
         break;
       }
@@ -229,6 +231,9 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
 
   render() {
     const siteSearchIndex = this._queryIndex.value?.length || 0;
+    const searchUrl = this._query
+      ? `/${this.locale}/search?${new URLSearchParams({ q: this._query })}`
+      : null;
     return html`
       <dialog @keydown=${this._keydown} @focusin=${this._focus} closedby="any">
         <form
@@ -266,7 +271,7 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
                   <li ?data-selected=${this._selected === i} data-result=${i}>
                     <a
                       href=${url}
-                      data-glean-id=${`quick-search: click -> ${this._query}`}
+                      data-glean-id=${`quick-search: results[${1 + i}] -> ${this._query} -> ${url}`}
                       ><span class="slug"
                         >${mdnUrl2Breadcrumb(url, this.locale)}</span
                       >
@@ -278,13 +283,14 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
                 `,
               ),
           })}
-          ${this._query
+          ${searchUrl
             ? html`<li
                 ?data-selected=${this._selected === siteSearchIndex}
                 data-result=${siteSearchIndex}
               >
                 <a
-                  href=${`/${this.locale}/search?${new URLSearchParams({ q: this._query })}`}
+                  href=${searchUrl}
+                  data-glean-id=${`quick-search: site-search -> ${this._query}`}
                   ><span class="title"
                     >${this.l10n.raw({
                       id: "search-modal-site-search",

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -97,6 +97,7 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
           item.dispatchEvent(
             new MouseEvent("click", {
               bubbles: true,
+              composed: true,
               // we attempt to pass modifier keys through
               // but browser support is incredibly varied:
               ctrlKey,
@@ -105,11 +106,6 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
               metaKey,
             }),
           );
-          // Workaround: For some reason, the dispatched click
-          // does not cause Glean.js to capture it via `data-glean-id`.
-          if (item.dataset.gleanId) {
-            gleanClick(item.dataset.gleanId);
-          }
         }
         break;
       }

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -187,6 +187,10 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
       this.showModal();
       if (selection) {
         this._query = selection;
+        if (!this._hasEngaged) {
+          this._hasEngaged = true;
+          gleanClick("quick-search-change: selection");
+        }
       }
     }
   }

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -343,7 +343,7 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
                         <h2 class="site-search-results__title">
                           <a
                             href=${result.mdn_url}
-                            data-glean-id=${`site-search: click -> ${1 + (results.metadata.page - 1) * results.metadata.size + index}`}
+                            data-glean-id=${`site-search: results[${1 + index + (results.metadata.page - 1) * results.metadata.size}] -> ${this._query} -> ${result.mdn_url}`}
                           >
                             ${result.highlight.title &&
                             result.highlight.title.length > 0

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -7,6 +7,7 @@ import { L10nMixin } from "../../l10n/mixin.js";
 
 import "../button/element.js";
 
+import { gleanClick } from "../../utils/glean.js";
 import { mdnUrl2Breadcrumb } from "../../utils/mdn-url2breadcrumb.js";
 import searchIcon from "../icon/search.svg?lit";
 
@@ -80,9 +81,15 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
         throw new Error(`${res.status}: ${res.statusText}`);
       }
 
-      return /** @type {Promise<import("./types.js").SearchResponse>} */ (
-        res.json()
+      const result = /** @type {import("./types.js").SearchResponse} */ (
+        await res.json()
       );
+
+      if (result.documents.length === 0 && result.metadata.total.value === 0) {
+        gleanClick("site-search: no-results");
+      }
+
+      return result;
     },
   });
 
@@ -327,14 +334,17 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
                 })}</p>
               <ul class="site-search-results">
                 ${results.documents.map(
-                  (result) =>
+                  (result, index) =>
                     html`<li class="site-search-results__item">
                       <article>
                         <p class="site-search-results__path">
                           ${mdnUrl2Breadcrumb(result.mdn_url, this.locale)}
                         </p>
                         <h2 class="site-search-results__title">
-                          <a href=${result.mdn_url}>
+                          <a
+                            href=${result.mdn_url}
+                            data-glean-id=${`site-search: click -> ${1 + (results.metadata.page - 1) * results.metadata.size + index}`}
+                          >
                             ${result.highlight.title &&
                             result.highlight.title.length > 0
                               ? unsafeHTML(result.highlight.title[0])


### PR DESCRIPTION
### Description

Adds measurements for "quick" search (modal), and "site" search (full-text search).

### Motivation

Ports measurements from yari, refines them, and adds some useful ones (e.g., zero site-search results).

### Additional details

The following measurements are added:

| ID | Event |
|--------|--------|
| `quick-search-open: {homepage,menu,keyboard -> {slash,ctrl-k}}` | User opens search modal from homepage, menu, or via keyboard (Slash or CTRL+K) |
| `quick-search-change: {type,paste,selection}` | User engages with search modal by typing, pasting, or text selection (on open) |
| `quick-search: results[<index>] -> <query> -> <url>` | User navigates to a result item |
| `quick-search: site-search -> <query>` | User navigates to site search |
| `site-search: no-results` | Site search returns empty search results |
| `site-search: results[<index>] -> <query> -> <url>` | User clicks a given result item in the site search | 

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/750.

