### PR TITLE
fix(content-section): use white img bg-color for all themes

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -127,7 +127,7 @@
 
     margin: 2rem auto;
 
-    background-color: var(--color-background-secondary);
+    background-color: var(--color-white);
     border: 1px solid var(--color-border-primary);
     border-radius: 0.25rem;
   }


### PR DESCRIPTION
### Description

Sets `.content-section img` background color to white for both themes.

### Motivation

To improve compatibility with transparent images.

### Related issues and pull requests

Fixes #885