### PR TITLE
ci(test): force color output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `test` workflow, setting the `FORCE_COLOR` environment variable to `1`.

### Motivation

Improve readability of test logs, especially in case of e2e failures (cf. https://github.com/mdn/fred/issues/1449).

### Additional details

| Before | After |
|--------|--------|
| <img width="859" height="638" alt="image" src="https://github.com/user-attachments/assets/f22966ec-ba56-4292-b7db-615fc9548a4a" /> | <img width="859" height="638" alt="image" src="https://github.com/user-attachments/assets/d0a6d88b-a16b-4eba-9864-95db01ded6f2" /> |
| <img width="859" height="642" alt="image" src="https://github.com/user-attachments/assets/035c5465-249b-4c0e-a86c-e6625944c20e" /> | <img width="859" height="642" alt="image" src="https://github.com/user-attachments/assets/8a84049e-63ba-45da-869d-ab334d695b63" /> | 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

