### PR TITLE
fix(about-tabs): apply styles correctly on hover

### DIFF
--- a/components/about-tabs/element.css
+++ b/components/about-tabs/element.css
@@ -31,14 +31,14 @@
 
   font-weight: normal;
 
-  color: var(--about-tablist-color);
+  color: var(--about-tablist-color) !important;
 
   text-decoration: none;
 }
 
 ::slotted([slot="tab"]:hover),
 ::slotted([slot="tab"].active) {
-  color: var(--about-tablist-active-color);
+  color: var(--about-tablist-active-color) !important;
   border-bottom: 2px solid var(--about-tablist-active-border);
 }
 


### PR DESCRIPTION
### Changes
- Ensure tab styles are applied on hover and active states

### Screenshots and screen recordings

### Before

<img width="2364" height="534" alt="image" src="https://github.com/user-attachments/assets/5348695a-d4af-46c5-9cff-5eb8c46c7c25" />

### After

https://github.com/user-attachments/assets/d6edb29f-866e-42ab-bd27-70fdddabf0ea

### Related issues and pull requests

Fixes #744 
