### PR TITLE
fix(sidebar): dedent current page highlight

### DIFF
--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -140,14 +140,26 @@
   }
 
   em {
+    --padding: 0.5rem;
+    --border: 2px;
+
     display: block;
 
-    padding-inline: 0.5rem;
+    padding-inline: var(--padding);
+    margin-left: calc(-1 * (var(--padding) + var(--border)));
 
     font-style: normal;
 
     background-color: var(--color-area-background);
-    border-left: 2px solid var(--color-area-highlight-border);
+    border-left: var(--border) solid var(--color-area-highlight-border);
+
+    summary > & {
+      padding-left: calc(var(--padding) + var(--sidebar-list-indent-chevron));
+      margin-left: calc(
+        -1 *
+          (var(--padding) + var(--border) + var(--sidebar-list-indent-chevron))
+      );
+    }
   }
 
   .icon {


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1388.

Handles both normal cases and when there's an icon on the left.

Now we keep the alignment of the text consistent regardless of whether the item is highlighted or not.

Screenshots:

| before | after |
| - | - |
| <img width="267" height="584" alt="sidebar-highlighted-code-and-text-firefox-1366x768-dpr-1" src="https://github.com/user-attachments/assets/c16ea047-dd7a-4700-b80d-dd09377b0ed6" /> | <img width="267" height="584" alt="sidebar-highlighted-code-and-text-firefox-1366x768-dpr-1" src="https://github.com/user-attachments/assets/e5395e24-ad19-4439-aba5-e38414878095" /> |
| <img width="267" height="584" alt="sidebar-highlighted-code-element-firefox-1366x768-dpr-1" src="https://github.com/user-attachments/assets/fdad1ee9-f960-4f83-9f6f-f8d4de3d2ec0" /> | <img width="267" height="584" alt="sidebar-highlighted-code-element-firefox-1366x768-dpr-1" src="https://github.com/user-attachments/assets/00db13ff-8811-4fbd-a2af-49ce9d534e5c" /> |
| <img width="267" height="646" alt="sidebar-html-collapsed-firefox-1366x830-dpr-1" src="https://github.com/user-attachments/assets/ed2dcb44-0982-42d8-a833-2f079b987bc8" /> | <img width="267" height="646" alt="sidebar-html-collapsed-firefox-1366x830-dpr-1" src="https://github.com/user-attachments/assets/f535e917-f160-4677-a3be-2476ba41142a" /> |
