### PR TITLE
fix(compat-table): support arbitrary nesting depth

### DIFF
--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -456,7 +456,11 @@ export class MDNCompatTable extends L10nMixin(LitElement) {
       });
 
       return html`<tr>
-        <th class=${`bc-feature bc-feature-depth-${depth}`} scope="row">
+        <th
+          class="bc-feature"
+          style=${`--compat-feature-depth: ${depth}`}
+          scope="row"
+        >
           ${titleNode}
         </th>
         ${browserCells}

--- a/components/compat-table/index-common.css
+++ b/components/compat-table/index-common.css
@@ -207,19 +207,16 @@ table {
     text-align: left;
 
     border: none;
+    border-left: max(
+        0px,
+        calc((var(--compat-feature-depth, 1) - 1) * 8px - 1px)
+      )
+      solid var(--color-border-primary);
 
     > * {
       flex-basis: max-content;
       border: none !important;
     }
-  }
-
-  .bc-feature-depth-2 {
-    border-left: 7px solid var(--color-border-primary);
-  }
-
-  .bc-feature-depth-3 {
-    border-left: 15px solid var(--color-border-primary);
   }
 }
 


### PR DESCRIPTION
### Description

Updates the `compat-table` to indent nested features programmatically using a new `--compat-feature-depth` CSS variable.

### Motivation

Ensure nested features are recognizable as such.

### Additional details

| Before | After |
|--------|--------|
| <img width="795" height="803" alt="image" src="https://github.com/user-attachments/assets/c919a53a-5b13-4e5c-b57a-8bd16fe149d3" /> | <img width="795" height="803" alt="image" src="https://github.com/user-attachments/assets/f0452fd9-a09d-4994-b8ca-82a201bf36de" /> | 

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1578.
