### PR TITLE
fix(homepage-contributor-spotlight): fix content overflow

### DIFF
--- a/components/homepage-contributor-spotlight/server.css
+++ b/components/homepage-contributor-spotlight/server.css
@@ -21,8 +21,7 @@
 }
 
 .homepage-contributor-spotlight__name {
-  width: max-content;
-  max-width: 100%;
+  width: fit-content;
 
   padding: 0.125em 0.25em;
 


### PR DESCRIPTION
### Description

#### Changes

- Edit `homepage-contributor-spotlight__name` class styles - prevent name content overflow on mobile screens

### Screenshots and screen recordings

### Before

https://github.com/user-attachments/assets/2de6bb60-cf99-4ab0-8164-c5e533becdfe

### After

https://github.com/user-attachments/assets/08627481-457d-4a9e-ba01-ce86c29d882d




### Related issues and pull requests

- #1027 

