### PR TITLE
feat(baseline-indicator): add renderSimplified method, avoid rendering repetitive links

### DIFF
--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -51,13 +51,11 @@ export class BaselineIndicator extends ServerComponent {
   static inlineScript = inlineScript;
 
   /**
-   * @param {import("@rari").Baseline} status
+   * @param {string | null | undefined} date
    */
-  parseDate(status) {
-    const lowDateRange = status.baseline_low_date?.match(/^([^0-9])/)?.[0];
-    return status.baseline_low_date
-      ? new Date(status.baseline_low_date.slice(lowDateRange ? 1 : 0))
-      : undefined;
+  parseDate(date) {
+    const lowDateRange = date?.match(/^([^0-9])/)?.[0];
+    return date ? new Date(date.slice(lowDateRange ? 1 : 0)) : undefined;
   }
 
   /**
@@ -109,7 +107,7 @@ export class BaselineIndicator extends ServerComponent {
       LOCALIZED_BCD_IDS[context.locale] || LOCALIZED_BCD_IDS[DEFAULT_LOCALE]
     }`;
 
-    const lowDate = this.parseDate(status);
+    const lowDate = this.parseDate(status.baseline_low_date);
     const level = status.baseline || "not";
 
     const feedbackLink = `${SURVEY_URL}?page=${encodeURIComponent(context.url)}&level=${level}`;
@@ -281,7 +279,7 @@ export class BaselineIndicator extends ServerComponent {
       return nothing;
     }
 
-    const lowDate = this.parseDate(status);
+    const lowDate = this.parseDate(status.baseline_low_date);
     const level = status.baseline || "not";
 
     return html`<p>

--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -51,7 +51,45 @@ export class BaselineIndicator extends ServerComponent {
   static inlineScript = inlineScript;
 
   /**
-   *
+   * @param {import("@rari").Baseline} status
+   */
+  parseDate(status) {
+    const lowDateRange = status.baseline_low_date?.match(/^([^0-9])/)?.[0];
+    return status.baseline_low_date
+      ? new Date(status.baseline_low_date.slice(lowDateRange ? 1 : 0))
+      : undefined;
+  }
+
+  /**
+   * @param {import("@fred").Context<import("@rari").DocPage>} context
+   * @param {string} level
+   * @param {Date} [lowDate]
+   */
+  getExtraText(context, level, lowDate) {
+    return level === "high" && lowDate
+      ? context.l10n.raw({
+          id: "baseline-high-extra",
+          args: {
+            date: lowDate.toLocaleDateString(context.locale, {
+              year: "numeric",
+              month: "long",
+            }),
+          },
+        })
+      : level === "low" && lowDate
+        ? context.l10n.raw({
+            id: "baseline-low-extra",
+            args: {
+              date: lowDate.toLocaleDateString(DEFAULT_LOCALE, {
+                year: "numeric",
+                month: "long",
+              }),
+            },
+          })
+        : context.l10n("baseline-not-extra");
+  }
+
+  /**
    * @param {import("@fred").Context<import("@rari").DocPage>} context
    */
   render(context) {
@@ -71,11 +109,7 @@ export class BaselineIndicator extends ServerComponent {
       LOCALIZED_BCD_IDS[context.locale] || LOCALIZED_BCD_IDS[DEFAULT_LOCALE]
     }`;
 
-    const low_date_range = status.baseline_low_date?.match(/^([^0-9])/)?.[0];
-    const low_date = status.baseline_low_date
-      ? new Date(status.baseline_low_date.slice(low_date_range ? 1 : 0))
-      : undefined;
-
+    const lowDate = this.parseDate(status);
     const level = status.baseline || "not";
 
     const feedbackLink = `${SURVEY_URL}?page=${encodeURIComponent(context.url)}&level=${level}`;
@@ -154,7 +188,7 @@ export class BaselineIndicator extends ServerComponent {
                     ? context.l10n(
                         "baseline-indicator-widely-available",
                       )`Widely available`
-                    : low_date?.getFullYear()}
+                    : lowDate?.getFullYear()}
                 </span>
                 ${status.asterisk && " *"}
               `}
@@ -191,31 +225,7 @@ export class BaselineIndicator extends ServerComponent {
         <span class="icon icon-chevron"></span>
       </summary>
       <div class="extra">
-        ${level === "high" && low_date
-          ? html`<p>
-              ${context.l10n.raw({
-                id: "baseline-high-extra",
-                args: {
-                  date: low_date.toLocaleDateString(context.locale, {
-                    year: "numeric",
-                    month: "long",
-                  }),
-                },
-              })}
-            </p>`
-          : level === "low" && low_date
-            ? html`<p>
-                ${context.l10n.raw({
-                  id: "baseline-low-extra",
-                  args: {
-                    date: low_date.toLocaleDateString(DEFAULT_LOCALE, {
-                      year: "numeric",
-                      month: "long",
-                    }),
-                  },
-                })}
-              </p>`
-            : html`<p>${context.l10n("baseline-not-extra")}</p>`}
+        <p>${this.getExtraText(context, level, lowDate)}</p>
         ${status.asterisk
           ? html`<p>* ${context.l10n("baseline-asterisk")}</p>`
           : nothing}
@@ -253,5 +263,51 @@ export class BaselineIndicator extends ServerComponent {
         </ul>
       </div>
     </details>`;
+  }
+
+  /**
+   * @param {import("@fred").Context<import("@rari").DocPage>} context
+   */
+  renderSimplified(context) {
+    const { doc } = context;
+
+    if (!doc) {
+      return nothing;
+    }
+
+    const status = doc.baseline;
+
+    if (!status) {
+      return nothing;
+    }
+
+    const lowDate = this.parseDate(status);
+    const level = status.baseline || "not";
+
+    return html`<p>
+      <strong>
+        ${level === "not"
+          ? context.l10n(
+              "baseline-indicator-limited-availability",
+            )`Limited availability`
+          : context.l10n("baseline-indicator-baseline")`Baseline`}
+        ${level === "high"
+          ? context.l10n(
+              "baseline-indicator-widely-available",
+            )`Widely available`
+          : level === "low"
+            ? html`${lowDate?.getFullYear()}
+              ${context.l10n(
+                "baseline-indicator-newly-available",
+              )`Newly available`}`
+            : nothing}
+        ${status.asterisk ? " *" : nothing}
+      </strong>
+      <br />
+      ${this.getExtraText(context, level, lowDate)}
+      ${status.asterisk
+        ? html`<br />* ${context.l10n("baseline-asterisk")}`
+        : nothing}
+    </p>`;
   }
 }


### PR DESCRIPTION
Currently most pages rendered to simplified HTML (and then markdown) have a lot of noise at the top, with Baseline learn more/feedback and BCD table links (and the BCD table isn't currently rendered, so the link is useless).

This adds a `renderSimplified` method, returning a simpler output. Extracts some common logic between the two render methods.

Tested locally with `FRED_SIMPLE_HTML=true npm start`:

http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
```
Baseline Widely available *
This feature is well established and works across many devices and browser versions. It’s been available across browsers since July 2015.
* Some parts of this feature may have varying levels of support.
```

http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length
```
Baseline Widely available
This feature is well established and works across many devices and browser versions. It’s been available across browsers since July 2015.
```

http://localhost:3000/en-US/docs/Web/API/CSS_Custom_Highlight_API
```
Baseline 2025 Newly available
Since June 2025, this feature works across the latest devices and browser versions. This feature might not work in older devices or browsers. 
```

http://localhost:3000/en-US/docs/Web/API/Speculation_Rules_API
```
Limited availability
This feature is not Baseline because it does not work in some of the most widely-used browsers. 
```