### PR TITLE
fix(site-search): add divider between result preview snippets

### DIFF
--- a/components/site-search/element.css
+++ b/components/site-search/element.css
@@ -209,6 +209,10 @@
     color: inherit;
     background-color: var(--color-highlight-background);
   }
+
+  .divider {
+    color: var(--color-text-secondary);
+  }
 }
 
 .site-search-results__locale-indicator {

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -361,7 +361,11 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
                         <p class="site-search-results__description">
                           ${result.highlight.body &&
                           result.highlight.body.length > 0
-                            ? result.highlight.body.map((b) => unsafeHTML(b))
+                            ? unsafeHTML(
+                                result.highlight.body.join(
+                                  ' <span class="divider">…</span> ',
+                                ),
+                              )
                             : result.summary}
                         </p>
                       </article>

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -1,6 +1,7 @@
 import { Task } from "@lit/task";
 import { LitElement, html, nothing } from "lit";
 
+import { join } from "lit/directives/join.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { L10nMixin } from "../../l10n/mixin.js";
@@ -361,10 +362,9 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
                         <p class="site-search-results__description">
                           ${result.highlight.body &&
                           result.highlight.body.length > 0
-                            ? result.highlight.body.flatMap((b, i) =>
-                                i === 0
-                                  ? [unsafeHTML(b)]
-                                  : [html` … `, unsafeHTML(b)],
+                            ? join(
+                                result.highlight.body.map((b) => unsafeHTML(b)),
+                                html`<span class="divider"> … </span>`,
                               )
                             : result.summary}
                         </p>

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -361,10 +361,10 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
                         <p class="site-search-results__description">
                           ${result.highlight.body &&
                           result.highlight.body.length > 0
-                            ? unsafeHTML(
-                                result.highlight.body.join(
-                                  ' <span class="divider">…</span> ',
-                                ),
+                            ? result.highlight.body.flatMap((b, i) =>
+                                i === 0
+                                  ? [unsafeHTML(b)]
+                                  : [html` … `, unsafeHTML(b)],
                               )
                             : result.summary}
                         </p>


### PR DESCRIPTION
### Description

Fixes the assembly of resutl highlight snippets with a divider.

### Motivation

Assembly was broken with missing whitespace

### Additional details

<img width="700" alt="image" src="https://github.com/user-attachments/assets/2224e384-d004-4a17-b20e-3cce35905efe" />

### Related issues and pull requests

Fixes #859 