### PR TITLE
fix(e2e): pin firefox version to stable

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -8,6 +8,7 @@ export const config = {
   capabilities: [
     {
       browserName: "firefox",
+      browserVersion: "stable",
       "moz:firefoxOptions": {
         args: ["-headless"],
       },


### PR DESCRIPTION
Relates to https://github.com/mdn/fred/issues/1449#issuecomment-4223528171

This appears to fix different Firefox versions being used across (and even within!) test runs, using `149.0.2` for everything - and should track the latest stable release over time.