### PR TITLE
fix(l10n): don't insert unicode directional isolates

### DIFF
--- a/l10n/fluent.js
+++ b/l10n/fluent.js
@@ -42,15 +42,16 @@ export class Fluent {
   constructor(locale = "en-US", resources = []) {
     this.locale = locale;
 
-    this.usBundle = Fluent.constructBundle(new FluentBundle(locale), [
-      enUS_ftl,
-    ]);
+    this.usBundle = Fluent.constructBundle(
+      new FluentBundle(locale, { useIsolating: false }),
+      [enUS_ftl],
+    );
 
     if (resources.length > 0) {
-      this.bundle = Fluent.constructBundle(new FluentBundle(locale), [
-        enUS_ftl,
-        ...resources,
-      ]);
+      this.bundle = Fluent.constructBundle(
+        new FluentBundle(locale, { useIsolating: false }),
+        [enUS_ftl, ...resources],
+      );
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1051

More details about directional isolates: https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation

We don't support any RTL locales, so this shouldn't be a problem.