### PR TITLE
fix(sidebar): titles with code element run together

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -83,7 +83,7 @@
 
   a,
   span:not(.highlight-container) {
-    display: inline-flex;
+    display: inline-block;
     padding-block: 0.25rem;
     vertical-align: middle;
   }
@@ -103,6 +103,7 @@
   code {
     font-family: var(--font-family-code);
     font-size: var(--font-size-normal);
+    line-height: 1;
   }
 
   em {


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1270

Tested locally with my local proof of concept for https://github.com/mdn/fred/issues/1282 which screenshots the entirety of the expanded html/css/js sidebars as well as select combinations of highlighted elements.

There's a few subpixel differences across all sidebars, but the major changes are:

| before | after |
| - | - |
| <img width="283" height="416" alt="sidebar-highlighted-code-and-text-firefox-1366x768-dpr-1" src="https://github.com/user-attachments/assets/173a1ae1-98d2-46d6-bb47-a3a4decf26bb" /> | <img width="283" height="416" alt="sidebar-highlighted-code-and-text-firefox-1366x768-dpr-1" src="https://github.com/user-attachments/assets/de78446f-403b-482e-9380-805a06ed4f1a" /> |
| <img width="262" height="320" alt="image" src="https://github.com/user-attachments/assets/85967d00-15d3-4f92-91d4-fdad08481d53" /> | <img width="262" height="320" alt="image" src="https://github.com/user-attachments/assets/684481f6-f13d-42de-86cd-cd7bdcaf91b4" /> |