### PR TITLE
fix(sidebar): make current page indentation not confusing

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -150,6 +150,10 @@
     border-left: 2px solid var(--color-area-highlight-border);
   }
 
+  li li em {
+    margin-left: calc(-0.5rem - 2px);
+  }
+
   .icon {
     margin-left: 0.5ch;
   }


### PR DESCRIPTION
### Description

This aligns the position of the emphasized sidebar item text with other elements at the same nesting levels

### Motivation

The current positioning makes the hierarchy harder to read at a glance and made `mix-blend-mode` appear as though it might have been nested under `min-*` by mistake. I double-checked that impression with my partner to confirm the ambiguity wasn’t just on my side.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="1147" height="908" alt="Screenshot_2026-03-16_18-52-39" src="https://github.com/user-attachments/assets/ffdda905-86fa-4085-b427-328edb8a5435" />
<img width="1147" height="908" alt="Screenshot_2026-03-16_19-00-42" src="https://github.com/user-attachments/assets/955b094f-52f4-492e-825f-ab2b9d3a047f" />
 <td>
<img width="1147" height="908" alt="Screenshot_2026-03-16_18-52-54" src="https://github.com/user-attachments/assets/ff1bd3f0-9927-4681-9ac7-799599dbfee6" />
<img width="1147" height="908" alt="Screenshot_2026-03-16_19-00-54" src="https://github.com/user-attachments/assets/a97c374c-7fb4-4799-b350-4f234e0b55ac" />

</table>

### Related issues and pull requests

This didn’t look confusing before #1329. I hope my PR doesn’t introduce any regressions like this. Tried to browse around MDN and didn’t notice any issues.