### PR TITLE
chore(l10n): add ja strings for 404 and page footer

### DIFF
--- a/l10n/locales/ja.ftl
+++ b/l10n/locales/ja.ftl
@@ -1,2 +1,22 @@
-blog-toc-title = この記事では
+article-footer-last-modified = このページが最後に更新されたのは <time data-l10n-name="date">{ $date }</time>で、<a data-l10n-name="contributors">MDN への貢献者によるものです</a>。
 
+blog-toc-title = この記事では
+contributor-spotlight-get-involved = 参加する
+homepage-hero-title = 開発者のための、<br>開発者によるリソース
+homepage-hero-description = 2005 年から <a data-l10n-name="css">CSS</a>, <a data-l10n-name="html">HTML</a>, そして <a data-l10n-name="js">JavaScript</a> についての文書を公開しています。
+not-found-title = ページが見つかりません
+not-found-description = 残念ながら、<code data-l10n-name="url">{ $url }</code> というページがありません。
+not-found-fallback-english = <strong data-l10n-name="strong">良いニュース:</strong> あなたがリクエストしたページの<em data-l10n-name="em">英語版</em>が存在します。
+not-found-fallback-search = リクエストされているページそのものは存在しませんが、サイト内検索をお試しください:
+article-footer-title = MDN をより良くするため手伝う
+article-footer-learn-how-to-contribute = 貢献する方法を学ぶ
+article-footer-view-this-page-on-github = このページを GitHub で見る
+article-footer-this-will-take-you-to-github-to = GitHub で 新しい issue を登録することができます。
+article-footer-report-a-problem-with-this-conte = このコンテンツについて問題を報告する
+
+content-feedback-question = このページは役に立ちましたか?
+content-feedback-yes = はい
+content-feedback-no = いいえ
+content-feedback-reason = なぜ役に立たなかったのか教えてもらえますか?
+content-feedback-submit = 送信
+content-feedback-thanks = あなたのフィードバックに感謝します!


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
This is initial commit to add Japanese translation to fred.
This PR includes ones for Not-Found-Page and footer shows in each page.

### Motivation
MDN front page and footers should have Japanese translation.
I saw German already has them.

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Relates https://github.com/mozilla-japan/translation/issues/871 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->