### PR TITLE
fix(content-section): Make table headings bold

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -157,7 +157,7 @@
     }
 
     th {
-      font-weight: var(--font-weight-normal);
+      font-weight: var(--font-weight-bold);
       text-align: left;
     }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
Changes the font-weight in content-section table headings from normal to bold.

### Motivation
Table headings should be visually distinguishable from content rows.

### Additional details
| Before | After |
| ------ | ----- |
| <img width="704" height="432" alt="Image" src="https://github.com/user-attachments/assets/8ca3362a-dd18-4802-af0e-88d2675667dd" /> | <img width="704" height="432" alt="Image" src="https://github.com/user-attachments/assets/4969b9e3-19fc-4be4-8865-07687ff4453f" /> |

### Related issues and pull requests
Fixes #1247

