### PR TITLE
feat (server) Add redirects middleware in dev env

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,5 @@
+export const VALID_LOCALES = new Map(
+  ["de", "en-US", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN", "zh-TW"].map(
+    (x) => [x.toLowerCase(), x],
+  ),
+);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "node --env-file=.env scripts/server.js",
     "dev": "node --env-file=.env ./server.js",
     "build": "rspack build",
+    "build:redirects": "node --env-file=.env scripts/build-redirects.js",
     "preview": "NODE_ENV=production node ./server.js",
     "ssr": "node build/ssr.js",
     "lit-analyzer": "npx @jackolope/lit-analyzer --rules.no-incompatible-type-binding off",

--- a/scripts/build-redirects.js
+++ b/scripts/build-redirects.js
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { VALID_LOCALES } from "../constants.js";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const root = path.join(dirname, "..", "..");
+
+function buildRedirects() {
+  const redirectMap = new Map();
+
+  for (const envvar of ["CONTENT_ROOT", "CONTENT_TRANSLATED_ROOT"]) {
+    if (!process.env[envvar]) {
+      console.error(`Missing ENV variable: ${envvar}`);
+      continue;
+    }
+
+    const base = process.env[envvar];
+    console.log(`${envvar} = ${base}`);
+
+    for (const locale of VALID_LOCALES.keys()) {
+      const path = [
+        // Absolute path.
+        `${base}/${locale}/_redirects.txt`,
+        `${base}/files/${locale}/_redirects.txt`,
+        // Relative path.
+        `${root}/${base}/${locale}/_redirects.txt`,
+        `${root}/${base}/files/${locale}/_redirects.txt`,
+      ].find((path) => fs.existsSync(path));
+
+      if (path) {
+        const content = fs.readFileSync(path, "utf8");
+        const lines = content.split("\n");
+        const redirectLines = lines.filter(
+          (line) => line.startsWith("/") && line.includes("\t"),
+        );
+        for (const redirectLine of redirectLines) {
+          const [source, target] = redirectLine.split("\t", 2);
+          if (source && target) {
+            redirectMap.set(source.toLowerCase(), target);
+          }
+        }
+        console.log(`- ${path}: ${redirectLines.length} redirects`);
+      }
+    }
+  }
+
+  const output = "redirects.json";
+
+  fs.writeFileSync(output, JSON.stringify(Object.fromEntries(redirectMap)));
+
+  const count = redirectMap.size;
+  const kb = Math.round(fs.statSync(output).size / 1024);
+  console.log(`Wrote ${count} redirects in ${kb} KB.`);
+}
+
+buildRedirects();

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ import openEditor from "open-editor";
 
 import { FRED_BUILD_ROOT } from "./build/env.js";
 import { PLAYGROUND_PORT, PORT, WRITER_MODE } from "./components/env/index.js";
+import redirects from "./redirects.json" with { type: "json" };
 import { handleRunner } from "./vendor/yari/libs/play/index.js";
 
 import "source-map-support/register.js";
@@ -131,6 +132,21 @@ export async function startServer() {
 
     // @ts-expect-error
     app.use(webpackHotMiddleware(rspackCompiler));
+
+    // redirects middleware
+    app.use((req, res, next) => {
+      if (!redirects || Object.keys(redirects).length === 0) next();
+
+      const redirectsMap = /** @type {Record<string, string>} */ (redirects);
+      const reqPath = req.path.toLowerCase();
+      const targetPath = redirectsMap[reqPath];
+
+      if (targetPath) {
+        return res.redirect(301, targetPath);
+      }
+
+      next();
+    });
   } else {
     const { default: compression } = await import("compression");
     app.use(compression());


### PR DESCRIPTION
### Description

#### Changes:
- Add middleware to handle redirects (`fromURL -> toURL`) - mapping found in `_redirects.txt` files
  - Add `build:redirects` script to output `redirects.json` from `_redirects.txt` found in `content` and `translated-content` repos

### Related issues and pull requests

Linked Issue: #811 

