### PR TITLE
feat(compat-table): render only visible timeline on click

### DIFF
--- a/components/compat-table/index-common.css
+++ b/components/compat-table/index-common.css
@@ -217,14 +217,6 @@ table {
   .bc-feature-depth-3 {
     border-left: 15px solid var(--color-border-primary);
   }
-
-  .timeline {
-    display: none;
-  }
-
-  .bc-has-history:focus-within .timeline {
-    display: initial;
-  }
 }
 
 .bc-head-txt-label {

--- a/components/compat-table/index-desktop.css
+++ b/components/compat-table/index-desktop.css
@@ -59,13 +59,17 @@
       }
     }
 
+    button[aria-expanded="false"] ~ .timeline {
+      display: none;
+    }
+
     .timeline {
       border-top: var(--border);
       border-left: none !important;
     }
 
     .bc-has-history {
-      &:focus-within > button {
+      & > button[aria-expanded="true"] {
         /* Highlight expanded item. */
         --padding-bottom-offset: -2px;
         border-bottom: 2px solid var(--color-border-primary);


### PR DESCRIPTION
### Description

Updates the Compat table to:

- render only the visible timeline (on demand), and
- toggle the timeline with click (instead of focus).

### Motivation

Reduces DOM size, and avoids the side-effect of the focus.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

