### PR TITLE
fix(l10n): client-rendered strings always in en-US

### DIFF
--- a/l10n/fluent.js
+++ b/l10n/fluent.js
@@ -185,7 +185,10 @@ function getLocale(locale) {
   }
   if (!fluent.has(locale)) {
     const ftl = ftlMap[locale];
-    const localeF = new Fluent(locale, ftl ? [ftl] : undefined);
+    if (!ftl) {
+      return new Fluent(locale);
+    }
+    const localeF = new Fluent(locale, [ftl]);
     fluent.set(locale, localeF);
   }
   return fluent.get(locale);


### PR DESCRIPTION
Noticed in https://github.com/mdn/fred/pull/1367.

Currently strings rendered on the client - so this is strings within custom elements which *aren't* SSRed - always render in en-US. This is because our entry-points race in an unexpected way, which we do need to fix, but has some drawbacks/considerations we need to make. I've got a draft PR for that I need to spend more time on tomorrow: https://github.com/mdn/fred/pull/1368

For now, we can and should fix the worst of the issue for localised strings by not caching the miss. This PR does that.

An example of the issue can be seen on https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/Array#compatibilit%C3%A9_des_navigateurs:

Before:

<img width="768" height="317" alt="Screen Shot 2026-03-12 at 17 28 53" src="https://github.com/user-attachments/assets/aacbf215-ac2e-4580-a75c-2e555f0f0e58" />

After:

<img width="768" height="317" alt="Screen Shot 2026-03-12 at 17 29 02" src="https://github.com/user-attachments/assets/331b2247-3691-4754-ad74-c3f3a356dd24" />