### PR TITLE
fix(footer): correct cookie link in the footer

### DIFF
--- a/components/footer/server.js
+++ b/components/footer/server.js
@@ -130,7 +130,7 @@ const mozillaLinks = (context) => [
   },
   {
     text: context.l10n`Cookies`,
-    href: "https://www.mozilla.org/privacy/websites/cookie-settings/",
+    href: "https://www.mozilla.org/en-US/privacy/websites/data-preferences/",
     external: true,
   },
   {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Correct the cookie link in the footer

### Motivation

The link was pointing to the wrong page where the actual setting could not be changed.

