### PR TITLE
ci(workflows): add needs-triage workflow

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,16 @@
+name: needs-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    if: github.repository_owner == 'mdn'
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds new `needs-triage` workflow which labels all opened/transferred/reopened issues with "needs triage".

### Motivation

Ensure all issues get triaged.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1564.
