### PR TITLE
chore(tests): move from args to commands in cli

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -121,4 +121,4 @@ jobs:
           # Increase GitHub API limit.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm test -- --e2e --content ../content --no-unit --no-lint
+          npm test -- e2e --content ../content

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run unit tests
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm test -- --unit --no-lint
+        run: npm test -- unit
 
       - name: Build
         run: npm run build
@@ -96,4 +96,4 @@ jobs:
         env:
           CONTENT_ROOT: ../content/files
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm test -- --no-unit --e2e --fred preview --rari --no-lint
+        run: npm test -- e2e --fred preview --rari

--- a/scripts/tests.js
+++ b/scripts/tests.js
@@ -1,126 +1,103 @@
+import { execSync } from "node:child_process";
+
 import { rariBin } from "@mdn/rari";
 import { concurrently } from "concurrently";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-const argv = await yargs(hideBin(process.argv))
-  .option("lint", {
-    describe: "run linters",
-    type: "boolean",
-    default: true,
-  })
-  .option("unit", {
-    describe: "run unit tests",
-    type: "boolean",
-    default: true,
-  })
-  .option("e2e", {
-    describe: "run e2e tests",
-    type: "boolean",
-    default: false,
-  })
-  .option("rari", {
-    describe: "run rari",
-    type: "boolean",
-    default: false,
-  })
-  .option("fred", {
-    describe: "run fred in this mode",
-    type: "string",
-    choices: ["preview", "dev"],
-  })
-  .option("content", {
-    describe: "run fred and rari from this content repo",
-    type: "string",
-  })
-  .check((argv) => {
-    if (argv.content && (argv.rari || argv.fred)) {
-      throw new Error("--content cannot be used with --rari or --fred");
+await yargs(hideBin(process.argv))
+  .command("lint", "run linters", {}, () => {
+    try {
+      execSync(`npx lefthook run --force pre-push`, { stdio: "inherit" });
+    } catch {
+      process.exitCode = 1;
     }
-    return true;
   })
-  .parse();
+  .command("unit", "run unit tests", {}, () => {
+    try {
+      execSync(`node --test "**/*.test.js"`, { stdio: "inherit" });
+    } catch {
+      process.exitCode = 1;
+    }
+  })
+  .command(
+    "e2e",
+    "run e2e tests",
+    (yargs) =>
+      yargs
+        .option("rari", {
+          describe: "run rari",
+          type: "boolean",
+          default: false,
+        })
+        .option("fred", {
+          describe: "run fred in this mode",
+          type: "string",
+          choices: ["preview", "dev"],
+        })
+        .option("content", {
+          describe: "run fred and rari from this content repo",
+          type: "string",
+        })
+        .check((argv) => {
+          if (argv.content && (argv.rari || argv.fred)) {
+            throw new Error("--content cannot be used with --rari or --fred");
+          }
+          return true;
+        }),
+    async (argv) => {
+      /** @type {import("concurrently").ConcurrentlyCommandInput[]} */
+      const jobs = [
+        {
+          command: `npx wdio run wdio.conf.js`,
+          name: "wdio",
+          prefixColor: "green",
+        },
+      ];
 
-const runs = [];
+      if (argv.content) {
+        jobs.push({
+          cwd: argv.content,
+          command: `npm start`,
+          name: "content",
+          prefixColor: "blue",
+        });
+      }
 
-if (argv.lint) {
-  runs.push(
-    concurrently([
-      {
-        command: `npx lefthook run --force pre-push`,
-        name: "lint",
-        prefixColor: "cyan",
-      },
-    ]).result,
-  );
-}
+      if (argv.fred === "preview") {
+        jobs.push({
+          command: `npm run preview`,
+          name: "server",
+          prefixColor: "red",
+        });
+      }
 
-if (argv.unit) {
-  runs.push(
-    concurrently([
-      {
-        command: `node --test "**/*.test.js"`,
-        name: "unit",
-        prefixColor: "yellow",
-      },
-    ]).result,
-  );
-}
+      if (argv.fred === "dev") {
+        jobs.push({
+          command: `npm run dev`,
+          name: "server",
+          prefixColor: "red",
+        });
+      }
 
-if (argv.e2e) {
-  /** @type {import("concurrently").ConcurrentlyCommandInput[]} */
-  const jobs = [
-    {
-      command: `npx wdio run wdio.conf.js`,
-      name: "wdio",
-      prefixColor: "green",
+      if (argv.rari) {
+        jobs.push({
+          command: `"${rariBin}" serve`,
+          name: "rari",
+          prefixColor: "blue",
+        });
+      }
+
+      try {
+        await concurrently(jobs, {
+          killOthersOn: ["failure", "success"],
+          restartTries: 0,
+          successCondition: "first",
+        }).result;
+      } catch {
+        process.exitCode = 1;
+      }
     },
-  ];
-
-  if (argv.content) {
-    jobs.push({
-      cwd: argv.content,
-      command: `npm start`,
-      name: "content",
-      prefixColor: "blue",
-    });
-  }
-
-  if (argv.fred === "preview") {
-    jobs.push({
-      command: `npm run preview`,
-      name: "server",
-      prefixColor: "red",
-    });
-  }
-
-  if (argv.fred === "dev") {
-    jobs.push({
-      command: `npm run dev`,
-      name: "server",
-      prefixColor: "red",
-    });
-  }
-
-  if (argv.rari) {
-    jobs.push({
-      command: `"${rariBin}" serve`,
-      name: "rari",
-      prefixColor: "blue",
-    });
-  }
-
-  runs.push(
-    concurrently(jobs, {
-      killOthersOn: ["failure", "success"],
-      restartTries: 0,
-      successCondition: "first",
-    }).result,
-  );
-}
-
-try {
-  await Promise.all(runs);
-} catch {
-  process.exitCode = 1;
-}
+  )
+  .demandCommand()
+  .parseAsync();

--- a/test/README.md
+++ b/test/README.md
@@ -2,28 +2,26 @@
 
 ## Running tests
 
-Tests can be run through the test running script: `npm test`.
+Tests can be run through the test running script: `npm test -- <command>`.
 
-View its options with: `npm test -- --help`.
-
-Options are default on or off depending on whether they need a specific environment setup to run. E.g. the e2e tests don't run by default because you need to run a rari and fred server.
+View available commands with: `npm test -- --help`.
 
 ### Examples
 
-To run only unit tests:
+To run unit tests:
 
 ```
-npm test -- --lint false
+npm test -- unit
 ```
 
 To run e2e tests against already running fred and rari servers:
 
 ```
-npm test -- --e2e
+npm test -- e2e
 ```
 
-To only run e2e tests and bring up a fred dev server and rari server:
+To run e2e tests and bring up a fred dev server and rari server:
 
 ```
-npm test -- --lint false --unit false --e2e --fred dev --rari
+npm test -- e2e --fred dev --rari
 ```


### PR DESCRIPTION
Would recommend reviewing [with whitespace changes hidden](https://github.com/mdn/fred/pull/1590/changes?w=1)

Relates to https://github.com/mdn/fred/pull/1588:

> Converting the test cli to use commands, and merging the visual-report cli in: using a long string of options makes the command hard to use, and complicates implementation

I think my original idea was to have a single "test" command to run everything locally, but the existing behaviour wasn't giving that, and made life more complicated, requiring me to have a separate command for generating the visual report which I'll merge into the commands here (which PR that happens on depends on which gets merged first!)

This will also make further follow-ups simpler, like being able to run a single test, and some kind of watch mode.

If we need a "run everything" mode we can always add that as another or the default command.