### PR TITLE
ci(npm-publish-simulation): use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -68,6 +68,8 @@ jobs:
       - name: (mdn/content) yarn start
         working-directory: mdn/content
         run: yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for Rari (localhost:8083)
         run: curl --retry-connrefused --retry 5 -I http://localhost:8083/en-US/


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `npm-publish-simulation` workflow to use the `GITHUB_TOKEN` to increase the API rate limit for rari.

### Motivation

The test has been [failing regularly](https://github.com/mdn/fred/actions/runs/18091295703/job/51472309734?pr=838#step:13:15):

```
[rari] Update for @webref/css available 6.23.11 -> 7.1.0
[rari] Updating @webref/css to 6.23.11
[rari] Error: GitHub error: API rate limit exceeded for 64.236.160.18. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) (https://api.github.com/repos/web-platform-dx/web-features/releases?per_page=10)
[rari] "/home/runner/work/fred/fred/mdn/content/node_modules/@mdn/rari/bin/rari" serve -vv exited with code 1
```

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

