### PR TITLE
fix(server): handle HEAD requests + send Content-Length header

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,7 +93,7 @@ async function serverRenderMiddleware(req, res, page) {
       "Content-Type": "text/html",
       "Content-Length": Buffer.byteLength(html),
     });
-    res.end(html);
+    res.end(res.locals.wasHead ? undefined : html);
   } catch (error) {
     console.error("SSR render error:", error);
     res.writeHead(500).end();
@@ -203,6 +203,16 @@ export async function startServer() {
   }
 
   const RARI_URL = process.env.RARI_URL || "http://localhost:8083";
+
+  // Convert HEAD requests to GET so Rari returns full response for rendering
+  app.use((req, res, next) => {
+    if (req.method === "HEAD") {
+      req.method = "GET";
+      res.locals.wasHead = true;
+    }
+    next();
+  });
+
   app.use(
     createProxyMiddleware({
       target: RARI_URL,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes the `server.js`:

- Handle HEAD requests properly.
- Send `Content-Length` header to clients.

### Motivation

Mainly avoid that `curl -I` requests crash the dev server.

### Additional details

Note: This only affects the local dev server.

#### Before

```console
% curl -I http://localhost:3000/en-US/
curl: (52) Empty reply from server
```

And crashes the server:

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at ProxyServer.proxyRes (file:///path/to/mdn/fred/server.js:253:29)
    at processTicksAndRejections (node:internal/process/task_queues:103:5)
```

#### After

```console
% curl -I http://localhost:3000/en-US/
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: text/html
Content-Length: 151484
Date: Wed, 21 Jan 2026 20:08:19 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

