### PR TITLE
fix(CODEOWNERS): add Engineering for dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,12 +6,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
-# ----------------------------------------------------------------------------
-# DEFAULT OWNERS
-# ----------------------------------------------------------------------------
-*    @mdn/core-dev
+* @mdn/engineering
 
-# These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
-# If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
-/package.json @mdn-bot
-/package-lock.json @mdn-bot
+/package.json @mdn/engineering @mdn-bot
+/package-lock.json @mdn/engineering @mdn-bot


### PR DESCRIPTION
### Description

Adds `@mdn/engineering` as code owner of `package.json` and `package-lock.json`.

Note: Also replaces `@mdn/core-dev` with `@mdn/engineering`.

### Motivation

Ensures that approval by a member of the Engineering team is sufficient for dependency changes.

### Additional details

<!--
BEGIN_COMMIT_OVERRIDE
ci(CODEOWNERS): add Engineering for dependencies
END_COMMIT_OVERRIDE
-->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
