### PR TITLE
fix(left-sidebar): unindent nested details

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -78,6 +78,23 @@
 
     ol {
       padding-left: 1.5rem;
+
+      /* Unindent nested details so their chevron aligns with
+         the parent list level instead of being indented. */
+      > li:has(> details) > details {
+        /* Leaf details (no nested collapsibles):
+           pull back the entire block. */
+        &:not(:has(ol > li > details)) {
+          margin-left: -1.5rem;
+        }
+
+        /* Parent details (has nested collapsibles):
+           only pull back the summary, keeping content
+           indented for nested sections to outdent into. */
+        &:has(ol > li > details) > summary {
+          margin-left: -1.5rem;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `left-sidebar` layout, unindenting nested details:

- If the details element has nested details, unindent (only) the summary element.
- If the details element has no nested details, unindent the whole details element.

### Motivation

1. Avoid confusion.
2. Save horizontal space (possibly less line breaks in nested sidebars).

### Additional details

| Sidebar | Before | After |
|--------|--------|--------|
| CSS | <img width="237" height="555" alt="image" src="https://github.com/user-attachments/assets/83ac36a5-8c22-47a6-8885-41d0890ebba2" /> | <img width="237" height="555" alt="image" src="https://github.com/user-attachments/assets/81551309-1c68-451c-b149-d9f8885cdb14" /> |
| WebExt | <img width="237" height="387" alt="image" src="https://github.com/user-attachments/assets/298ed8a2-3d9f-4555-9317-4b07b816f6fb" /> | <img width="237" height="387" alt="image" src="https://github.com/user-attachments/assets/5a1140e5-68f9-4cec-9e52-bac693ce5a65" /> | 

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1311.