### PR TITLE
fix(content-section): add min-width to headers of properties table

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -174,6 +174,7 @@
       }
 
       th {
+        min-width: 25%;
         font-weight: var(--font-weight-bold);
         background-color: transparent;
       }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Add `min-width: 25%` to `th` of `.properties` tables (used in "Technical summary" section of HTML elements documentation). I tried `20%` but most headers would still wrap.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

The headers column was squished and text wrapped for no reason.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

I noticed while working on this that the properties table lack a top margin so there is no spacing with the "Technical summary" header (see attached image). I could fix in this PR or open another PR.

<img width="983" height="497" alt="image" src="https://github.com/user-attachments/assets/8a79dc36-b78c-4c2b-9dab-a7e5968927c6" />

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #969 

<!--
BEGIN_COMMIT_OVERRIDE
fix(content-section): add min-width to headers of properties table (#1534)
END_COMMIT_OVERRIDE
-->