### PR TITLE
feat(bcd): render links to JSON in simplified HTML

### DIFF
--- a/components/bcd-section/server.js
+++ b/components/bcd-section/server.js
@@ -1,0 +1,48 @@
+import { html } from "@lit-labs/ssr";
+import { nothing } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { BCD_BASE_URL } from "../env/index.js";
+import { HeadingAnchor } from "../heading-anchor/server.js";
+import { ServerComponent } from "../server/index.js";
+
+export class BCDSection extends ServerComponent {
+  /**
+   * @param {import("@fred").Context} _context
+   * @param {import("@rari").Compat} section
+   */
+  render(_context, { id, title, query, isH3 }) {
+    const level = isH3 ? 3 : 2;
+    return html`<section
+      class="content-section"
+      aria-labelledby=${ifDefined(id ?? undefined)}
+    >
+      ${HeadingAnchor.render(level, id ? String(id) : null, String(title))}
+      <mdn-compat-table-lazy
+        locale="en-US"
+        query=${query}
+      ></mdn-compat-table-lazy>
+    </section>`;
+  }
+
+  /**
+   * @param {import("@fred").Context} _context
+   * @param {import("@rari").Compat} section
+   */
+  renderSimplified(_context, { id, title, query, isH3 }) {
+    return html`<section
+      class="content-section"
+      aria-labelledby=${ifDefined(id ?? undefined)}
+    >
+      ${isH3
+        ? nothing
+        : HeadingAnchor.render(2, id ? String(id) : null, String(title))}
+      <a
+        href="${BCD_BASE_URL}/bcd/api/v0/current/${query}.json"
+        target="_blank"
+        rel="noopener"
+        ><code>${query}</code></a
+      >
+    </section>`;
+  }
+}

--- a/components/compat-section/server.js
+++ b/components/compat-section/server.js
@@ -2,11 +2,11 @@ import { html } from "@lit-labs/ssr";
 import { nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-import { BCD_BASE_URL } from "../env/index.js";
+import { queryToUrl } from "../compat-table/utils.js";
 import { HeadingAnchor } from "../heading-anchor/server.js";
 import { ServerComponent } from "../server/index.js";
 
-export class BCDSection extends ServerComponent {
+export class CompatSection extends ServerComponent {
   /**
    * @param {import("@fred").Context} _context
    * @param {import("@rari").Compat} section
@@ -37,10 +37,7 @@ export class BCDSection extends ServerComponent {
       ${isH3
         ? nothing
         : HeadingAnchor.render(2, id ? String(id) : null, String(title))}
-      <a
-        href="${BCD_BASE_URL}/bcd/api/v0/current/${query}.json"
-        target="_blank"
-        rel="noopener"
+      <a href=${queryToUrl(query)} target="_blank" rel="noopener"
         ><code>${query}</code></a
       >
     </section>`;

--- a/components/compat-table-lazy/element.js
+++ b/components/compat-table-lazy/element.js
@@ -8,7 +8,7 @@ import {
   DEFAULT_LOCALE,
   ISSUE_METADATA_TEMPLATE,
 } from "../compat-table/constants.js";
-import { BCD_BASE_URL } from "../env/index.js";
+import { queryToUrl } from "../compat-table/utils.js";
 
 import styles from "./element.css?lit";
 
@@ -76,10 +76,7 @@ export class MDNCompatTableLazy extends L10nMixin(LitElement) {
   _dataTask = new Task(this, {
     args: () => [this.query],
     task: async ([query], { signal }) => {
-      const response = await fetch(
-        `${BCD_BASE_URL}/bcd/api/v0/current/${query}.json`,
-        { signal },
-      );
+      const response = await fetch(queryToUrl(query), { signal });
       if (!response.ok) {
         console.error("Failed to fetch BCD data:", response);
 

--- a/components/compat-table/utils.js
+++ b/components/compat-table/utils.js
@@ -1,3 +1,5 @@
+import { BCD_BASE_URL } from "../env/index.js";
+
 /**
  * A list of browsers to be hidden.
  * @constant {string[]}
@@ -292,4 +294,12 @@ export function getCurrentSupport(support) {
 
   // Default (likely never reached).
   return getFirst(support);
+}
+
+/**
+ * Get the URL to the JSON file for a given BCD key
+ * @param {string} query
+ */
+export function queryToUrl(query) {
+  return `${BCD_BASE_URL}/bcd/api/v0/current/${query}.json`;
 }

--- a/components/content-section/server.js
+++ b/components/content-section/server.js
@@ -2,6 +2,7 @@ import { html } from "@lit-labs/ssr";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
+import { BCDSection } from "../bcd-section/server.js";
 import { HeadingAnchor } from "../heading-anchor/server.js";
 import { ServerComponent } from "../server/index.js";
 import { SpecificationsList } from "../specifications-list/index.js";
@@ -10,12 +11,11 @@ export class ContentSection extends ServerComponent {
   /**
    * @param {import("@fred").Context} context
    * @param {import("@rari").Section} section
-   * @returns {import("@lit").TemplateResult}
    */
   render(context, { type, value }) {
     switch (type) {
       case "browser_compatibility": {
-        return BCD(value);
+        return BCDSection.render(context, value);
       }
       case "specifications": {
         return SpecificationsSection(context, value);
@@ -40,24 +40,6 @@ function Prose({ id, title, content, isH3 }) {
   >
     ${HeadingAnchor.render(level, id ? String(id) : null, String(title))}
     ${unsafeHTML(content)}
-  </section>`;
-}
-
-/**
- * @param {import("@rari").Compat} section
- * @returns {import("@lit").TemplateResult}
- */
-function BCD({ id, title, query, isH3 }) {
-  const level = isH3 ? 3 : 2;
-  return html`<section
-    class="content-section"
-    aria-labelledby=${ifDefined(id ?? undefined)}
-  >
-    ${HeadingAnchor.render(level, id ? String(id) : null, String(title))}
-    <mdn-compat-table-lazy
-      locale="en-US"
-      query=${query}
-    ></mdn-compat-table-lazy>
   </section>`;
 }
 

--- a/components/content-section/server.js
+++ b/components/content-section/server.js
@@ -2,7 +2,7 @@ import { html } from "@lit-labs/ssr";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
-import { BCDSection } from "../bcd-section/server.js";
+import { CompatSection } from "../compat-section/server.js";
 import { HeadingAnchor } from "../heading-anchor/server.js";
 import { ServerComponent } from "../server/index.js";
 import { SpecificationsList } from "../specifications-list/index.js";
@@ -15,7 +15,7 @@ export class ContentSection extends ServerComponent {
   render(context, { type, value }) {
     switch (type) {
       case "browser_compatibility": {
-        return BCDSection.render(context, value);
+        return CompatSection.render(context, value);
       }
       case "specifications": {
         return SpecificationsSection(context, value);


### PR DESCRIPTION
BCD sections are currently empty in the simplified HTML: this extracts the BCD section into its own server component, and renders a link to the JSON when in simplified mode.