### PR TITLE
chore(deps): unpin npm version, set `packageManager` instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,8 +111,7 @@
         "webpack-stats-plugin": "^1.1.3"
       },
       "engines": {
-        "node": ">=22",
-        "npm": "^10"
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "webpack-stats-plugin": "^1.1.3"
   },
   "engines": {
-    "node": ">=22",
-    "npm": "^10"
-  }
+    "node": ">=22"
+  },
+  "packageManager": "npm@10.9.4"
 }


### PR DESCRIPTION
### Description

Specify npm version via `packageManager` field, not `engines.npm`.

### Motivation

Setting `engines.npm` to `"^10"` appears to prevent installing the package in content with npm 11, if `engine-strict` is enabled.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

