### PR TITLE
fix(menu): update Color format converter link (Color picker)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -196,7 +196,7 @@ jobs:
               -o -path '*/en-us/web/css/css_backgrounds_and_borders/border-radius_generator/index.md' \
               -o -path '*/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md' \
               -o -path '*/en-us/web/css/css_colors/index.md' \
-              -o -path '*/en-us/web/css/css_colors/color_picker_tool/index.md' \
+              -o -path '*/en-us/web/css/css_colors/color_format_converter/index.md' \
               -o -path '*/en-us/web/css/css_selectors/index.md' \
               -o -path '*/en-us/web/css/css_syntax/at-rule/index.md' \
               -o -path '*/en-us/web/css/functions/index.md' \

--- a/components/menu/constants.js
+++ b/components/menu/constants.js
@@ -36,7 +36,7 @@ export const MISSING_DOCS = {
     "Web/API/Web_Animations_API/Using_the_Web_Animations_API",
     "Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model",
     "Web/CSS/CSS_colors/Color_mixer",
-    "Web/CSS/CSS_colors/Color_picker",
+    "Web/CSS/CSS_colors/Color_format_converter",
     "Web/CSS/CSS_shapes/Shape_generator",
     "Web/CSS/Guides",
     "Web/CSS/Properties",

--- a/components/menu/constants.js
+++ b/components/menu/constants.js
@@ -36,7 +36,6 @@ export const MISSING_DOCS = {
     "Web/API/Web_Animations_API/Using_the_Web_Animations_API",
     "Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model",
     "Web/CSS/CSS_colors/Color_mixer",
-    "Web/CSS/CSS_colors/Color_format_converter",
     "Web/CSS/CSS_shapes/Shape_generator",
     "Web/CSS/Guides",
     "Web/CSS/Properties",

--- a/components/menu/server.js
+++ b/components/menu/server.js
@@ -618,10 +618,13 @@ export class Menu extends ServerComponent {
                     )}
                   </li>
                   <li>
-                    ${link("Web/CSS/CSS_colors/Color_mixer", "Color mixer")}
+                    ${link(
+                      "Web/CSS/CSS_colors/Color_format_converter",
+                      "Color format converter",
+                    )}
                   </li>
                   <li>
-                    ${link("Web/CSS/CSS_colors/Color_picker", "Color picker")}
+                    ${link("Web/CSS/CSS_colors/Color_mixer", "Color mixer")}
                   </li>
                   <li>
                     ${link(


### PR DESCRIPTION
- related content PR https://github.com/mdn/content/pull/41158

### Description

Due to new capabilities, the tool has been renamed from `Color picker` to `Color format converter`.

### Motivation

Avlid cssref maco flaw in each content PR.

### Additional details

Sorted the updated entry in alphabetical order.

### Related issues and pull requests

https://github.com/mdn/content/pull/41158