### PR TITLE
test(e2e): increase timeout

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -28,7 +28,7 @@ export const config = {
   reporters: ["spec"],
   mochaOpts: {
     ui: "bdd",
-    timeout: 60_000,
+    timeout: 120_000,
   },
   baseUrl: `http://localhost:${FRED_PORT}/`,
   async before(_, __, browser) {


### PR DESCRIPTION
Relates to: https://github.com/mdn/fred/issues/1449

Windows is just exceptionally slow, so bumping the timeout should fix some of the flakiness.