### PR TITLE
fix(search-modal): overflow documentElement when dialog is open

### DIFF
--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -209,6 +209,14 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
     this.shadowRoot?.querySelector("dialog")?.close();
   }
 
+  /** @param {ToggleEvent} event */
+  _toggle({ newState }) {
+    document.documentElement.classList.toggle(
+      "search-modal-open",
+      newState === "open",
+    );
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this._globalKeydown = this._globalKeydown.bind(this);
@@ -221,6 +229,7 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
     super.disconnectedCallback();
     this.renderRoot.removeEventListener("mouseover", this._loadIndex);
     document.removeEventListener("keydown", this._globalKeydown);
+    document.documentElement.classList.remove("search-modal-open");
   }
 
   _renderLoadingSearchIndex() {
@@ -237,7 +246,12 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
       ? `/${this.locale}/search?${new URLSearchParams({ q: this._query })}`
       : null;
     return html`
-      <dialog @keydown=${this._keydown} @focusin=${this._focus} closedby="any">
+      <dialog
+        @keydown=${this._keydown}
+        @focusin=${this._focus}
+        @toggle=${this._toggle}
+        closedby="any"
+      >
         <form
           method="get"
           action=${`/${this.locale}/search`}

--- a/components/search-modal/global.css
+++ b/components/search-modal/global.css
@@ -1,0 +1,4 @@
+:root.search-modal-open {
+  overflow: hidden;
+  scrollbar-gutter: stable;
+}

--- a/components/search-modal/global.css
+++ b/components/search-modal/global.css
@@ -1,4 +1,7 @@
-:root.search-modal-open {
-  overflow: hidden;
+:root {
   scrollbar-gutter: stable;
+
+  &.search-modal-open {
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update the `search-modal`, making the `<html>` element overflow when the dialog is open.

### Motivation

Avoid that scrolling on the backdrop scrolls the page content in the background.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/725.
