### PR TITLE
fix(blog-index): correct grid layout

### DIFF
--- a/components/blog-index/server.css
+++ b/components/blog-index/server.css
@@ -68,7 +68,7 @@
   display: grid;
 
   grid-template-rows: subgrid;
-  grid-row: span 6;
+  grid-row: span 5;
 
   padding: 2rem;
   margin-top: 2rem;
@@ -78,13 +78,6 @@
 }
 
 .blog-post-preview__header {
-  display: grid;
-
-  flex-direction: column;
-
-  grid-template-rows: subgrid;
-  grid-row: span 3;
-
   h2 {
     align-self: center;
 


### PR DESCRIPTION
### Description

Fixes blog layout bug in Safari. Chrome and Firefox are fine.

### Motivation

| Before | After |
| - | - |
| <img width="1728" height="1085" alt="desktop-before" src="https://github.com/user-attachments/assets/d57e39da-f4b9-4206-bd1d-5c1ad757cae2" /> | <img width="1728" height="1085" alt="desktop-after" src="https://github.com/user-attachments/assets/fad86878-4c15-4d8c-b78c-bf0c5780c14c" /> |
| <img width="575" height="1117" alt="mobile-before" src="https://github.com/user-attachments/assets/d83e6371-3ab1-4bc1-8280-6fd0d16a91f3" /> | <img width="575" height="1117" alt="mobile-after" src="https://github.com/user-attachments/assets/7ed155e0-62ae-42db-a9c6-da6167d4c188" /> |