### PR TITLE
feat(glean): add missing placement measurements

### DIFF
--- a/components/placement-bottom/element.js
+++ b/components/placement-bottom/element.js
@@ -41,16 +41,18 @@ export class MDNPlacementBottom extends PlacementMixin(LitElement) {
         ["--bottom-color", textColor],
       ].filter(([_, v]) => Boolean(v)),
     );
+    const type = placementContext?.hpFooter ? "hp-footer" : "bottom-banner";
 
     return html`<div
       ${ref(this._placementRef)}
       class="bottom-placement"
       style=${styleMap(styles)}
+      data-type=${type}
     >
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean-id=${`pong: pong->click hp-footer`}
+          data-glean-id=${`pong: pong->click ${type}`}
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored"

--- a/components/placement-hp-main/element.js
+++ b/components/placement-hp-main/element.js
@@ -41,16 +41,18 @@ export class MDNPlacementHpMain extends PlacementMixin(LitElement) {
         ["--hp-main-color", textColor],
       ].filter(([_, v]) => Boolean(v)),
     );
+    const type = "hp-main";
 
     return html`<div
       ${ref(this._placementRef)}
       class="hp-main-placement"
       style=${styleMap(styles)}
+      data-type=${type}
     >
       <section class="placement-container">
         <a
           class="placement-link"
-          data-glean-id=${`pong: pong->click hp-main`}
+          data-glean-id=${`pong: pong->click ${type}`}
           href=${this.clickLink(click, version)}
           target="_blank"
           rel="sponsored"

--- a/components/placement-sidebar/element.js
+++ b/components/placement-sidebar/element.js
@@ -65,6 +65,7 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
         ["--side-color-dark", textColorDark || textColor],
       ].filter(([_, v]) => Boolean(v)),
     );
+    const type = "side";
 
     return imageFormat === "skyscraper"
       ? html`<section class="sidebar-placement-skyscraper">
@@ -72,10 +73,11 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
             ${ref(this._placementRef)}
             class="placement-container"
             style=${styleMap(styles)}
+            data-type=${type}
           >
             <a
               class="placement-link"
-              data-glean-id=${`pong: pong->click side`}
+              data-glean-id=${`pong: pong->click ${type}`}
               href=${this.clickLink(click, version)}
               target="_blank"
               rel="sponsored"
@@ -98,10 +100,11 @@ export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
             ${ref(this._placementRef)}
             class="placement-container"
             style=${styleMap(styles)}
+            data-type=${type}
           >
             <a
               class="placement-link"
-              data-glean-id=${`pong: pong->click side`}
+              data-glean-id=${`pong: pong->click ${type}`}
               href=${this.clickLink(click, version)}
               target="_blank"
               rel="sponsored"

--- a/components/placement-top/element.js
+++ b/components/placement-top/element.js
@@ -104,18 +104,20 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
         ["--place-top-cta-color-dark", ctaTextColorDark || ctaBackgroundColor],
       ].filter(([_, v]) => Boolean(v)),
     );
+    const type = "top-banner";
 
     return imageFormat === "leaderboard"
       ? html`<div
           ${ref(this._placementRef)}
           class="top-placement-leaderboard"
           style=${styleMap(styles)}
+          data-type=${type}
         >
           <section class="placement-container">
             <div class="placement-inner">
               <a
                 class="placement-link"
-                data-glean-id=${`pong: pong->click top-banner`}
+                data-glean-id=${`pong: pong->click ${type}`}
                 href=${this.clickLink(click, version)}
                 target="_blank"
                 rel="sponsored"
@@ -137,12 +139,13 @@ export class MDNPlacementTop extends PlacementMixin(LitElement) {
           ${ref(this._placementRef)}
           class="top-placement"
           style=${styleMap(styles)}
+          data-type=${type}
         >
           <section class="placement-container">
             <div class="placement-inner">
               <a
                 class="placement-link"
-                data-glean-id=${`pong: pong->click top-banner`}
+                data-glean-id=${`pong: pong->click ${type}`}
                 href=${this.clickLink(click, version)}
                 target="_blank"
                 rel="sponsored"

--- a/components/placement/context.js
+++ b/components/placement/context.js
@@ -2,6 +2,7 @@
  * @import * as Placements from "../placement/types.js";
  */
 
+import { gleanClick } from "../../utils/glean.js";
 import { globalUser } from "../user/context.js";
 
 /**
@@ -89,12 +90,24 @@ async function fetchPlacementData() {
       ),
     }),
   });
+
+  gleanClick(`pong: pong->fetched ${response.status}`);
+
   if (!response.ok) {
     throw new Error(response.statusText);
   }
 
   try {
+    /** @type {Placements.PlacementContextData} */
     const placementResponse = await response.json();
+
+    const typs = Object.entries(PLACEMENT_MAP)
+      .filter(([key]) => key in placementResponse)
+      .map(([, { typ }]) => typ);
+    if (typs.length > 0) {
+      gleanClick(`pong: pong->served ${typs.join(",")}`);
+    }
+
     return placementResponse;
   } catch {
     throw new Error(response.statusText);

--- a/components/placement/mixin.js
+++ b/components/placement/mixin.js
@@ -2,6 +2,7 @@ import { Task } from "@lit/task";
 import { nothing } from "lit";
 import { createRef } from "lit/directives/ref.js";
 
+import { gleanClick } from "../../utils/glean.js";
 import { ViewedController } from "../viewed-controller/viewed-controller.js";
 
 import { globalPlacementContext } from "./context.js";
@@ -20,6 +21,7 @@ import "../placement-no/element.js";
 export const PlacementMixin = (Base) =>
   class PlacementElement extends Base {
     static ssr = false;
+    /** @type {import('lit/directives/ref.js').Ref<HTMLElement>} */
     _placementRef = createRef();
 
     _dataTask = new Task(this, {
@@ -48,6 +50,8 @@ export const PlacementMixin = (Base) =>
           navigator.sendBeacon?.(
             this.viewedLink(this._viewedUrl, this._version),
           );
+          const type = this._placementRef.value?.dataset.type ?? "unknown";
+          gleanClick(`pong: pong->viewed ${type}`);
         }
       });
     }


### PR DESCRIPTION
### Description

Adds missing placement measurements.

### Motivation

Ensures consistent reporting.

### Additional details

| Measurement ID | Event |
|--------|--------|
| `pong: pong->fetched 200`<br>`pong: pong->fetched 500` | HTTP Status of the `/pong/get` request |
| `pong: pong->served bottom-banner`<br>`pong: pong->served side,top-banner,bottom-banner`<br>… | List of fetched placement types |
| `pong: pong->viewed side`<br>`pong: pong->viewed top-banner`<br>… | Placement seen by user | 

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/797.

