### PR TITLE
fix(content-section): display index in multiple columns

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -380,6 +380,22 @@
     }
   }
 
+  /* Alphabetical/grouped indexes (rari `CSS_Ref`, `ListGroups`, `APIListAlpha`, `css_ref_list`) */
+  .index {
+    columns: 18rem;
+    column-gap: 2rem;
+
+    h3 {
+      margin-top: 0;
+      break-after: avoid;
+    }
+
+    ul {
+      margin-top: 0.5rem;
+      break-inside: avoid;
+    }
+  }
+
   /* Article footer */
   &.article-footer {
     margin: 2rem 0;

--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -382,16 +382,12 @@
 
   /* Alphabetical/grouped indexes (rari `CSS_Ref`, `ListGroups`, `APIListAlpha`, `css_ref_list`) */
   .index {
-    columns: 18rem;
-    column-gap: 2rem;
-
-    h3 {
-      margin-top: 0;
-      break-after: avoid;
+    ul {
+      columns: 18rem;
+      column-gap: 2rem;
     }
 
-    ul {
-      margin-top: 0.5rem;
+    li {
       break-inside: avoid;
     }
   }


### PR DESCRIPTION
### Description

Updates the `content-section` style for index lists (`.index`) to use multiple columns, according to space.

### Motivation

Restore the layout from Yari times, reducing the length of the page.

### Additional details

Rather than fixing the column count, we use a minimum column width.

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/779.