### PR TITLE
ci(npm-publish*): remove obsolete npm upgrade

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -24,10 +24,6 @@ jobs:
           cache: npm
           cache-dependency-path: mdn/fred/package-lock.json
 
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
       - name: (mdn/fred) Install all npm packages
         working-directory: mdn/fred
         run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,11 +38,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
 
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - name: Install latest npm
-        if: steps.release.outputs.release_created
-        run: npm install -g npm@latest
-
       - name: Install
         if: steps.release.outputs.release_created
         run: npm ci


### PR DESCRIPTION
#### Summary

Updates the `npm-publish` and `npm-publish-simulation` workflows, removing the now-obsolete npm upgrade.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Part of https://github.com/mdn/fred/issues/1300.