### PR TITLE
fix(browserslist): add Firefox 115 ESR explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "Safari > 0 and last 2.5 years",
     "iOS > 0 and last 2.5 years",
     "Firefox ESR",
+    "Firefox 115",
     "not dead"
   ],
   "dependencies": {


### PR DESCRIPTION
Firefox 115 ESR is [being supported until August 2026](https://whattrainisitnow.com/release/?version=esr), but it recently dropped out of our browserslist query, so adding it back explicitly.

Before:
<img width="1280" height="955" alt="image" src="https://github.com/user-attachments/assets/cfd608b7-991a-40ca-9934-611b1b904e52" />


After:
<img width="1280" height="955" alt="image(1)" src="https://github.com/user-attachments/assets/b26769e3-e1ad-4862-9253-4015aed7c222" />


Relates to https://github.com/mdn/fred/issues/1544