### PR TITLE
chore(transcend): use TRANSCEND_AIRGAP_URL

### DIFF
--- a/components/env/index.js
+++ b/components/env/index.js
@@ -50,4 +50,4 @@ export const OBSERVATORY_API_URL = parseString(
 );
 
 // Transcend Consent Management - https://docs.transcend.io/docs/consent
-export const TRANSCEND_BUNDLE_ID = parseString("TRANSCEND_BUNDLE_ID", "");
+export const TRANSCEND_AIRGAP_URL = parseString("TRANSCEND_AIRGAP_URL", "");

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -6,7 +6,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import inlineScript from "../../entry.inline.js?source&csp=true";
 import {
   ROBOTS_GLOBAL_ALLOW,
-  TRANSCEND_BUNDLE_ID,
+  TRANSCEND_AIRGAP_URL,
   WRITER_MODE,
 } from "../env/index.js";
 import { RUNTIME_ENV, runtimeVariables } from "../env/runtime.js";
@@ -116,12 +116,12 @@ export class OuterLayout extends ServerComponent {
                 fetchpriority="low"
               />`,
           )}
-          ${TRANSCEND_BUNDLE_ID &&
+          ${TRANSCEND_AIRGAP_URL &&
           html`<script
             data-cfasync="false"
             data-report-only="on"
             data-prompt="0"
-            src=${`https://transcend-cdn.com/cm/${TRANSCEND_BUNDLE_ID}/airgap.js`}
+            src=${TRANSCEND_AIRGAP_URL}
           ></script>`}
           ${scripts?.map(
             (path) => html`<script src=${path} type="module"></script>`,


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the Transcend integration, using `TRANSCEND_AIRGAP_URL` instead of `TRANSCEND_BUNDLE_ID`.

### Motivation

Allow distinguishing stage and production environment.

### Additional details

Blocked by https://github.com/mdn/dex/pull/303.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1422.

Follow-up of https://github.com/mdn/fred/pull/1423.