### PR TITLE
ci(test/build): use GITHUB_TOKEN to install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Install
         run: npm ci
+          # Increase GitHub API limit.
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Install
         run: npm ci
+        env:
           # Increase GitHub API limit.
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `build` job in the `test` workflow to use the `GITHUB_TOKEN` to increase the API rate limit.

### Motivation

It failed on `main`, see: https://github.com/mdn/fred/actions/runs/18267299148/job/52003561274#step:4:15

```
npm error code 1
npm error path /home/runner/work/fred/fred/node_modules/@mdn/rari
npm error command failed
npm error command sh -c node ./lib/postinstall.js
npm error Finding release for v0.1.51
npm error GET https://api.github.com/repos/mdn/rari/releases/tags/v0.1.51
npm error Deleting invalid download cache
npm error Downloading rari failed: Error: Request (https://api.github.com/repos/mdn/rari/releases/tags/v0.1.51) failed: 403
```

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

