### PR TITLE
ci(npm-publish-sim): add the gh token to the run-tests stage

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -119,5 +119,7 @@ jobs:
         env:
           FRED_PORT: 5042
           CONTENT_REPO_ROOT: ../content
+          # Increase GitHub API limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/npm-test.js


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This adds the GH token to the run-tests stage workflow. Needed because rari needs some dependencies when run from the content repo.

### Motivation

CI was sometimes failing on rate limits.

