### PR TITLE
ci(main-review-companion): add missing actions permission

### DIFF
--- a/.github/workflows/main-review-companion.yml
+++ b/.github/workflows/main-review-companion.yml
@@ -11,8 +11,10 @@ on:
 
 permissions:
   contents: read
-  # Authenticate with GCP.
+  # See: _deploy.yml
   id-token: write
+  # See: _deploy.yml
+  actions: read
 
 jobs:
   build:


### PR DESCRIPTION
### Description

Updates the `main-review-companion`, adding the `actions: read` permission.

### Motivation

The workflow is currently failing with the following error:

> The workflow is not valid. .github/workflows/main-review-companion.yml (Line: 25, Col: 3): Error calling workflow 'mdn/fred/.github/workflows/_deploy.yml@f3b4b2f797e5e6c711ef3b091f204ad5601671af'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'.

### Additional details

In https://github.com/mdn/fred/pull/1235, we added this permission to the composable `_deploy` workflow, so all calling workflows need to provide it.

### Related issues and pull requests

Follow-up of https://github.com/mdn/fred/pull/1235.
