### PR TITLE
fix(sidebar): align siblings' text, control indent directly

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -71,11 +71,11 @@
 
         flex-shrink: 0;
 
-        width: calc(var(--calc-width-height));
-        height: calc(var(--calc-width-height));
+        width: var(--calc-width-height);
+        height: var(--calc-width-height);
 
         margin-right: var(--calc-margin-right);
-        margin-left: calc(var(--calc-margin-left));
+        margin-left: var(--calc-margin-left);
 
         content: "";
 


### PR DESCRIPTION
Best effort attempt at fixing https://github.com/mdn/fred/issues/1311 given the universal feedback on https://github.com/mdn/fred/issues/1311#issuecomment-3946512145 to go with the `indent-all` option.

This takes that approach - which ensures hierarchical consistency across each level (including the root) - and makes it better:
- Adds a variable controlling the indent level, which automatically resizes the chevron to match
- Saves some space around the chevron icon by cropping it slightly - ensuring the left edge of the chevron itself, not its containing box, is aligned with its parent's text
- Indents lists with no `<details>` element in it slightly less: this ends up looking visually more consistent, and saves space

With all this, despite the increase in base padding to make everything align on the root level, we actually increase the space available for text compared to `main`.

| Before                                                                                                                              | After                                                                                                                                              |
| ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="261" height="584" alt="1-main" src="https://github.com/user-attachments/assets/9ff070e9-47bc-4f88-b0fe-c828766bb627" /> | <img width="261" height="584" alt="1-1311-indent-control" src="https://github.com/user-attachments/assets/a8d6aeb7-e650-4cd0-b1f1-13e51f28dc4d" /> |
| <img width="261" height="584" alt="2-main" src="https://github.com/user-attachments/assets/17852f20-213d-48e9-9e60-04d22091b3e8" /> | <img width="261" height="584" alt="2-1311-indent-control" src="https://github.com/user-attachments/assets/cbb82f4e-4968-417e-b76d-6675e7b4c99f" /> |
| <img width="261" height="584" alt="3-main" src="https://github.com/user-attachments/assets/24374001-5059-4a44-ab41-559a1d7b2e54" /> | <img width="261" height="584" alt="3-1311-indent-control" src="https://github.com/user-attachments/assets/487f5500-0e54-4355-a672-698afac97728" /> |
| <img width="261" height="584" alt="4-main" src="https://github.com/user-attachments/assets/9ab97cd6-b2da-4483-80df-19852beae015" /> | <img width="261" height="584" alt="4-1311-indent-control" src="https://github.com/user-attachments/assets/28ab7d3f-8235-41f3-a984-4b581a77c981" /> |
