### PR TITLE
fix(live-sample): add fullscreen + orientation lock to sandbox

### DIFF
--- a/components/live-sample-result/element.js
+++ b/components/live-sample-result/element.js
@@ -113,6 +113,8 @@ export class MDNLiveSampleResult extends L10nMixin(LitElement) {
             ...new Set([
               "allow-modals",
               "allow-downloads",
+              "allow-fullscreen",
+              "allow-orientation-lock",
               ...(this.sandbox?.split(" ") || []),
             ]),
           ].join(" ")}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Apply `allow-fullscreen` and `allow-orientation-lock` to all live samples.

### Motivation

Ensure live samples requiring these work without authors needing to explicitly allowlist (Rari doesn't currently support these).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Similar to https://github.com/mdn/fred/pull/1215.

Fixes https://github.com/mdn/rari/issues/347.
Fixes https://github.com/mdn/rari/issues/561.
