### PR TITLE
fix(generic-doc): consolidate style

### DIFF
--- a/components/generic-content/server.css
+++ b/components/generic-content/server.css
@@ -1,4 +1,13 @@
 .generic-content {
+  h1 {
+    margin: 1rem 0;
+
+    font-size: var(--font-size-largest);
+    font-weight: normal;
+
+    line-height: var(--font-line-header);
+  }
+
   .content-section {
     h2 {
       margin: 4rem 0 0.5rem;

--- a/components/generic-content/server.css
+++ b/components/generic-content/server.css
@@ -1,4 +1,6 @@
 .generic-content {
+  margin-block-end: 3rem;
+
   h1 {
     margin: 1rem 0;
 

--- a/components/generic-layout/server.css
+++ b/components/generic-layout/server.css
@@ -1,13 +1,1 @@
 @import url("../layout/2-sidebars.css");
-
-/* Generic Layout */
-
-/* Content */
-.generic-layout__content {
-  padding-block: 2rem;
-}
-
-/* TOC */
-.generic-layout__toc {
-  padding-block: 2rem;
-}

--- a/components/generic-sidebar/server.css
+++ b/components/generic-sidebar/server.css
@@ -1,7 +1,6 @@
 .generic-sidebar {
   --color-accent: var(--color-blue-50);
   --color-background-accent: var(--color-background-blue);
-  --color-border-items: light-dark(var(--color-gray-80), var(--color-gray-20));
   margin-bottom: 2rem;
 
   .generic-sidebar__header {

--- a/components/generic-sidebar/server.css
+++ b/components/generic-sidebar/server.css
@@ -2,57 +2,52 @@
   --color-accent: var(--color-blue-50);
   --color-background-accent: var(--color-background-blue);
   --color-border-items: light-dark(var(--color-gray-80), var(--color-gray-20));
-  padding-block: 2rem;
   margin-bottom: 2rem;
 
   .generic-sidebar__header {
     h2 {
-      margin: 0 0 1rem;
+      padding: 0.75em 0;
+      margin: 0;
 
       font-size: var(--font-size-large);
       font-weight: var(--font-weight-normal);
 
       line-height: 1.2;
 
-      color: var(--color-text-secondary);
-
       letter-spacing: 1.5px;
     }
   }
 
   .generic-sidebar__list {
-    padding-left: 0;
-    font-size: var(--font-size-small);
+    padding: 0;
+    margin: 0;
     list-style: none;
   }
 
   .generic-sidebar__item {
     margin: 0;
+
+    &:not(:last-child) {
+      margin-bottom: 0.5rem;
+    }
   }
 
   .generic-sidebar__link {
     display: inline-block;
+    padding: 0.25em 0.5em;
+    color: var(--color-text-primary);
 
-    padding: 0.5rem 1rem;
+    &:hover {
+      color: var(--color-area-link);
+    }
 
-    color: var(--color-text-secondary);
-
-    text-decoration: none;
-
-    border-left: 2px solid var(--color-border-items);
-
-    &:hover,
-    &:active {
-      color: var(--color-accent);
+    &:not(:hover) {
+      text-decoration: none;
     }
 
     &[aria-current="true"] {
-      font-weight: var(--font-weight-bold);
-
       background-color: var(--color-background-accent);
       border-left: 2px solid var(--color-accent);
-      border-top-right-radius: 0.25rem;
-      border-bottom-right-radius: 0.25rem;
     }
   }
 

--- a/components/generic-toc/server.css
+++ b/components/generic-toc/server.css
@@ -1,20 +1,23 @@
 .generic-toc {
+  --color-accent: var(--color-blue-50);
+  --color-background-accent: var(--color-background-blue);
+  --color-border-items: light-dark(var(--color-gray-80), var(--color-gray-20));
+
   .generic-toc__header {
-    margin: 0 0 1rem;
+    padding: 0.75em 0;
+    margin: 0;
 
     font-size: var(--font-size-large);
     font-weight: var(--font-weight-normal);
 
     line-height: 1.2;
 
-    color: var(--color-text-secondary);
-
     letter-spacing: 1.5px;
   }
 
   .generic-toc__list {
-    padding-left: 0;
-    font-size: var(--font-size-small);
+    padding: 0;
+    margin: 0;
     list-style: none;
   }
 
@@ -25,26 +28,23 @@
   .generic-toc__link {
     display: inline-block;
 
-    padding: 0.5rem 1rem;
+    padding: 0.25em 0.5em;
 
-    color: var(--color-text-secondary);
+    color: inherit;
 
-    text-decoration: none;
+    box-shadow: -2px 0 0 var(--color-border-primary);
 
-    border-left: 2px solid var(--color-border-items);
+    &:not(:hover) {
+      text-decoration: none;
+    }
 
-    &:hover,
-    &:active {
-      color: var(--color-accent);
+    &:hover:not([aria-current="true"]) {
+      color: var(--color-link-normal);
     }
 
     &[aria-current="true"] {
-      font-weight: var(--font-weight-bold);
-
       background-color: var(--color-background-accent);
-      border-left: 2px solid var(--color-accent);
-      border-top-right-radius: 0.25rem;
-      border-bottom-right-radius: 0.25rem;
+      box-shadow: -2px 0 0 var(--color-accent);
     }
   }
 

--- a/components/generic-toc/server.css
+++ b/components/generic-toc/server.css
@@ -28,6 +28,7 @@
     display: inline-block;
 
     padding: 0.25em 0.5em;
+    margin-left: 2px;
 
     color: inherit;
 

--- a/components/generic-toc/server.css
+++ b/components/generic-toc/server.css
@@ -1,7 +1,6 @@
 .generic-toc {
   --color-accent: var(--color-blue-50);
   --color-background-accent: var(--color-background-blue);
-  --color-border-items: light-dark(var(--color-gray-80), var(--color-gray-20));
 
   .generic-toc__header {
     padding: 0.75em 0;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Consolidate styling of generic docs, aligning with reference pages, in particular in terms of the `<h1>` heading, the table of contents (TOC), and the sidebar.

### Motivation

Ensure the upcoming MCP page looks good, and recognizably similar to reference pages.

### Additional details

Eventually, we might want to merge the sidebar and TOC components, and this is an important step towards it.

| Page | Before | After |
|--------|--------|--------|
| MCP | <img width="3510" height="1964" alt="image" src="https://github.com/user-attachments/assets/11fb763b-35e6-4a2a-b9b5-b2e252d0ea54" /> | <img width="3510" height="1964" alt="image" src="https://github.com/user-attachments/assets/5972699e-4584-472b-b82b-44ab355bcdec" /> |
| Observatory FAQ | <img width="3510" height="1964" alt="image" src="https://github.com/user-attachments/assets/e9a094c6-170f-4d07-aba3-bb0c13002ebc" /> | <img width="3510" height="1964" alt="image" src="https://github.com/user-attachments/assets/47f33fda-c568-48b4-bb45-8e23e711597c" /> |

### Related issues and pull requests

Relates to https://github.com/mdn/generic-content/issues/30.

Triggered by https://github.com/mdn/generic-content/pull/31.