### PR TITLE
ci(_build): default BLOG_PAGINATION to false

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -139,7 +139,7 @@ jobs:
 
           ADDITIONAL_LOCALES_FOR_GENERICS_AND_SPAS: de
 
-          BLOG_PAGINATION: ${{ steps.privileged.outputs.BLOG_PAGINATION }}
+          BLOG_PAGINATION: ${{ steps.privileged.outputs.BLOG_PAGINATION || 'false' }}
 
           # Increase GitHub API limit.
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update the `_build` workflow, defaulting `BLOG_PAGINATION` to `"false"` rather than `""` (the empty string).

### Motivation

Rari rejects the empty environment variable (see [this failed workflow run](https://github.com/mdn/fred/actions/runs/21291949374/job/61288146302?pr=1221#step:13:133)):

```
error generating settings: invalid type: string "", expected a boolean for key `blog_pagination` in the environment
```

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/fred/pull/1235.

