### PR TITLE
chore(menu): add Scrimba link

### DIFF
--- a/components/menu/tabs.json
+++ b/components/menu/tabs.json
@@ -378,6 +378,10 @@
           {
             "href": "/en-US/curriculum/",
             "text": "MDN Curriculum"
+          },
+          {
+            "href": "https://scrimba.com/frontend-path-c0j?via=mdn-learn-navbar",
+            "text": "Check out the video course from Scrimba, our partner"
           }
         ]
       },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds Scrimba link to the "Learn" section in the `menu` component.

### Motivation

Promote the course of our partner, which teaches the content of the MDN Curriculum.

### Additional details

Screenshot:

<img width="1402" height="534" alt="image" src="https://github.com/user-attachments/assets/d60957d6-6563-4435-9e5c-a78356439eef" />


### Related issues and pull requests

Fixes https://github.com/mdn/mdn/issues/814.