### PR TITLE
fix(writer-mode): improve handling of _open route

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ import { Worker } from "node:worker_threads";
 import cookieParser from "cookie-parser";
 import express from "express";
 import { createProxyMiddleware } from "http-proxy-middleware";
-import openEditor from "open-editor";
+import { getEditorInfo } from "open-editor";
 
 import { FRED_BUILD_ROOT } from "./build/env.js";
 import {
@@ -204,7 +204,14 @@ export async function startServer() {
         console.log(
           `Attempting to open ${absolutePath} with ${process.env.EDITOR}`,
         );
-        openEditor([absolutePath]);
+        const { binary, arguments: args } = getEditorInfo([absolutePath]);
+        const child = spawn(binary, args, { detached: true, stdio: "ignore" });
+
+        child.on("error", (error) => {
+          console.error("Failed to open editor:", error);
+          return;
+        });
+        child.unref();
       }
       res.sendStatus(204);
     });

--- a/server.js
+++ b/server.js
@@ -191,7 +191,7 @@ export async function startServer() {
   );
 
   if (WRITER_MODE) {
-    app.get("/_open", async (req, _res) => {
+    app.get("/_open", async (req, res) => {
       const { filepath } = req.query;
       const { CONTENT_ROOT, CONTENT_TRANSLATED_ROOT } = process.env;
       if (typeof filepath === "string") {
@@ -201,8 +201,12 @@ export async function startServer() {
             : CONTENT_TRANSLATED_ROOT) || "",
           filepath,
         );
+        console.log(
+          `Attempting to open ${absolutePath} with ${process.env.EDITOR}`,
+        );
         openEditor([absolutePath]);
       }
+      res.sendStatus(204);
     });
   }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

* Return a status code (`204 no content`) as to not leave the connection dangling.
* Add a log in console when trying to open the editor.
* Spawn manually the process to open the editor so we can tap on errors and handle them without crashing the server.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

The route handling is incomplete at the moment, the connection is never closed, errors are not handled, and nothing is logged while this can be tricky to debug or investigate.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Closes #906

