### PR TITLE
chore(footer): add socials + external links in new tab

### DIFF
--- a/components/footer/server.js
+++ b/components/footer/server.js
@@ -175,7 +175,7 @@ export class Footer extends ServerComponent {
                   <a
                     href=${item.href}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     aria-label=${item.ariaLabel}
                     data-icon=${item.icon}
                   ></a>


### PR DESCRIPTION
Add target="_blank" rel="noopener noreferrer"

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates footer social links and external navigation links to open in a new tab by adding target="_blank" along with rel="noopener noreferrer" for security and privacy.

### Motivation

External links (such as social media and outbound resources) should open in a new tab to avoid disrupting the current navigation context.

### Additional details

Applies only to external links; internal navigation behavior remains unchanged.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

