### PR TITLE
fix(content-section): decrease code paddings for headings

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -18,6 +18,10 @@
     margin: 1rem 0 0;
     font-weight: var(--font-weight-normal);
     line-height: var(--font-line-header);
+
+    code {
+      padding: 0 0.125em;
+    }
   }
 
   h2 {


### PR DESCRIPTION
### Description

Decreases code paddings for headings.

### Motivation

To avoid overlapping, [see the example](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API/Using_types#applying_different_cross-document_types_using_pageswap_and_pagereveal_events).

### Before/after

<img width="1640" height="1390" alt="headings" src="https://github.com/user-attachments/assets/bdda91c8-c14d-408e-9318-bee69a069e8e" />
