### PR TITLE
ci(npm-publish-sim): use npm in content repo

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -73,8 +73,8 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: mdn/content/.nvmrc
-          cache: yarn
-          cache-dependency-path: mdn/content/yarn.lock
+          cache: npm
+          cache-dependency-path: mdn/content/package-lock.json
 
       - name: (mdn/content) Download tarball
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -85,18 +85,18 @@ jobs:
         working-directory: mdn/content
         shell: bash
         run: |
-          yarn cache clean --all
+          npm cache clean --force
           TARBALL=$(ls ../../mdn-fred-*.tgz)
-          yarn add file:$TARBALL
-          yarn install
+          npm install file:$TARBALL
+          npm install
         env:
           # Increase GitHub API limit.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: (mdn/content) yarn fred-ssr (Linux)
+      - name: (mdn/content) Render (Linux)
         if: runner.os == 'Linux'
         working-directory: mdn/content
-        run: yarn fred-ssr
+        run: npx fred-ssr
 
       - name: (mdn/fred) Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/scripts/npm-test.js
+++ b/scripts/npm-test.js
@@ -9,7 +9,7 @@ concurrently(
     },
     {
       cwd: process.env.CONTENT_REPO_ROOT,
-      command: `yarn start`,
+      command: `npm start`,
       name: "content",
       prefixColor: "blue",
     },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the repo to use npm in mdn/content.

### Motivation

Consistency across MDN repos.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1106.