### PR TITLE
fix(content-section): loosen restrictions on heading ids

### DIFF
--- a/components/heading-anchor/server.js
+++ b/components/heading-anchor/server.js
@@ -11,8 +11,6 @@ export class HeadingAnchor extends ServerComponent {
    * @param {string} title
    */
   render(level, id, title) {
-    // remove leading numbers, dots, underscores, and commas to form a valid element id
-    id = id ? id.replace(/^[0-9._,]+/, "") : id;
     return id
       ? hh`<${unsafeStatic("h" + level)} id=${ifDefined(id)} class="heading"><a class="heading-anchor" href="#${id}">${unsafeStatic(title)}</a></${unsafeStatic("h" + level)}>`
       : nothing;


### PR DESCRIPTION
### Description

This removes some overly eager id sanitizing that prevented ToC links (for example) to work in some cases.

### Related issues and pull requests

Fixes #1007 

