### PR TITLE
fix(content-section): add `<kbd>` style

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -117,20 +117,22 @@
     }
   }
 
-  code,
-  kbd {
+  code {
     padding: 0.125em 0.25em;
-    border-radius: 0.25em;
+    border-radius: var(--radius-normal);
   }
 
   kbd {
+    padding: 0.0625em 0.125em;
+
     font-family: var(--font-family-code);
 
     color: var(--color-text-secondary);
 
-    background-color: var(--color-background-page);
+    background-color: var(--color-background-primary);
     border: 1px solid var(--color-border-primary);
-    box-shadow: inset 0 -1px 0 0 var(--color-border-primary);
+    border-bottom-width: 2px;
+    border-radius: var(--radius-normal);
   }
 
   img {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Styles `<kbd>` elements in content.

Like yari, but:
- Regular font size, not smaller.
- Thinner border, for consistency.

### Motivation

Parity with yari.

### Additional details

### Yari

<img width="773" height="310" alt="image" src="https://github.com/user-attachments/assets/67b15206-392d-4dcd-8331-85d8fb8ae057" />

### Fred (before)

<img width="780" height="245" alt="image" src="https://github.com/user-attachments/assets/34765cb5-36f5-4828-971c-9d32699b36fb" />

### Fred (after)

<img width="780" height="279" alt="image" src="https://github.com/user-attachments/assets/65cc831d-787d-49db-95b8-93bef3286045" />

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/947.