### PR TITLE
fix(glean): measure Curriculum banner + shared Playground loads

### DIFF
--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -1,7 +1,6 @@
 import { html } from "@lit-labs/ssr";
 import { nothing } from "lit";
 
-import { gleanClick } from "../../utils/glean.js";
 import { ServerComponent } from "../server/index.js";
 
 import inlineScript from "./inline.js?source&csp=true";
@@ -47,12 +46,6 @@ const LOCALIZED_BCD_IDS = {
 
 const SURVEY_URL =
   "https://survey.alchemer.com/s3/7634825/MDN-baseline-feedback";
-
-const handleToggle = (/** @type {Event} */ { currentTarget: target }) => {
-  if (target instanceof HTMLDetailsElement && target.open) {
-    gleanClick("baseline_toggle_open");
-  }
-};
 
 export class BaselineIndicator extends ServerComponent {
   static inlineScript = inlineScript;
@@ -137,7 +130,7 @@ export class BaselineIndicator extends ServerComponent {
 
     return html`<details
       class="baseline-indicator ${level}"
-      @toggle=${handleToggle}
+      data-glean-toggle-open="baseline_toggle_open"
     >
       <summary>
         <span

--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -1,6 +1,7 @@
 import { html } from "@lit-labs/ssr";
 import { nothing } from "lit";
 
+import { gleanClick } from "../../utils/glean.js";
 import { ServerComponent } from "../server/index.js";
 
 import inlineScript from "./inline.js?source&csp=true";
@@ -46,6 +47,12 @@ const LOCALIZED_BCD_IDS = {
 
 const SURVEY_URL =
   "https://survey.alchemer.com/s3/7634825/MDN-baseline-feedback";
+
+const handleToggle = (/** @type {Event} */ { currentTarget: target }) => {
+  if (target instanceof HTMLDetailsElement && target.open) {
+    gleanClick("baseline_toggle_open");
+  }
+};
 
 export class BaselineIndicator extends ServerComponent {
   static inlineScript = inlineScript;
@@ -130,7 +137,7 @@ export class BaselineIndicator extends ServerComponent {
 
     return html`<details
       class="baseline-indicator ${level}"
-      data-glean-toggle-open="baseline_toggle_open"
+      @toggle=${handleToggle}
     >
       <summary>
         <span

--- a/components/curriculum-landing/server.js
+++ b/components/curriculum-landing/server.js
@@ -267,6 +267,7 @@ export class CurriculumLanding extends ServerComponent {
                 target="_blank"
                 rel="origin noreferrer"
                 class="external"
+                data-glean-id="curriculum: partner banner click"
               >
                 Scrimba's Frontend Developer Career Path
               </a>
@@ -279,6 +280,7 @@ export class CurriculumLanding extends ServerComponent {
               target="_blank"
               rel="origin noreferrer"
               class="external"
+              data-glean-id="curriculum: partner banner click"
             >
               Find out more
             </a>

--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -239,7 +239,7 @@ ${"```"}`,
     permalink.search = new URLSearchParams({ id }).toString();
     this._permalink = permalink.toString();
 
-    gleanClick("play_action: load-shared");
+    gleanClick("playground: load-shared");
     const code = await response.json();
     return stateToSession(code);
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes some Glean measurements:

1. ~~Implements the Baseline banner toggle measurement properly (`data-glean-toggle` had no effect).~~
2. Port the Curriculum partner banner click measurement.
3. Rename the ID of the Playground `load-shared` measurement.

### Motivation

Consistent reporting.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/647.