### PR TITLE
ci(npm-publish): allow manual run

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

Updates the `npm-publish` workflow to also run on `workflow_dispatch`.

### Motivation

Allows triggering the release-please PR when all commits since the last release were pushed by Dependabot (which prevents `npm-publish` from running, because secrets cannot be accessed).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

