### PR TITLE
ci(workflows): pin 3rd party actions

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -68,34 +68,34 @@ jobs:
           fi
 
       - name: Checkout (fred)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: mdn/fred
           persist-credentials: false
 
       - name: Checkout (content)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/content
           path: mdn/content
           persist-credentials: false
 
       - name: Checkout (translated-content)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/translated-content
           path: mdn/translated-content
           persist-credentials: false
 
       - name: Checkout (curriculum)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/curriculum
           path: mdn/curriculum
           persist-credentials: false
 
       - name: Checkout (blog)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/blog
           path: mdn/blog
@@ -104,21 +104,21 @@ jobs:
           persist-credentials: false
 
       - name: Checkout (generic-content)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/generic-content
           path: mdn/generic-content
           persist-credentials: false
 
       - name: Checkout (mdn-contributor-spotlight)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/mdn-contributor-spotlight
           path: mdn/mdn-contributor-spotlight
           persist-credentials: false
 
       - name: Setup (fred)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: "mdn/fred/.nvmrc"
           cache: npm
@@ -251,17 +251,17 @@ jobs:
         run: npm run ssr
 
       - name: Authenticate with GCP
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
           workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Upload to GCS
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: ${{ env.BUILD_OUT_ROOT }}
           destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"

--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
       - name: (mdn/fred) Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: mdn/fred
           persist-credentials: false
 
       - name: (mdn/fred) Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: mdn/fred/.nvmrc
           cache: npm
@@ -41,7 +41,7 @@ jobs:
           echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
       - name: (mdn/fred) archive tarball
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: tarball
           path: mdn/fred/${{ steps.build.outputs.tarball }}
@@ -59,21 +59,21 @@ jobs:
 
     steps:
       - name: (mdn/content) Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/content
           path: mdn/content
           persist-credentials: false
 
       - name: (mdn/content) Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: mdn/content/.nvmrc
           cache: yarn
           cache-dependency-path: mdn/content/yarn.lock
 
       - name: (mdn/content) Download tarball
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: tarball
 
@@ -95,13 +95,13 @@ jobs:
         run: yarn fred-ssr
 
       - name: (mdn/fred) Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: mdn/fred
           persist-credentials: false
 
       - name: (mdn/fred) Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: mdn/fred/.nvmrc
           cache: npm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         if: steps.release.outputs.release_created
         with:
           persist-credentials: false
 
       - name: Setup
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         if: steps.release.outputs.release_created
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           cache: npm
           node-version-file: ".nvmrc"
@@ -54,20 +54,20 @@ jobs:
 
     steps:
       - name: Checkout (fred)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: fred
           persist-credentials: false
 
       - name: Checkout (content)
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: mdn/content
           path: content
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           cache: npm
           node-version-file: "fred/.nvmrc"


### PR DESCRIPTION
### Description

Pins all 3rd party GitHub Actions to specific commit hashes instead of version tags.

Each pinned action includes an inline comment with the resolved version number for reference.

### Motivation

Security best practice to pin actions to immutable commit hashes, preventing potential supply chain attacks from compromised action versions or tag hijacking.

### Additional details

See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1005.