### PR TITLE
fix(l10n): correct compat-support-flags rendering across locales

### DIFF
--- a/l10n/fluent.js
+++ b/l10n/fluent.js
@@ -165,12 +165,45 @@ export class Fluent {
 
     /** @type {Error[]} */
     const errors = [];
-    const formatted = bundle?.formatPattern(message, args, errors);
+    const formatted = bundle?.formatPattern(
+      message,
+      /** @type {Record<string, import("@fluent/bundle").FluentVariable>} */ (
+        escapeArgs(args)
+      ),
+      errors,
+    );
     if (errors.length > 0) {
       console.error(errors);
     }
     return formatted;
   }
+}
+
+/**
+ * HTML-escape string-valued args so that variable substitution can't inject
+ * tags that confuse the downstream sanitizer. Only string values are touched
+ * so that Number/Date selectors keep working.
+ *
+ * @param {Record<string, unknown>} args
+ * @returns {Record<string, unknown>}
+ */
+function escapeArgs(args) {
+  /** @type {Record<string, unknown>} */
+  const out = {};
+  for (const [k, v] of Object.entries(args)) {
+    out[k] = typeof v === "string" ? escapeHtml(v) : v;
+  }
+  return out;
+}
+
+/**
+ * @param {string} s
+ */
+function escapeHtml(s) {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 /** @type {Map<string, Fluent>} */

--- a/l10n/fluent.js
+++ b/l10n/fluent.js
@@ -57,7 +57,7 @@ export class Fluent {
   /**
    * @param {string} id
    * @param {string} [attr]
-   * @param {Record<string, any>} [args]
+   * @param {Record<string, FluentVariable | undefined>} [args]
    * @param {Record<string, import("../types/fluent.js").Element>} [elements]
    * @returns {string | ReturnType<typeof unsafeHTML> | undefined}
    */
@@ -124,7 +124,7 @@ export class Fluent {
   /**
    * @param {string} id
    * @param {string} [attr]
-   * @param {Record<string, FluentVariable>} [args]
+   * @param {Record<string, FluentVariable | undefined>} [args]
    * @param {FluentBundle | undefined} [bundle]
    * @param {boolean} [us]
    * @returns {string | undefined}
@@ -179,14 +179,16 @@ export class Fluent {
  * tags that confuse the downstream sanitizer. Only string values are touched
  * so that Number/Date selectors keep working.
  *
- * @param {Record<string, import("@fluent/bundle").FluentVariable>} args
- * @returns {Record<string, import("@fluent/bundle").FluentVariable>}
+ * @param {Record<string, FluentVariable | undefined>} args
+ * @returns {Record<string, FluentVariable>}
  */
 function escapeArgs(args) {
-  /** @type {Record<string, import("@fluent/bundle").FluentVariable>} */
+  /** @type {Record<string, FluentVariable>} */
   const out = {};
   for (const [k, v] of Object.entries(args)) {
-    out[k] = typeof v === "string" ? escapeHtml(v) : v;
+    if (v !== undefined) {
+      out[k] = typeof v === "string" ? escapeHtml(v) : v;
+    }
   }
   return out;
 }
@@ -273,7 +275,7 @@ export default function getFluentContext(locale) {
   }
 
   /**
-   * @param {{ id: string, attr?: string, args?: Record<string, any>, elements?: Record<string, import("../types/fluent.js").Element> }} param0
+   * @param {{ id: string, attr?: string, args?: Record<string, FluentVariable | undefined>, elements?: Record<string, import("../types/fluent.js").Element> }} param0
    */
   l10n.raw = function ({ id, attr, args, elements }) {
     const fluent = getLocale(locale);

--- a/l10n/fluent.js
+++ b/l10n/fluent.js
@@ -5,7 +5,8 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import enUS_ftl from "./locales/en-US.ftl";
 
 /**
- * @import { AllowedTags } from "insane";
+ * @import { FluentVariable } from "@fluent/bundle"
+ * @import { AllowedTags } from "insane"
  */
 
 /** @type {Record<string, string>} */
@@ -123,7 +124,7 @@ export class Fluent {
   /**
    * @param {string} id
    * @param {string} [attr]
-   * @param {Record<string, any>} [args]
+   * @param {Record<string, FluentVariable>} [args]
    * @param {FluentBundle | undefined} [bundle]
    * @param {boolean} [us]
    * @returns {string | undefined}
@@ -165,13 +166,7 @@ export class Fluent {
 
     /** @type {Error[]} */
     const errors = [];
-    const formatted = bundle?.formatPattern(
-      message,
-      /** @type {Record<string, import("@fluent/bundle").FluentVariable>} */ (
-        escapeArgs(args)
-      ),
-      errors,
-    );
+    const formatted = bundle?.formatPattern(message, escapeArgs(args), errors);
     if (errors.length > 0) {
       console.error(errors);
     }
@@ -184,11 +179,11 @@ export class Fluent {
  * tags that confuse the downstream sanitizer. Only string values are touched
  * so that Number/Date selectors keep working.
  *
- * @param {Record<string, unknown>} args
- * @returns {Record<string, unknown>}
+ * @param {Record<string, import("@fluent/bundle").FluentVariable>} args
+ * @returns {Record<string, import("@fluent/bundle").FluentVariable>}
  */
 function escapeArgs(args) {
-  /** @type {Record<string, unknown>} */
+  /** @type {Record<string, import("@fluent/bundle").FluentVariable>} */
   const out = {};
   for (const [k, v] of Object.entries(args)) {
     out[k] = typeof v === "string" ? escapeHtml(v) : v;

--- a/l10n/locales/de.ftl
+++ b/l10n/locales/de.ftl
@@ -58,19 +58,19 @@ compat-support-altname = Alternativer Name: { $altname }
 compat-support-removed = Ab { $version } entfernt
 compat-support-see-impl-url = Siehe <a data-l10n-name="impl_url">{ $label }</a>
 compat-support-flags =
-    { NUMBER($has_added) ->
-        [one] Ab Version { $version_added }
-        *[other] { "" }
+    { $has_added ->
+        [1] Ab Version { $version_added }
+        *[0] { "" }
     }{ $has_last ->
-        [one]
-            { NUMBER($has_added) ->
-                *[zero] Bis { $versionLast } muss
-                [one] { " " }bis { $versionLast } muss
+        [1]
+            { $has_added ->
+                *[0] Bis { $versionLast } muss
+                [1] { " " }bis { $versionLast } muss
             }
-        *[zero]
-            { NUMBER($has_added) ->
-                *[zero] muss
-                [one] { " " }muss
+        *[0]
+            { $has_added ->
+                *[0] muss
+                [1] { " " }muss
             }
     }
     { " " }die Einstellung <code data-l10n-name="name">{ $flag_name }</code>{ " " }
@@ -78,17 +78,17 @@ compat-support-flags =
         *[preference] explizit festgelegt werden
         [runtime_flag] als Laufzeit-Flag explizit festgelegt werden
 
-    }{ NUMBER($has_value) ->
-        [one] { " " }auf <code data-l10n-name="value">{ $flag_value }</code>
-        *[other] { "" }
+    }{ $has_value ->
+        [1] { " " }auf <code data-l10n-name="value">{ $flag_value }</code>
+        *[0] { "" }
     }{ "." }
-    { NUMBER($has_pref_url) ->
-        [one]
+    { $has_pref_url ->
+        [1]
             { $flag_type ->
                 [preference] Um die Einstellungen in { $browser_name } zu ändern, besuchen Sie { $browser_pref_url }.
                 *[other] { "" }
             }
-        *[other] { "" }
+        *[0] { "" }
     }
 compat-legend-yes = { compat-support-full }
 compat-legend-partial = { compat-support-partial }

--- a/l10n/locales/en-US.ftl
+++ b/l10n/locales/en-US.ftl
@@ -91,33 +91,33 @@ compat-support-altname = Alternate name: { $altname }
 compat-support-removed = Removed in { $version } and later
 compat-support-see-impl-url = See <a data-l10n-name="impl_url">{ $label }</a>
 compat-support-flags =
-  { NUMBER($has_added) ->
-    [one] From version { $version_added }
-    *[other] {""}
+  { $has_added ->
+    [1] From version { $version_added }
+    *[0] {""}
   }{ $has_last ->
-    [one] { NUMBER($has_added) ->
-          *[zero] Until { $versionLast } users
-          [one] {" "}until { $versionLast } users
+    [1] { $has_added ->
+          *[0] Until { $versionLast } users
+          [1] {" "}until { $versionLast } users
       }
-    *[zero] { NUMBER($has_added) ->
-          *[zero] Users
-          [one] {" "}users
+    *[0] { $has_added ->
+          *[0] Users
+          [1] {" "}users
       }
   }
   {" "}must explicitly set the <code data-l10n-name="name">{ $flag_name }</code>{" "}
   { $flag_type ->
     *[preference] preference
     [runtime_flag] runtime flag
-  }{ NUMBER($has_value) ->
-    [one] {" "}to <code data-l10n-name="value">{ $flag_value }</code>
-    *[other] {""}
+  }{ $has_value ->
+    [1] {" "}to <code data-l10n-name="value">{ $flag_value }</code>
+    *[0] {""}
   }{"."}
-  { NUMBER($has_pref_url) ->
-    [one] { $flag_type ->
+  { $has_pref_url ->
+    [1] { $flag_type ->
       [preference] To change preferences in { $browser_name }, visit { $browser_pref_url }.
       *[other] {""}
     }
-    *[other] {""}
+    *[0] {""}
   }
 
 compat-legend = Legend

--- a/l10n/locales/fr.ftl
+++ b/l10n/locales/fr.ftl
@@ -52,19 +52,19 @@ compat-support-altname = Nom alternatif : { $altname }
 compat-support-removed = Supprimé en version { $version } et supérieure
 compat-support-see-impl-url = Voir <a data-l10n-name="impl_url">{ $label }</a>
 compat-support-flags =
-    { NUMBER($has_added) ->
-        [one] De la version { $version_added }
-       *[other] { "" }
+    { $has_added ->
+        [1] De la version { $version_added }
+       *[0] { "" }
     }{ $has_last ->
-        [one]
-            { NUMBER($has_added) ->
-               *[zero] Jusqu'à la version { $versionLast }, les utilisateur·ice·s
-                [one] { " " }jusqu'à { $versionLast }, les utilisateur·ice·s
+        [1]
+            { $has_added ->
+               *[0] Jusqu'à la version { $versionLast }, les utilisateur·ice·s
+                [1] { " " }jusqu'à { $versionLast }, les utilisateur·ice·s
             }
-       *[zero]
-            { NUMBER($has_added) ->
-               *[zero] Les utilisateur·ice·s
-                [one] {" "}les utilisateur·ice·s
+       *[0]
+            { $has_added ->
+               *[0] Les utilisateur·ice·s
+                [1] {" "}les utilisateur·ice·s
             }
     }
     { " " }doivent explicitement définir
@@ -73,17 +73,17 @@ compat-support-flags =
         [runtime_flag] l'indicateur d'exécution
     }
     { " " }<code data-l10n-name="name">{ $flag_name }</code>
-    { NUMBER($has_value) ->
-        [one] { " " }à <code data-l10n-name="value">{ $flag_value }</code>
-       *[other] { "" }
+    { $has_value ->
+        [1] { " " }à <code data-l10n-name="value">{ $flag_value }</code>
+       *[0] { "" }
     }{"."}
-    { NUMBER($has_pref_url) ->
-        [one]
+    { $has_pref_url ->
+        [1]
             { $flag_type ->
                 [preference] Pour changer vos préférences sur le navigateur { $browser_name }, visitez { $browser_pref_url }.
                *[other] { "" }
             }
-       *[other] { "" }
+       *[0] { "" }
     }
 compat-legend-yes = { compat-support-full }
 compat-legend-partial = { compat-support-partial }

--- a/l10n/locales/zh-CN.ftl
+++ b/l10n/locales/zh-CN.ftl
@@ -52,36 +52,36 @@ compat-support-altname = 备用名称：{ $altname }
 compat-support-removed = 已在 { $version } 及更高版本中移除
 compat-support-see-impl-url = 参见 <a data-l10n-name="impl_url">{ $label }</a>
 compat-support-flags =
-    { NUMBER($has_added) ->
-        [one] 自版本 { $version_added } 起
-       *[other] { "" }
+    { $has_added ->
+        [1] 自版本 { $version_added } 起
+       *[0] { "" }
     }{ $has_last ->
-        [one]
-            { NUMBER($has_added) ->
-               *[zero] 截至 { $versionLast }，用户
-                [one] { " " }截至 { $versionLast }，用户
+        [1]
+            { $has_added ->
+               *[0] 截至 { $versionLast }，用户
+                [1] { " " }截至 { $versionLast }，用户
             }
-       *[zero]
-            { NUMBER($has_added) ->
-               *[zero] 用户
-                [one] { " " }用户
+       *[0]
+            { $has_added ->
+               *[0] 用户
+                [1] { " " }用户
             }
     }
     { " " }必须显式将 <code data-l10n-name="name">{ $flag_name }</code>{ " " }
     { $flag_type ->
        *[preference] 首选项
         [runtime_flag] 运行时标志
-    }{ NUMBER($has_value) ->
-        [one] { " " }设置为 <code data-l10n-name="value">{ $flag_value }</code>
-       *[other] { "" }
+    }{ $has_value ->
+        [1] { " " }设置为 <code data-l10n-name="value">{ $flag_value }</code>
+       *[0] { "" }
     }{ "。" }
-    { NUMBER($has_pref_url) ->
-        [one]
+    { $has_pref_url ->
+        [1]
             { $flag_type ->
                 [preference] 要更改 { $browser_name } 中的首选项，请访问 { $browser_pref_url }。
                *[other] { "" }
             }
-       *[other] { "" }
+        *[0] { "" }
     }
 compat-legend-yes = { compat-support-full }
 compat-legend-partial = { compat-support-partial }

--- a/l10n/template.ftl
+++ b/l10n/template.ftl
@@ -56,36 +56,36 @@ compat-support-altname = Alternate name: { $altname }
 compat-support-removed = Removed in { $version } and later
 compat-support-see-impl-url = See <a data-l10n-name="impl_url">{ $label }</a>
 compat-support-flags =
-    { NUMBER($has_added) ->
-        [one] From version { $version_added }
-       *[other] { "" }
+    { $has_added ->
+        [1] From version { $version_added }
+       *[0] { "" }
     }{ $has_last ->
-        [one]
-            { NUMBER($has_added) ->
-               *[zero] Until { $versionLast } users
-                [one] { " " }until { $versionLast } users
+        [1]
+            { $has_added ->
+               *[0] Until { $versionLast } users
+                [1] { " " }until { $versionLast } users
             }
-       *[zero]
-            { NUMBER($has_added) ->
-               *[zero] Users
-                [one] { " " }users
+       *[0]
+            { $has_added ->
+               *[0] Users
+                [1] { " " }users
             }
     }
     { " " }must explicitly set the <code data-l10n-name="name">{ $flag_name }</code>{ " " }
     { $flag_type ->
        *[preference] preference
         [runtime_flag] runtime flag
-    }{ NUMBER($has_value) ->
-        [one] { " " }to <code data-l10n-name="value">{ $flag_value }</code>
-       *[other] { "" }
+    }{ $has_value ->
+        [1] { " " }to <code data-l10n-name="value">{ $flag_value }</code>
+       *[0] { "" }
     }{ "." }
-    { NUMBER($has_pref_url) ->
-        [one]
+    { $has_pref_url ->
+        [1]
             { $flag_type ->
                 [preference] To change preferences in { $browser_name }, visit { $browser_pref_url }.
                *[other] { "" }
             }
-       *[other] { "" }
+       *[0] { "" }
     }
 compat-legend-yes = { compat-support-full }
 compat-legend-partial = { compat-support-partial }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fixes two bugs in the BCD flag footnote rendering: a CLDR plural-rule mismatch in `compat-support-flags`, and HTML special chars in flag names breaking the sanitizer.

### Motivation

1. `has_added`/`has_last`/`has_value`/`has_pref_url` are boolean 0/1 args, but the FTL selectors used CLDR plural variants (`[one]` / `*[other]`). French (and others) treat 0 as `one`, so the wrong branch fired — producing extra text and a literal `{ $versionLast }`. Switch to exact-integer variants (`[1]` / `*[0]`).
2. Flag names like `<select> showPicker() method` got parsed by `insane` after Fluent substitution, eating content up to the next close tag (empty `<code>` element). HTML-escape string args before `formatPattern`.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1220.

Also resolves the residual variable-rendering quirk noted in https://github.com/mdn/fred/issues/1183.
