### PR TITLE
chore(outer-layout): skip Transcend snippet on Playground

### DIFF
--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -117,6 +117,7 @@ export class OuterLayout extends ServerComponent {
               />`,
           )}
           ${TRANSCEND_AIRGAP_URL &&
+          context.renderer !== "SpaPlay" &&
           html`<script
             data-cfasync="false"
             data-report-only="on"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `outer-layout` component to not insert the Transcend snippet in the Playground.

### Motivation

Check hypothesis that the Playground is the cause for regular "junk" cookies/data flaws.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #1609.