### PR TITLE
fix(compat-table): revert report action to plain link

### DIFF
--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -224,16 +224,11 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
   }
 
   _renderIssueLink() {
-    const onClick = (/** @type {MouseEvent} */ event) => {
-      event.preventDefault();
-      window.open(this._issueUrl, "_blank", "noopener,noreferrer");
-    };
     const source_file = this.data.__compat?.source_file;
     return html`<div class="bc-on-github">
       <a
         class="bc-github-link external external-icon"
-        href="#"
-        @click=${onClick}
+        href=${this._issueUrl}
         target="_blank"
         rel="noopener noreferrer"
         title=${this.l10n(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the "Report problems with this compatibility data" from a JavaScript link to a plain link.

### Motivation

We changed this to prevent BCD issue spam, but we still get spam, yet it prevents opening the link using middle-click.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1421.