### PR TITLE
fix(homepage-hero): use `data-glean-id`, not `data-glean`

### DIFF
--- a/components/homepage-hero/server.js
+++ b/components/homepage-hero/server.js
@@ -20,17 +20,17 @@ export class HomepageHero extends ServerComponent {
             css: {
               tag: "a",
               href: `/${context.locale}/docs/Web/CSS`,
-              "data-glean": "homepage_hero: css",
+              "data-glean-id": "homepage_hero: css",
             },
             html: {
               tag: "a",
               href: `/${context.locale}/docs/Web/HTML`,
-              "data-glean": "homepage_hero: html",
+              "data-glean-id": "homepage_hero: html",
             },
             js: {
               tag: "a",
               href: `/${context.locale}/docs/Web/JavaScript`,
-              "data-glean": "homepage_hero: js",
+              "data-glean-id": "homepage_hero: js",
             },
           },
         })}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes the `homepage-hero` component to use the `data-glean-id` attribute, not `data-glean`.

### Motivation

Fixes the measurement.

### Additional details

Missed in https://github.com/mdn/fred/pull/743

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/647.