### PR TITLE
chore(scrim-inline): move global style out of element

### DIFF
--- a/components/scrim-inline/element.css
+++ b/components/scrim-inline/element.css
@@ -2,13 +2,6 @@
 
 :host {
   display: block;
-
-  width: 100%;
-  max-width: 36rem;
-  aspect-ratio: 1.5;
-
-  margin: 0.5rem auto;
-
   overflow: hidden;
 }
 

--- a/components/scrim-inline/global.css
+++ b/components/scrim-inline/global.css
@@ -7,3 +7,13 @@
     url("./assets/BarlowCondensed-SemiBold.woff2") format("woff2");
   font-display: block;
 }
+
+mdn-scrim-inline {
+  display: block;
+
+  width: 100%;
+  max-width: 36rem;
+  aspect-ratio: 1.5;
+
+  margin: 0.5rem auto;
+}


### PR DESCRIPTION
### Description

Moves the scrim-inline style back into the global space.

### Motivation

Avoids layout shift, see [Leo's comment](https://github.com/mdn/fred/pull/700#issuecomment-3265044804).

### Additional details

This reverts commit 6c4e1dc92b4bbef17395b23daff2c55b1bd287d9.

### Related issues and pull requests

Follow-up of https://github.com/mdn/fred/pull/700.

