### PR TITLE
chore(l10n): machine translate missing German strings

### DIFF
--- a/l10n/locales/de.ftl
+++ b/l10n/locales/de.ftl
@@ -19,7 +19,6 @@ site-search-suggestion-matches =  { $relation ->
        *[other] { $matches } Übereinstimmungen
     }
 }
-site-search-suggestions-text = Meinten Sie:
 
 blog-time-to-read = { $minutes ->
     [one]   { $minutes } Minute Lesezeit
@@ -296,7 +295,7 @@ sidebar-filter-clear-filter-input = Filterfeld leeren
 site-search-search = Suchen
 site-search-previous = Zurück
 site-search-next = Weiter
-site-search-suggestions-text = Meinten Sie …?
+site-search-suggestions-text = Meinten Sie:
 site-search-searching = Suche läuft…
 site-search-language = Sprache
 site-search-both = Beides


### PR DESCRIPTION
@caugner I thought it made sense to do a one-shot machine translation of the missing strings before we integrate this into an automated pipeline.

I used a script I'll be cleaning up and opening a PR for to copy the missing English strings into `de.ftl` (first commit).

Then used machine translation locally to translate those English strings into German (second commit).

I then remotely translated those translated strings back to English and checked if the differences seemed consequential - I've left one inline comment where it seemed to be.

Mein Deutsch is nicht so gut, so unfortunately I can't validate the correctness/good-sounding-ness of the strings beyond that - but I was hoping you could!