### PR TITLE
fix(search-modal): disable autocompletions on search input

### DIFF
--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -245,6 +245,7 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
             type="search"
             name="q"
             .value=${this._query}
+            autocomplete="off"
             autofocus
             @input=${this._input}
             placeholder=${this.l10n`Search`}


### PR DESCRIPTION
### Changes
- Add `autocomplete="off"` to search input

### Screen recordings

### Before

https://github.com/user-attachments/assets/a8993a29-a8be-444f-8768-c6327b3048d8

### After

https://github.com/user-attachments/assets/156dde7a-53a2-40e8-b76d-5a6294b49280


### Related issues and pull requests

- #801 

