### PR TITLE
fix(glean): use correct ids for placements + fallback

### DIFF
--- a/components/placement-bottom/element.js
+++ b/components/placement-bottom/element.js
@@ -50,7 +50,7 @@ export class MDNPlacementBottom extends PlacementMixin(LitElement) {
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean-id=${`pong: pong->click top-banner`}
+          data-glean-id=${`pong: pong->click hp-footer`}
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored"

--- a/components/placement-hp-main/element.js
+++ b/components/placement-hp-main/element.js
@@ -50,7 +50,7 @@ export class MDNPlacementHpMain extends PlacementMixin(LitElement) {
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean-id=${`pong: pong->click top-banner`}
+          data-glean-id=${`pong: pong->click hp-main`}
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored"

--- a/components/placement-top/element.js
+++ b/components/placement-top/element.js
@@ -37,7 +37,7 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
             href="https://scrimba.com/learn/frontend?via=mdn"
             target="_blank"
             rel="noreferrer"
-            data-glean-id=${`pong: pong->click fallback-scrimba`}
+            data-glean-id="banner_scrimba_click"
           >
             Scrimba
           </a>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes the `data-glean-id` of the `hp-main` and `bottom` banner, which were incorrectly attributed to the `top-banner`.

Also changes the `data-glean-id` of the Scrimba fallback banner to the same as in yari (`banner_scrimba_click`).

### Motivation

Ensures consistent reporting.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/647.
