### PR TITLE
fix(survey): move above H1 element

### DIFF
--- a/components/reference-layout/server.css
+++ b/components/reference-layout/server.css
@@ -112,4 +112,8 @@
       --toc-header-font-size: var(--font-size-larger);
     }
   }
+
+  mdn-survey {
+    margin-top: 0.5rem;
+  }
 }

--- a/components/reference-layout/server.js
+++ b/components/reference-layout/server.js
@@ -26,10 +26,9 @@ export class ReferenceLayout extends ServerComponent {
           <div class="reference-layout__header">
             ${WRITER_MODE ? WriterToolbar.render(context) : nothing}
             ${TranslationBanner.render(context)}
-            <h1>${doc.title}</h1>
-            ${BaselineIndicator.render(context)}
             <mdn-survey></mdn-survey>
-            ${description}
+            <h1>${doc.title}</h1>
+            ${BaselineIndicator.render(context)} ${description}
           </div>
           <aside class="reference-layout__toc">
             ${ReferenceToc.render(context)}

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  padding-top: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .survey {

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -2,6 +2,7 @@
 
 :host {
   display: block;
+  padding-top: 0.5rem;
 }
 
 .survey {

--- a/components/survey/element.css
+++ b/components/survey/element.css
@@ -2,7 +2,6 @@
 
 :host {
   display: block;
-  margin-top: 0.5rem;
 }
 
 .survey {


### PR DESCRIPTION
### Description

Moves the survey above the H1 element.

### Motivation

Remove surveys from the content flow.

### Additional details

As discussed with the content team:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/299eae31-b026-4ff6-a5fe-076c1fb98da7" />


### Related issues and pull requests

Fixes #869 