### PR TITLE
ci(workflows): deploy without `pull-requests: write`

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -11,10 +11,12 @@ on:
         description: "Deployment prefix"
         required: true
         type: string
+    outputs:
+      url:
+        description: "Deployment URL"
+        value: ${{ jobs.deploy.outputs.url }}
 
 permissions:
-  # Post comment in pull request.
-  pull-requests: write
   # Authenticate with GCP.
   id-token: write
 
@@ -29,6 +31,9 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    outputs:
+      url: ${{ steps.set-output.outputs.url }}
 
     environment:
       name: review
@@ -267,24 +272,9 @@ jobs:
           concurrency: 500
           process_gcloudignore: false
 
-      - name: Post message in PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --comments --json comments \
-            --jq ".comments | sort_by(.createdAt) | map(select(.author.login == \"github-actions\")) | .[0].id")
-          if [ -n "$COMMENT_ID" ]; then
-            gh api graphql -f query='
-                mutation($id:ID!, $body:String!) {
-                  updateIssueComment(input:{id:$id, body:$body}) {
-                    issueComment {
-                      id
-                    }
-                  }
-                }' -f id="$COMMENT_ID" -f body="$BODY"
-          else
-            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"
-          fi
+      - name: Set deployment URL output
+        id: set-output
         env:
-          BODY: "${{ github.sha }} was deployed to: https://${{ env.PREFIX }}.${{ vars.HOST }}/"
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ github.token }}
+          URL: "https://${{ env.PREFIX }}.${{ vars.HOST }}/"
+        run: |
+          echo "url=$URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -5,12 +5,11 @@ on:
     branches:
       - main
 
-# Same as: _deploy.yml
 permissions:
+  # Authenticate with GCP (same as _deploy.yml).
+  id-token: write
   # Post comment in pull request.
   pull-requests: write
-  # Authenticate with GCP.
-  id-token: write
 
 jobs:
   deploy:
@@ -20,3 +19,28 @@ jobs:
     with:
       cancel-in-progress: true
       prefix: fred-pr${{ github.event.pull_request.number }}
+
+  comment:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment in PR
+        run: |
+          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --comments --json comments \
+            --jq ".comments | sort_by(.createdAt) | map(select(.author.login == \"github-actions\")) | .[0].id")
+          if [ -n "$COMMENT_ID" ]; then
+            gh api graphql -f query='
+                mutation($id:ID!, $body:String!) {
+                  updateIssueComment(input:{id:$id, body:$body}) {
+                    issueComment {
+                      id
+                    }
+                  }
+                }' -f id="$COMMENT_ID" -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"
+          fi
+        env:
+          BODY: "${{ github.sha }} was deployed to: ${{ needs.deploy.outputs.url }}"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Description

Updates the composable `_deploy` workflow to no longer require the `pull-requests: write` permission by moving the "Post message in PR" step into the `pr-review-companion`.

### Motivation

- Separates concerns.
- Fixes the `main-review-companion`, which was failing since https://github.com/mdn/fred/pull/929, because it didn't grant all permissions specified in `_deploy`.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/mdn/fred/issues/924.
