### PR TITLE
fix(content-section): preserve white space only in pre, not code

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -82,8 +82,11 @@
   pre,
   code {
     font-family: var(--font-family-code);
-    white-space: pre-wrap;
     background-color: var(--color-background-secondary);
+  }
+
+  pre {
+    white-space: pre-wrap;
   }
 
   pre:not(.code-example pre) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Preserve white space only in `pre`, not `code`.

### Motivation

Content uses non-significant white space in `<code>` without `<pre>`, and this was rendered on MDN.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/847.
