### PR TITLE
fix(hooks/sidebar-scroll-to-current): update scroll target

### DIFF
--- a/hooks/sidebar-scroll-to-current.js
+++ b/hooks/sidebar-scroll-to-current.js
@@ -1,4 +1,4 @@
-const sidebar = document.querySelector(".left-sidebar");
+const sidebar = document.querySelector("#main-sidebar");
 const current = sidebar?.querySelector('[aria-current="page"]');
 if (sidebar && current instanceof HTMLElement) {
   sidebar.scrollTo({


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `sidebar-scroll-to-current` hook to scroll `#main-sidebar` instead of `.left-sidebar`.

### Motivation

Feature was broken, as `.left-sidebar` no longer scrolls (`#main-sidebar` now does).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1297.