### PR TITLE
fix(lit-analyzer): fix missing imports, fail in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         run: npx eslint .
 
       - name: Run lit-analyzer
-        run: npm run lit-analyzer -- components
+        run: npm run lit-analyzer
 
       - name: Run stylelint
         run: npx stylelint '**/*.css' || (exit_code=$? && (npx stylelint --fix '**/*.css' || true) && git diff --color && exit $exit_code)

--- a/components/interactive-example/with-choices.js
+++ b/components/interactive-example/with-choices.js
@@ -9,6 +9,7 @@ import { randomIdString } from "../utils/index.js";
 
 import { isCSSSupported } from "./utils.js";
 
+import "../button/element.js";
 import "../play-controller/element.js";
 import "../play-runner/element.js";
 

--- a/components/interactive-example/with-console.js
+++ b/components/interactive-example/with-console.js
@@ -3,6 +3,7 @@ import { html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
+import "../button/element.js";
 import "../play-controller/element.js";
 import "../play-editor/element.js";
 import "../play-runner/element.js";

--- a/components/interactive-example/with-tabs.js
+++ b/components/interactive-example/with-tabs.js
@@ -2,6 +2,7 @@ import { decode } from "he";
 import { html } from "lit";
 import { ref } from "lit/directives/ref.js";
 
+import "../button/element.js";
 import "../play-controller/element.js";
 import "../play-editor/element.js";
 import "../play-runner/element.js";

--- a/components/language-always-redirect-button/element.js
+++ b/components/language-always-redirect-button/element.js
@@ -3,6 +3,8 @@ import { LitElement, html } from "lit";
 import { gleanClick } from "../../utils/glean.js";
 import { setPreferredLocale } from "../preferred-locale/utils.js";
 
+import "../button/element.js";
+
 export class MDNLanguageAlwaysRedirectButton extends LitElement {
   static properties = {
     locale: { type: String },

--- a/components/language-switcher/element.js
+++ b/components/language-switcher/element.js
@@ -14,6 +14,7 @@ import {
 
 import styles from "./element.css?lit";
 
+import "../button/element.js";
 import "../dropdown/element.js";
 import "../switch/element.js";
 

--- a/components/observatory-results/comparison.js
+++ b/components/observatory-results/comparison.js
@@ -1,5 +1,7 @@
 import { html } from "lit";
 
+import "../observatory-comparison-table/element.js";
+
 /**
  *
  * @param {{result: import("@observatory").Result}} result

--- a/components/observatory-results/rating.js
+++ b/components/observatory-results/rating.js
@@ -6,6 +6,7 @@ import { Tooltip } from "./tooltip.js";
 import { Trend } from "./trend.js";
 
 import "../observatory-rescan-button/element.js";
+import "../observatory-human-duration/element.js";
 import "../dropdown/element.js";
 
 /**

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -10,6 +10,8 @@ import exitIcon from "../icon/cancel.svg?lit";
 
 import styles from "./element.css?lit";
 
+import "../button/element.js";
+
 export class MDNSearchModal extends L10nMixin(LitElement) {
   static ssr = false;
   static styles = styles;

--- a/components/sidebar-filter/element.js
+++ b/components/sidebar-filter/element.js
@@ -11,6 +11,8 @@ import cancelIcon from "../icon/cancel.svg?lit";
 import styles from "./element.css?lit";
 import { SidebarFilterer } from "./sidebar-filterer.js";
 
+import "../button/element.js";
+
 class MDNSidebarFilter extends L10nMixin(LitElement) {
   static styles = styles;
 

--- a/components/user-menu/element.js
+++ b/components/user-menu/element.js
@@ -12,6 +12,7 @@ import { globalUser } from "../user/context.js";
 import styles from "./element.css?lit";
 
 import "../button/element.js";
+import "../dropdown/element.js";
 
 export class MDNUserMenu extends L10nMixin(LitElement) {
   static ssr = false;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rspack build",
     "preview": "NODE_ENV=production node ./server.js",
     "ssr": "node build/ssr.js",
-    "lit-analyzer": "npx @jackolope/lit-analyzer --rules.no-incompatible-type-binding off",
+    "lit-analyzer": "node scripts/lit-analyzer.js",
     "test": "node scripts/tests.js",
     "tsc": "tsc",
     "rari": "rari",

--- a/scripts/lit-analyzer.js
+++ b/scripts/lit-analyzer.js
@@ -1,0 +1,27 @@
+import { concurrently } from "concurrently";
+
+/** @type {import("concurrently").ConcurrentlyCommandInput[]} */
+const jobs = [
+  {
+    command: `npx @jackolope/lit-analyzer 'components/**/!(server|sandbox).js'`,
+    name: "client",
+    prefixColor: "green",
+  },
+  // `server.js`/`sandbox.js` are server-rendered and the client loads elements by
+  // tag name, so they don't import the elements they reference; `no-missing-import`
+  // is disabled for them. The `element.js` files are included only so their
+  // custom-element definitions are in scope, which keeps `no-unknown-tag-name` able
+  // to catch genuine typos rather than flag every `mdn-*` tag as unknown (their own
+  // diagnostics come from the client pass).
+  {
+    command: `npx @jackolope/lit-analyzer --rules.no-missing-import off 'components/**/@(server|sandbox|element).js'`,
+    name: "ssr",
+    prefixColor: "blue",
+  },
+];
+
+try {
+  await concurrently(jobs, { group: true }).result;
+} catch {
+  process.exitCode = 1;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,13 @@
     "plugins": [
       {
         "name": "@jackolope/ts-lit-plugin",
-        "strict": true
+        "strict": true,
+        "rules": {
+          "no-missing-import": "error",
+          "no-unknown-tag-name": "error",
+          "no-incompatible-type-binding": "off",
+          "no-unknown-attribute": "off"
+        }
       }
     ]
   },


### PR DESCRIPTION
Part of https://github.com/mdn/fred/issues/1629

- Migrates the inline `--rules.no-incompatible-type-binding off` config to `tsconfig.json`
- Adds `"no-unknown-attribute": "off"` as lit-analyzer can't detect our attributes automatically, we need to add jsdoc hints: to be done in a follow-up PR
- Makes `no-missing-import` and `no-unknown-tag-name` errors so they fail in CI
- Splits command into a script which runs a different config against client and server
  - Server config disables `no-missing-import` as we automatically import all components in the SSR bundle
- Fixes all the errors (in the second commit)
