### PR TITLE
fix(sidebar-filter): remove only highlight spans on reset

### DIFF
--- a/components/curriculum/sidebar.css
+++ b/components/curriculum/sidebar.css
@@ -78,7 +78,7 @@
   }
 
   a,
-  span:not(.highlight-container) {
+  span:not(.sidebar-filter-mark-container) {
     display: inline-flex;
     padding-block: 0.25rem;
   }

--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -115,7 +115,7 @@
   }
 
   a,
-  span:not(.highlight-container) {
+  span:not(.sidebar-filter-mark-container) {
     display: inline-block;
     padding-block: 0.25rem;
     vertical-align: middle;

--- a/components/sidebar-filter/sidebar-filterer.js
+++ b/components/sidebar-filter/sidebar-filterer.js
@@ -154,7 +154,7 @@ export class SidebarFilterer {
    * @param {HTMLAnchorElement} link The link element to reset.
    */
   resetHighlighting(link) {
-    const nodes = [...link.querySelectorAll("span, mark")];
+    const nodes = [...link.querySelectorAll("span.highlight-container, mark")];
     const parents = new Set();
     for (const node of nodes) {
       const parent = node.parentElement;

--- a/components/sidebar-filter/sidebar-filterer.js
+++ b/components/sidebar-filter/sidebar-filterer.js
@@ -154,7 +154,9 @@ export class SidebarFilterer {
    * @param {HTMLAnchorElement} link The link element to reset.
    */
   resetHighlighting(link) {
-    const nodes = [...link.querySelectorAll("span.highlight-container, mark")];
+    const nodes = [
+      ...link.querySelectorAll("span.sidebar-filter-mark-container, mark"),
+    ];
     const parents = new Set();
     for (const node of nodes) {
       const parent = node.parentElement;
@@ -250,7 +252,7 @@ export class SidebarFilterer {
       );
 
       const span = this.replaceChildNode(node, "span");
-      span.className = "highlight-container";
+      span.className = "sidebar-filter-mark-container";
 
       /** @type {Text|undefined} */
       const initialRest = [...span.childNodes].find(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `sidebar-filter` component to target highlight `span`s by class name.

### Motivation

Prevents the component from removing unrelated `span`s.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/rari/pull/635#pullrequestreview-4139530470.

