### PR TITLE
ci(pr-build): run in fork PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository_owner == 'mdn' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.base.repo.owner.login == 'mdn' && github.event.pull_request.user.login != 'dependabot[bot]'
     uses: ./.github/workflows/_build.yml
     secrets: inherit
     with:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `pr-build` workflow, checking `github.event.pull_request.base.repo.owner.login` instead of `github.repository_owner`.

### Motivation

Ensure the workflow runs in fork PRs (like this one).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Triggered by https://github.com/mdn/fred/pull/1414.