### PR TITLE
fix (ui): fix theme and language dropdown slightly overlap breadcrumb…

### DIFF
--- a/components/color-theme/element.css
+++ b/components/color-theme/element.css
@@ -66,7 +66,7 @@
   width: max-content;
 
   padding: 0.75rem;
-  margin: 0;
+  margin: 0.29rem 0 0;
 
   background-color: var(--color-background-primary);
   border: 1px solid var(--color-border-primary);

--- a/components/language-switcher/element.css
+++ b/components/language-switcher/element.css
@@ -53,7 +53,7 @@
   width: max-content;
 
   padding: 0.75rem;
-  margin: 0;
+  margin: 0.29rem 0 0;
 
   background-color: var(--color-background-primary);
   border: 1px solid var(--color-border-primary);


### PR DESCRIPTION
### Description

#### Changes
- Fix `Theme` and `Language` dropdowns overlapping breadcrumbs bar on open

### Additional details

#### Before 

<img width="376" height="494" alt="image" src="https://github.com/user-attachments/assets/22e17982-416e-4e7e-958b-d979ac5b9aa8" />


<img width="554" height="864" alt="image" src="https://github.com/user-attachments/assets/dbf3c50a-543d-4615-a4f1-2d9c5cce5d97" />

#### After

<img width="422" height="400" alt="image" src="https://github.com/user-attachments/assets/a9865f7e-cb9c-438a-ae20-2f6ecca1e2f0" />

<img width="598" height="896" alt="image" src="https://github.com/user-attachments/assets/5995d80d-0cba-45a2-b64e-f06bba99054d" />


### Related issues and pull requests

Linked Issues: #487 

