### PR TITLE
chore(media): reorder width-first in two-part queries

### DIFF
--- a/components/media/index.css
+++ b/components/media/index.css
@@ -2,23 +2,23 @@
 
 @custom-media --screen-xsmall (width <= 426px);
 
-@custom-media --screen-small-and-wider (426px < width);
+@custom-media --screen-small-and-wider (width > 426px);
 @custom-media --screen-small-only (426px < width <= 769px);
 @custom-media --screen-small-and-narrower (width <= 769px);
 
-@custom-media --screen-medium-and-wider (769px < width);
+@custom-media --screen-medium-and-wider (width > 769px);
 @custom-media --screen-medium-only (769px < width <= 992px);
 @custom-media --screen-medium-and-narrower (width <= 992px);
 
-@custom-media --screen-large-and-wider (992px < width);
+@custom-media --screen-large-and-wider (width > 992px);
 @custom-media --screen-large-only (992px < width <= 1200px);
 @custom-media --screen-large-and-narrower (width <= 1200px);
 
-@custom-media --screen-xlarge-and-wider (1200px < width);
+@custom-media --screen-xlarge-and-wider (width > 1200px);
 @custom-media --screen-xlarge-only (1200px < width <= 1441px);
 @custom-media --screen-xlarge-and-narrower (width <= 1441px);
 
-@custom-media --screen-xxlarge (1441px < width);
+@custom-media --screen-xxlarge (width > 1441px);
 
 @custom-media --screen-menu-full (width > 1044px);
 @custom-media --screen-menu-hamburger (width <= 1044px);


### PR DESCRIPTION
### Description

Reorders two-part queries width-first.

### Motivation

It’s difficult to read number-first queries: “number less than variable” sounds like a riddle.

```diff
- 426px < width
+ width > 426px
```

Having width in the middle still makes sense in three-part queries: “variable is in between numbers”.

```
992px < width <= 1200px
```