### PR TITLE
fix(left-sidebar): text alignment of current page

### DIFF
--- a/components/curriculum/sidebar.css
+++ b/components/curriculum/sidebar.css
@@ -102,9 +102,12 @@
 
     padding-inline: 0.5rem;
 
+    /* Negative margin for text alignment. */
+    margin-inline-start: calc(-1 * (0.5rem + 2px));
+
     font-style: normal;
 
     background-color: var(--background-toc-active);
-    border-left: 2px solid var(--category-color);
+    border-inline-start: 2px solid var(--category-color);
   }
 }

--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -111,10 +111,13 @@
 
     padding-inline: 0.5rem;
 
+    /* Negative margin for text alignment. */
+    margin-inline-start: calc(-1 * (0.5rem + 2px));
+
     font-style: normal;
 
     background-color: var(--color-area-background);
-    border-left: 2px solid var(--color-area-highlight-border);
+    border-inline-start: 2px solid var(--color-area-highlight-border);
   }
 
   .icon {


### PR DESCRIPTION
### Description

This PR adds a negative margin to the `<em>` element which houses the current link (`<a aria-current="page">`) inside `left-sidebar`. The value of this negative margin is calculated as the sum of padding and border width.

It seems like this codebase mixes logical properties with physical properties everywhere, which is confusing and probably not intentional. For this PR, I've converted the `border-left` declaration within the same ruleset into its logical equivalent (`border-inline-start`) ~~and also grouped it together with the `padding-inline` and `margin-inline-start` declarations for better readability / local reasoniing~~.

### Motivation

This change was necessary for optical left alignment of all items within the same list.

| Before | After |
| --- | --- |
| <img width="280" height="264" alt="Screenshot showing the beginning of Core modules. The active item in the list is emphasized with border and additional padding, producing additional space before the text starts" src="https://github.com/user-attachments/assets/2edefc6c-b1b8-48fc-ade8-5973dce8e4b6" /> | <img width="279" height="266" alt="Screenshot of the exact same UI but with the text inside the active item neatly aligned with the non-active items" src="https://github.com/user-attachments/assets/34d59be5-42ab-4c0c-b8ba-05703d74761a" /> |


### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N/A