### PR TITLE
fix(live-sample): add `sandbox="allow-downloads"` to all samples

### DIFF
--- a/components/live-sample-result/element.js
+++ b/components/live-sample-result/element.js
@@ -110,7 +110,11 @@ export class MDNLiveSampleResult extends L10nMixin(LitElement) {
           .code=${this.code}
           .allow=${this.allow}
           .sandbox=${[
-            ...new Set(["allow-modals", ...(this.sandbox?.split(" ") || [])]),
+            ...new Set([
+              "allow-modals",
+              "allow-downloads",
+              ...(this.sandbox?.split(" ") || []),
+            ]),
           ].join(" ")}
           .srcPrefix=${this.srcPrefix}
           permalink


### PR DESCRIPTION
Alternative to https://github.com/mdn/rari/pull/472.

Fixes https://github.com/mdn/content/issues/42463.

Apply `allow-downloads` to all live samples with no need for authors to explicitly allowlist it.

Tested locally with http://localhost:3000/en-US/docs/Web/HTML/Reference/Elements/a#using_the_download_attribute_to_save_a_canvas_as_a_png