### PR TITLE
docs: add example command for copying .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ MDN's next fr(ont)e(n)d.
 
 ## Getting started
 
-1. Copy `.env-dist` to `.env` and update
+1. Copy `.env-dist` to `.env` and update values as needed. The file contains comments for guidance:
+
+```bash
+   cp .env-dist .env
+```
+
 2. Install dependencies `npm install`
 3. Bring up the dev environment with `npm run start`
 


### PR DESCRIPTION
### Changes

- Add command for copying .env example file (`.env-dist`)

### Motivation

Figured we match what's in PR for `content` repo here: https://github.com/mdn/content/pull/41266/commits/e18d18a13632aa39f6262b20d6309f591049caf7#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R187

<!--
BEGIN_COMMIT_OVERRIDE
docs(README): add example command for copying .env file (https://github.com/mdn/fred/pull/1016)
END_COMMIT_OVERRIDE
-->
