### PR TITLE
ci(dependabot): group some major updates by scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,27 @@ updates:
           - patch
         exclude-patterns:
           - "@mdn/*"
+      codemirror:
+        patterns:
+          - "@codemirror/*"
+        update-types:
+          - major
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+        update-types:
+          - major
+      rspack:
+        patterns:
+          - "@rspack/*"
+        update-types:
+          - major
+      wdio:
+        patterns:
+          - "@wdio/*"
+        update-types:
+          - major
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
### Description

Updates the Dependabot config, grouping major updates of `@codemirror/*`, `@eslint/*`/`eslint`, `@rspack/*`, and `@wdio/*`.

### Motivation

Ensure related breaking changes within each scope land together in a single PR, reducing manual effort to merge them, and making upgrades easier.


### Related issues and pull requests

The current case is Rspack 2:

- https://github.com/mdn/fred/pull/1574
- https://github.com/mdn/fred/pull/1575