### PR TITLE
fix(playground): "false" shown at top of page

### DIFF
--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -116,14 +116,14 @@ export class OuterLayout extends ServerComponent {
                 fetchpriority="low"
               />`,
           )}
-          ${TRANSCEND_AIRGAP_URL &&
-          context.renderer !== "SpaPlay" &&
-          html`<script
-            data-cfasync="false"
-            data-report-only="on"
-            data-prompt="0"
-            src=${TRANSCEND_AIRGAP_URL}
-          ></script>`}
+          ${TRANSCEND_AIRGAP_URL && context.renderer !== "SpaPlay"
+            ? html`<script
+                data-cfasync="false"
+                data-report-only="on"
+                data-prompt="0"
+                src=${TRANSCEND_AIRGAP_URL}
+              ></script>`
+            : nothing}
           ${scripts?.map(
             (path) => html`<script src=${path} type="module"></script>`,
           )}


### PR DESCRIPTION
this is because, with TRANSCEND_AIRGAP_URL set,
`context.renderer !== "SpaPlay"` evaluates to false,
and that's stringified and rendered to the page

use a ternary and render `nothing` instead

## Before

<img width="1366" height="768" alt="Screen Shot 2026-06-02 at 10 18 34" src="https://github.com/user-attachments/assets/9ab0c3b2-5202-4354-b047-40a37504d203" />

## After

<img width="1366" height="768" alt="Screen Shot 2026-06-02 at 10 20 36" src="https://github.com/user-attachments/assets/0e7aebc1-dcc2-48df-a021-c364ea8bfe47" />


