### PR TITLE
ci(_build): avoid empty BLOG_ROOT + build with rari `--all-available` option

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -252,7 +252,7 @@ jobs:
             done
           fi
 
-          npm run rari build -- --all $FILE_LIST --templ-stats
+          npm run rari build -- --all-available $FILE_LIST --templ-stats
 
       - name: Render (fred)
         working-directory: mdn/fred


### PR DESCRIPTION
### Description

Updates the `_build` to build properly without blog.

### Motivation

The `pr-build` workflow is failing in unprivileged fork PRs with Rari errors, because 1.) `BLOG_ROOT` is empty, and 2.) `--all` expects `BLOG_ROOT` to be set.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

