### PR TITLE
ci(npm-publish-sim): install in content with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -85,6 +85,9 @@ jobs:
           TARBALL=$(ls ../../mdn-fred-*.tgz)
           yarn add file:$TARBALL
           yarn install
+        env:
+          # Increase GitHub API limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: (mdn/content) yarn fred-ssr (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `npm-publish-simulation` workflow to run `yarn install` in mdn/content using the `GITHUB_TOKEN`.

### Motivation

Avoids failures due to HTTP 403.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of:

- https://github.com/mdn/fred/pull/925
