### PR TITLE
chore(deps): promote source-map-support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "lit-html": "^3.3.1",
         "open-editor": "^5.1.0",
         "prism-svelte": "^0.5.0",
-        "prismjs": "^1.29.0"
+        "prismjs": "^1.29.0",
+        "source-map-support": "^0.5.21"
       },
       "bin": {
         "fred-server": "scripts/server.js",
@@ -92,7 +93,6 @@
         "rspack-manifest-plugin": "^5.1.0",
         "sass-embedded": "^1.93.2",
         "sass-loader": "^16.0.5",
-        "source-map-support": "^0.5.21",
         "spdy": "^4.0.2",
         "stylelint": "^16.24.0",
         "stylelint-config-recess-order": "^7.3.0",
@@ -10518,7 +10518,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
@@ -25081,7 +25080,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -25101,7 +25099,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "lit-html": "^3.3.1",
     "open-editor": "^5.1.0",
     "prism-svelte": "^0.5.0",
-    "prismjs": "^1.29.0"
+    "prismjs": "^1.29.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.18.7",
@@ -112,7 +113,6 @@
     "rspack-manifest-plugin": "^5.1.0",
     "sass-embedded": "^1.93.2",
     "sass-loader": "^16.0.5",
-    "source-map-support": "^0.5.21",
     "spdy": "^4.0.2",
     "stylelint": "^16.24.0",
     "stylelint-config-recess-order": "^7.3.0",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Moves `source-map-support` to the runtime dependencies.

### Motivation

The dependency is used in `/server.js`, which is run by the `fred-server` bin, and declaring this dependency as a dev dependency means it's not available in content.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Blocks https://github.com/mdn/content/pull/41359.
