### PR TITLE
chore(survey): add developer survey 2025

### DIFF
--- a/components/reference-layout/server.css
+++ b/components/reference-layout/server.css
@@ -6,7 +6,7 @@
   grid-template-areas:
     "sidebar . header . toc"
     "sidebar . body   . toc";
-  grid-template-rows: min-content auto;
+  grid-template-rows: min-content 1fr;
   grid-template-columns: var(--layout-2-sidebars);
 
   justify-content: space-between;

--- a/components/reference-layout/server.js
+++ b/components/reference-layout/server.js
@@ -26,9 +26,10 @@ export class ReferenceLayout extends ServerComponent {
           <div class="reference-layout__header">
             ${WRITER_MODE ? WriterToolbar.render(context) : nothing}
             ${TranslationBanner.render(context)}
-            <mdn-survey></mdn-survey>
             <h1>${doc.title}</h1>
-            ${BaselineIndicator.render(context)} ${description}
+            ${BaselineIndicator.render(context)}
+            <mdn-survey></mdn-survey>
+            ${description}
           </div>
           <aside class="reference-layout__toc">
             ${ReferenceToc.render(context)}

--- a/components/reference-layout/server.js
+++ b/components/reference-layout/server.js
@@ -26,6 +26,7 @@ export class ReferenceLayout extends ServerComponent {
           <div class="reference-layout__header">
             ${WRITER_MODE ? WriterToolbar.render(context) : nothing}
             ${TranslationBanner.render(context)}
+            <mdn-survey></mdn-survey>
             <h1>${doc.title}</h1>
             ${BaselineIndicator.render(context)} ${description}
           </div>
@@ -34,7 +35,6 @@ export class ReferenceLayout extends ServerComponent {
             <mdn-placement-sidebar></mdn-placement-sidebar>
           </aside>
           <div class="reference-layout__body">
-            <mdn-survey></mdn-survey>
             ${sections} ${ArticleFooter.render(context)}
           </div>
         </main>

--- a/components/survey/README.md
+++ b/components/survey/README.md
@@ -1,5 +1,5 @@
 # Surveys
 
-You can force show a survey by appending `?force_survey=true` to the URL of any doc page.
+You can force show a survey by appending `?force_survey` to the URL of any doc page.
 
 If multiple surveys are configured, this will only show the first in the array: you can force a particular survey by appending `?force_survey=SURVEY_KEY` to the URL.

--- a/components/survey/README.md
+++ b/components/survey/README.md
@@ -1,0 +1,5 @@
+# Surveys
+
+You can force show a survey by appending `?force_survey=true` to the URL of any doc page.
+
+If multiple surveys are configured, this will only show the first in the array: you can force a particular survey by appending `?force_survey=SURVEY_KEY` to the URL.

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -9,7 +9,6 @@
 
   padding: 1rem;
   padding-left: 5rem;
-  margin-top: 1.6rem;
 
   background-color: var(--color-background-purple);
   border-radius: 0.5rem;

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -48,7 +48,8 @@ mdn-button::part(icon) {
   color: var(--color-text-purple);
 }
 
-summary {
+summary,
+a {
   color: var(--color-text-purple);
   cursor: pointer;
 }

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -1,3 +1,5 @@
+@import url("../external-link/global.css");
+
 :host {
   display: block;
 }

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -9,6 +9,7 @@
 
   padding: 1rem;
   padding-left: 5rem;
+  margin-top: 1.6rem;
 
   background-color: var(--color-background-purple);
   border-radius: 0.5rem;
@@ -48,10 +49,17 @@ mdn-button::part(icon) {
   color: var(--color-text-purple);
 }
 
-summary,
-a {
+summary {
   color: var(--color-text-purple);
   cursor: pointer;
+}
+
+a {
+  color: var(--color-text-purple);
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 iframe {

--- a/components/survey/element.js
+++ b/components/survey/element.js
@@ -7,7 +7,7 @@ import { L10nMixin } from "../../l10n/mixin.js";
 import closeIcon from "../icon/cancel.svg?lit";
 
 import styles from "./element.css?lit";
-import { SURVEYS, SurveyBucket } from "./surveys.js";
+import { SURVEYS } from "./surveys.js";
 import { getSurveyState, writeSurveyState } from "./utils.js";
 
 /**
@@ -27,8 +27,8 @@ export class MDNSurvey extends L10nMixin(LitElement) {
     this._surveyState = undefined;
     /** @type {boolean} */
     this._isOpen = false;
-    /** @type {string | null}  */
-    this._force = null;
+    /** @type {boolean}  */
+    this._force = false;
     /** @type {string | undefined} */
     this._source = undefined;
 
@@ -65,12 +65,13 @@ export class MDNSurvey extends L10nMixin(LitElement) {
    * @returns {Survey.Survey | undefined}
    */
   #findSurvey() {
-    this._force = new URLSearchParams(location.search).get("force_survey");
+    const forcedSurvey = new URLSearchParams(location.search).get(
+      "force_survey",
+    );
+    this._force = forcedSurvey !== null;
     return SURVEYS.find((survey) => {
       if (this._force) {
-        return this._force in SurveyBucket
-          ? survey.key === this._force
-          : this._force;
+        return forcedSurvey ? survey.key === forcedSurvey : true;
       }
 
       if (!survey.show(location.pathname)) {
@@ -199,7 +200,9 @@ export class MDNSurvey extends L10nMixin(LitElement) {
           ></mdn-button>
         </header>
         ${this._survey.link
-          ? html`<a href=${this._source}>${this._survey.question}</a>`
+          ? html`<a href=${this._source} target="_blank"
+              >${this._survey.question}</a
+            >`
           : html`<details ${ref(this._detailsRef)} @toggle=${this.#onToggle}>
               <summary>${this._survey.question}</summary>
               ${this._isOpen && this._source

--- a/components/survey/element.js
+++ b/components/survey/element.js
@@ -129,7 +129,7 @@ export class MDNSurvey extends L10nMixin(LitElement) {
   }
 
   #markOpened() {
-    if (!this._survey || !this._surveyState || this._isOpen) return;
+    if (!this._survey || !this._surveyState) return;
 
     this._surveyState = {
       ...this._surveyState,

--- a/components/survey/element.js
+++ b/components/survey/element.js
@@ -113,20 +113,30 @@ export class MDNSurvey extends L10nMixin(LitElement) {
     this.requestUpdate();
   }
 
+  #onLinkClick() {
+    this.#markOpened();
+  }
+
   #onToggle() {
     if (!this._survey || !this._surveyState || this._isOpen) return;
 
     const details = this._detailsRef.value;
     if (details && details.open) {
-      this._surveyState = {
-        ...this._surveyState,
-        opened_at: Date.now(),
-      };
-      writeSurveyState(this._survey.bucket, this._surveyState);
-      this.#measure("opened");
+      this.#markOpened();
       this._isOpen = true;
       this.requestUpdate();
     }
+  }
+
+  #markOpened() {
+    if (!this._survey || !this._surveyState || this._isOpen) return;
+
+    this._surveyState = {
+      ...this._surveyState,
+      opened_at: Date.now(),
+    };
+    writeSurveyState(this._survey.bucket, this._surveyState);
+    this.#measure("opened");
   }
 
   #onSubmitted() {
@@ -200,7 +210,10 @@ export class MDNSurvey extends L10nMixin(LitElement) {
           ></mdn-button>
         </header>
         ${this._survey.link
-          ? html`<a href=${this._source} target="_blank"
+          ? html`<a
+              href=${this._source}
+              target="_blank"
+              @click=${this.#onLinkClick}
               >${this._survey.question}</a
             >`
           : html`<details ${ref(this._detailsRef)} @toggle=${this.#onToggle}>

--- a/components/survey/element.js
+++ b/components/survey/element.js
@@ -4,6 +4,7 @@ import { createRef, ref } from "lit/directives/ref.js";
 
 import "../button/element.js";
 import { L10nMixin } from "../../l10n/mixin.js";
+import { gleanClick } from "../../utils/glean.js";
 import closeIcon from "../icon/cancel.svg?lit";
 
 import styles from "./element.css?lit";
@@ -146,8 +147,7 @@ export class MDNSurvey extends L10nMixin(LitElement) {
   #measure(action) {
     if (!this._survey) return;
 
-    // TODO: GLEAN
-    console.log(`Survey: ${action} ${this._survey.bucket}`);
+    gleanClick(`survey: ${action} ${this._survey.bucket}`);
   }
 
   #setupMessageListener() {

--- a/components/survey/element.js
+++ b/components/survey/element.js
@@ -213,6 +213,7 @@ export class MDNSurvey extends L10nMixin(LitElement) {
           ? html`<a
               href=${this._source}
               target="_blank"
+              title=${this.l10n`Take survey (Opens in a new tab)`}
               @click=${this.#onLinkClick}
               >${this._survey.question}</a
             >`

--- a/components/survey/element.js
+++ b/components/survey/element.js
@@ -211,6 +211,7 @@ export class MDNSurvey extends L10nMixin(LitElement) {
         </header>
         ${this._survey.link
           ? html`<a
+              class="external"
               href=${this._source}
               target="_blank"
               title=${this.l10n`Take survey (Opens in a new tab)`}

--- a/components/survey/surveys.js
+++ b/components/survey/surveys.js
@@ -29,6 +29,7 @@ export const SurveyBucket = Object.freeze({
   HOUSE_SURVEY_2025: "HOUSE_SURVEY_2025",
   JS_PROPOSALS_2025: "JS_PROPOSALS_2025",
   FIRST_FRED_2025: "FIRST_FRED_2025",
+  DEVELOPER_SURVEY_2025: "DEVELOPER_SURVEY_2025",
 });
 
 /**
@@ -43,25 +44,28 @@ export const SurveyBucket = Object.freeze({
  * @type {Survey.Survey[]}
  */
 export const SURVEYS = [
-  // {
-  //   key: "something unique in the current surveys",
-  //   bucket: SurveyBucket.FIRST_FRED_2025,
-  //   show: (mdn_url) => {
-  //     return /^\/[a-z]{2}(-[A-Z]{2})?\/docs\/Web\/CSS/.test(mdn_url);
-  //   },
-  //   src: (mdn_url) => {
-  //     const url = new URL(
-  //       "https://survey.alchemer.com/s3/8385674/MDN-short-survey-Fred",
-  //     );
-  //     url.searchParams.set("referrer", mdn_url);
-  //     return url.toString();
-  //   },
-  //   teaser: html`Fred is <strong>MDN</strong>'s shiny new frontend!`,
-  //   question: "How satisfied are you with this new MDN frontend?",
-  //   footnote: "fred = fr(ont)e(n)d",
-  //   rateFrom: 0,
-  //   rateTill: 1,
-  //   start: 0,
-  //   end: Infinity,
-  // },
+  {
+    key: SurveyBucket.DEVELOPER_SURVEY_2025,
+    bucket: SurveyBucket.DEVELOPER_SURVEY_2025,
+    show: (mdn_url) => {
+      return /^\/[a-z]{2}(-[A-Z]{2})?\/docs\/(Glossary|Learn|Web)/.test(
+        mdn_url,
+      );
+    },
+    src: (mdn_url) => {
+      const url = new URL(
+        "https://survey.alchemer.com/s3/8409929/MDN-Developer-Survey",
+      );
+      url.searchParams.set("referrer", mdn_url);
+      return url.toString();
+    },
+    teaser:
+      "We’re running a survey to understand how you use MDN in your web development work.",
+    question: "We’d love for you to take 10 minutes to share your feedback.",
+    link: true,
+    rateFrom: 0,
+    rateTill: 0.3,
+    start: Date.parse("2025-10-06"),
+    end: Date.parse("2025-10-20"),
+  },
 ];

--- a/components/survey/types.d.ts
+++ b/components/survey/types.d.ts
@@ -23,6 +23,8 @@ export interface Survey {
   question: TemplateResult | string;
   /** Optional footer HTML displayed below the survey */
   footnote?: TemplateResult | string;
+  /** Link to the survey instead of embedding it */
+  link?: boolean;
 }
 
 export interface SurveyState {


### PR DESCRIPTION
add support for linking to surveys, simplify force logic, fix layout issue on short pages

fixes https://github.com/mdn/fred/issues/849

added "needs content decision" because I think the movement of the survey below the description paragraph(s) was an unintentional change from yari -> fred, posted some images to slack to determine where we want to place it

I have some ideas about simplifying this logic even further to make adding surveys easier, and migrating some logic server-side/inline to avoid the content shift - but testing this is a bit of a pain, so I'd like to work on adding proper support for component-based testing first - and none of this should block this survey.

Screenshot:

<img width="1366" height="768" alt="Screen Shot 2025-10-03 at 12 30 45" src="https://github.com/user-attachments/assets/e95abded-bbb4-4cb0-b579-3c7e24d657f8" />
