### PR TITLE
ci(pr-review-companion): identify PR number from head repository

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -25,13 +25,17 @@ jobs:
       - name: Identify PR
         id: identify-pr
         run: |
-          PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls --jq '.[0].number')
+          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number")
           echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
         env:
+          BASE_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
   deploy:
     needs: identify-pr
+    if: needs.identify-pr.outputs.pr-number
     uses: ./.github/workflows/_deploy.yml
     secrets: inherit
     with:
@@ -42,6 +46,7 @@ jobs:
 
   comment:
     needs: [identify-pr, deploy]
+    if: needs.identify-pr.outputs.pr-number
     runs-on: ubuntu-latest
     steps:
       - name: Comment in PR


### PR DESCRIPTION
### Description

Update the `pr-review-companion` workflow, identifying the PR number from the head repository instead of the base repository.

### Motivation

The current approach fails to identify the PR number for fork PRs, because the commits API only returns commits in the given repo, excluding forks.

### Additional details

Noticed in https://github.com/mdn/fred/pull/1221 that the PR number was empty. And here's is the explanation:

```console
$ gh api repos/mdn/fred/commits/56a905455f8be1a8d8194089c2cbaf2a0debd455/pulls
[]

$ gh api repos/mayank99/fred/commits/56a905455f8be1a8d8194089c2cbaf2a0debd455/pulls
[
  {
    "url": "https://api.github.com/repos/mdn/fred/pulls/1221",
    // …
    "number": 1221,
    // …
    "base": {
      // …
      "repo": {
        // …
        "full_name": "mdn/fred",
        // …
      }
    },
    // ...
  }
]
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

