### PR TITLE
fix(a11y-menu): add `id="content"` to all pages

### DIFF
--- a/components/blog-index/server.js
+++ b/components/blog-index/server.js
@@ -82,7 +82,7 @@ export class BlogIndex extends ServerComponent {
     return PageLayout.render(
       context,
       html`
-        <div class="blog-index">
+        <div id="content" class="blog-index">
           <header class="blog-index__header">
             <h1>${context.l10n`Blog it better`}</h1>
           </header>

--- a/components/blog-post/server.js
+++ b/components/blog-post/server.js
@@ -70,14 +70,14 @@ export class BlogPost extends ServerComponent {
     if (!blogMeta || !doc) {
       return PageLayout.render(
         context,
-        html`<p>
+        html`<p id="content">
           ${context.l10n("blog-post-not-found")`Blog post not found`}
         </p>`,
       );
     }
 
     const postContent = html`
-      <article class="blog-post">
+      <article id="content" class="blog-post">
         <aside class="blog-post__toc">
           ${RenderToc(context)}
           <mdn-placement-sidebar></mdn-placement-sidebar>

--- a/components/contributor-spotlight/server.js
+++ b/components/contributor-spotlight/server.js
@@ -60,7 +60,7 @@ export class ContributorSpotlight extends ServerComponent {
       context,
       html`
         <div class="contributor-spotlight-container">
-          <main class="contributor-spotlight">
+          <main id="content" class="contributor-spotlight">
             ${header}
             <section class="profile-header">
               <img

--- a/components/homepage/server.js
+++ b/components/homepage/server.js
@@ -14,7 +14,7 @@ export class Homepage extends ServerComponent {
     return PageLayout.render(
       context,
       html`
-        <div class="homepage homepage--dark">
+        <div id="content" class="homepage homepage--dark">
           ${HomepageHeader.render(context)}
         </div>
         <div class="homepage">

--- a/components/playground/server.js
+++ b/components/playground/server.js
@@ -9,7 +9,7 @@ export class Playground extends ServerComponent {
     return PageLayout.render(
       context,
       html`
-        <main class="playground">
+        <main id="content" class="playground">
           <mdn-playground></mdn-playground>
           <div class="sidebar">
             <mdn-placement-sidebar></mdn-placement-sidebar>

--- a/components/site-search/server.js
+++ b/components/site-search/server.js
@@ -10,7 +10,7 @@ export class SiteSearch extends ServerComponent {
   render(context) {
     return PageLayout.render(
       context,
-      html`<div class="site-search">
+      html`<div id="content" class="site-search">
         <h1 class="visually-hidden">${context.l10n`Search`}</h1>
         <mdn-site-search></mdn-site-search>
       </div>`,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds `id="content"` to all pages.

### Motivation

Ensures the "Skip to content" link works on all pages (to skip the menu).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/802.