### PR TITLE
fix(components): correct invalid attributes

### DIFF
--- a/components/about-tabs/element.js
+++ b/components/about-tabs/element.js
@@ -5,9 +5,11 @@ import styles from "./element.css?lit";
 export class MDNAboutTabs extends LitElement {
   static styles = styles;
 
-  static properties = {
-    active_index: { type: Number },
-  };
+  static get properties() {
+    return {
+      active_index: { type: Number },
+    };
+  }
 
   constructor() {
     super();

--- a/components/advertising/server.js
+++ b/components/advertising/server.js
@@ -52,7 +52,7 @@ export class Advertising extends ServerComponent {
                 <ul class="sing__stats">
                   ${STATS.map(
                     (s) => html`
-                      <li key=${s.id}>
+                      <li>
                         <span class="sing__number">${s.number}</span>
                         <span class="sing__legend">${s.legend}</span>
                       </li>

--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -217,16 +217,11 @@ export class BaselineIndicator extends ServerComponent {
           : nothing}
         <div class="browsers">
           ${ENGINES.map(
-            ({ name, browsers }) =>
-              html`<span
-                key=${name}
-                class="engine"
-                title=${engineTitle(browsers)}
-              >
+            ({ browsers }) =>
+              html`<span class="engine" title=${engineTitle(browsers)}>
                 ${browsers.map(
                   (browser) =>
                     html`<span
-                      key=${browser.ids[0]}
                       class=${`browser ${browser.ids[0]} ${
                         isBrowserSupported(browser) ? "supported" : ""
                       }`}

--- a/components/button/element.js
+++ b/components/button/element.js
@@ -6,17 +6,19 @@ import Button from "./pure.js";
 export class MDNButton extends LitElement {
   static styles = styles;
 
-  static properties = {
-    disabled: { type: Boolean },
-    variant: { type: String },
-    action: { type: String },
-    icon: { state: true },
-    iconOnly: { type: Boolean, attribute: "icon-only" },
-    iconPosition: { type: String, attribute: "icon-position" },
-    href: { type: String },
-    target: { type: String },
-    rel: { type: String },
-  };
+  static get properties() {
+    return {
+      disabled: { type: Boolean },
+      variant: { type: String },
+      action: { type: String },
+      icon: { state: true },
+      iconOnly: { type: Boolean, attribute: "icon-only" },
+      iconPosition: { type: String, attribute: "icon-position" },
+      href: { type: String },
+      target: { type: String },
+      rel: { type: String },
+    };
+  }
 
   constructor() {
     super();

--- a/components/code-example/element.js
+++ b/components/code-example/element.js
@@ -17,10 +17,12 @@ const LANGUAGE_CLASSES = new Set(["html", "js", "css", "wat"]);
 export class MDNCodeExample extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    language: { type: String },
-    code: { type: String },
-  };
+  static get properties() {
+    return {
+      language: { type: String },
+      code: { type: String },
+    };
+  }
 
   constructor() {
     super();

--- a/components/collection-save-button/element.js
+++ b/components/collection-save-button/element.js
@@ -16,13 +16,15 @@ export class MDNCollectionSaveButton extends L10nMixin(LitElement) {
   static ssr = false;
   static styles = styles;
 
-  static properties = {
-    docUrl: { type: String, attribute: "doc-url" },
-    docTitle: { type: String, attribute: "doc-title" },
-    _item: { state: true },
-    _pending: { state: true },
-    _lastAction: { state: true },
-  };
+  static get properties() {
+    return {
+      docUrl: { type: String, attribute: "doc-url" },
+      docTitle: { type: String, attribute: "doc-title" },
+      _item: { state: true },
+      _pending: { state: true },
+      _lastAction: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/color-theme/element.js
+++ b/components/color-theme/element.js
@@ -10,9 +10,11 @@ import "../dropdown/element.js";
 export class MDNColorTheme extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    _mode: { state: true },
-  };
+  static get properties() {
+    return {
+      _mode: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/compat-table-lazy/element.js
+++ b/components/compat-table-lazy/element.js
@@ -19,10 +19,12 @@ import styles from "./element.css?lit";
 export class MDNCompatTableLazy extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    query: {},
-    locale: {},
-  };
+  static get properties() {
+    return {
+      query: {},
+      locale: {},
+    };
+  }
 
   constructor() {
     super();

--- a/components/compat-table/element.js
+++ b/components/compat-table/element.js
@@ -63,16 +63,18 @@ function browserToIconName(browser) {
 }
 
 export class MDNCompatTable extends L10nMixin(LitElement) {
-  static properties = {
-    query: {},
-    locale: {},
-    data: {},
-    browserInfo: { attribute: "browserinfo" },
-    _pathname: { state: true },
-    _platforms: { state: true },
-    _browsers: { state: true },
-    _showTimelineId: { state: true },
-  };
+  static get properties() {
+    return {
+      query: {},
+      locale: {},
+      data: {},
+      browserInfo: { attribute: "browserinfo" },
+      _pathname: { state: true },
+      _platforms: { state: true },
+      _browsers: { state: true },
+      _showTimelineId: { state: true },
+    };
+  }
 
   static styles = styles;
 

--- a/components/content-feedback/element.js
+++ b/components/content-feedback/element.js
@@ -17,11 +17,13 @@ import styles from "./element.css?lit";
 export class MDNContentFeedback extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    locale: { type: String },
-    _reason: { state: true },
-    _view: { state: true },
-  };
+  static get properties() {
+    return {
+      locale: { type: String },
+      _reason: { state: true },
+      _view: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/contributor-list/element.js
+++ b/components/contributor-list/element.js
@@ -7,9 +7,11 @@ import styles from "./element.css?lit";
 export class MDNContributorList extends LitElement {
   static ssr = false;
 
-  static properties = {
-    _contributors: { state: true },
-  };
+  static get properties() {
+    return {
+      _contributors: { state: true },
+    };
+  }
 
   static styles = styles;
 

--- a/components/copy-button/element.js
+++ b/components/copy-button/element.js
@@ -5,11 +5,13 @@ import { MDNButton } from "../button/element.js";
 import check from "../icon/check.svg?lit";
 
 export class MDNCopyButton extends L10nMixin(LitElement) {
-  static properties = {
-    variant: {},
-    _message: { state: true },
-    _copiedSuccessfully: { state: true },
-  };
+  static get properties() {
+    return {
+      variant: {},
+      _message: { state: true },
+      _copiedSuccessfully: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/curriculum-landing/server.js
+++ b/components/curriculum-landing/server.js
@@ -220,11 +220,7 @@ export class CurriculumLanding extends ServerComponent {
                 : nothing;
 
             return html`
-              <li
-                id=${listItemId}
-                class="modules-list-list-item"
-                key="mll-${i}"
-              >
+              <li id=${listItemId} class="modules-list-list-item">
                 <input
                   class="visually-hidden"
                   id=${radioId}

--- a/components/curriculum-tabs/element.js
+++ b/components/curriculum-tabs/element.js
@@ -7,9 +7,11 @@ import { L10nMixin } from "../../l10n/mixin.js";
  */
 export class MDNCurriculumTabs extends L10nMixin(LitElement) {
   static ssr = false;
-  static properties = {
-    selectedtab: {},
-  };
+  static get properties() {
+    return {
+      selectedtab: {},
+    };
+  }
 
   // Disable shadow DOM
   createRenderRoot() {

--- a/components/dropdown/element.js
+++ b/components/dropdown/element.js
@@ -21,10 +21,12 @@ import styles from "./element.css?lit";
 export class MDNDropdown extends LitElement {
   static styles = styles;
 
-  static properties = {
-    open: { type: Boolean },
-    loaded: { type: Boolean, reflect: true },
-  };
+  static get properties() {
+    return {
+      open: { type: Boolean },
+      loaded: { type: Boolean, reflect: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/interactive-example/element.js
+++ b/components/interactive-example/element.js
@@ -21,7 +21,9 @@ const GLEAN_EVENT_TYPES = ["focus", "copy", "cut", "paste", "click"];
 export class InteractiveExampleBase extends LitElement {
   static ssr = false;
 
-  static properties = { name: { type: String } };
+  static get properties() {
+    return { name: { type: String } };
+  }
 
   static styles = styles;
 

--- a/components/interactive-example/with-choices.js
+++ b/components/interactive-example/with-choices.js
@@ -23,11 +23,13 @@ import "../play-runner/element.js";
  */
 export const InteractiveExampleWithChoices = (Base) =>
   class extends L10nMixin(Base) {
-    static properties = {
-      __choiceSelected: { state: true },
-      __choiceUnsupported: { state: true },
-      __choiceUpdated: { state: true },
-    };
+    static get properties() {
+      return {
+        __choiceSelected: { state: true },
+        __choiceUnsupported: { state: true },
+        __choiceUpdated: { state: true },
+      };
+    }
 
     /** @param {any[]} _args  */
     constructor(..._args) {

--- a/components/interactive-example/with-choices.js
+++ b/components/interactive-example/with-choices.js
@@ -149,7 +149,7 @@ export const InteractiveExampleWithChoices = (Base) =>
                   <mdn-play-editor
                     data-index=${index}
                     language="css"
-                    minimal="true"
+                    minimal
                     .delay=${100}
                     .value=${code?.trim()}
                     aria-label=${ifDefined(

--- a/components/issues-table/element.js
+++ b/components/issues-table/element.js
@@ -7,11 +7,13 @@ import styles from "./element.css?lit";
 export class MDNIssuesTable extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    _issues: { state: true },
-    _isLoading: { state: true },
-    _error: { state: true },
-  };
+  static get properties() {
+    return {
+      _issues: { state: true },
+      _isLoading: { state: true },
+      _error: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/language-always-redirect-button/element.js
+++ b/components/language-always-redirect-button/element.js
@@ -6,10 +6,12 @@ import { setPreferredLocale } from "../preferred-locale/utils.js";
 import "../button/element.js";
 
 export class MDNLanguageAlwaysRedirectButton extends LitElement {
-  static properties = {
-    locale: { type: String },
-    to: { type: String },
-  };
+  static get properties() {
+    return {
+      locale: { type: String },
+      to: { type: String },
+    };
+  }
 
   constructor() {
     super();

--- a/components/language-switcher/element.js
+++ b/components/language-switcher/element.js
@@ -21,14 +21,16 @@ import "../switch/element.js";
 export class MDNLanguageSwitcher extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    locale: { type: String },
-    native: { type: String },
-    translations: { type: Array },
-    url: { type: String },
-    notFound: { type: Boolean, attribute: "not-found" },
-    _preferredLocale: { state: true },
-  };
+  static get properties() {
+    return {
+      locale: { type: String },
+      native: { type: String },
+      translations: { type: Array },
+      url: { type: String },
+      notFound: { type: Boolean, attribute: "not-found" },
+      _preferredLocale: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/live-sample-result/element.js
+++ b/components/live-sample-result/element.js
@@ -12,15 +12,17 @@ import "../button/element.js";
 export class MDNLiveSampleResult extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    liveId: { attribute: "live-id" },
-    code: { type: Object },
-    allowed: {},
-    sandbox: {},
-    srcPrefix: { attribute: "src-prefix" },
-    height: {},
-    breakoutLink: { state: true },
-  };
+  static get properties() {
+    return {
+      liveId: { attribute: "live-id" },
+      code: { type: Object },
+      allowed: {},
+      sandbox: {},
+      srcPrefix: { attribute: "src-prefix" },
+      height: {},
+      breakoutLink: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/modal/element.js
+++ b/components/modal/element.js
@@ -9,9 +9,11 @@ import styles from "./element.css?lit";
 export class MDNModal extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    modalTitle: { type: String, attribute: "modal-title" },
-  };
+  static get properties() {
+    return {
+      modalTitle: { type: String, attribute: "modal-title" },
+    };
+  }
 
   constructor() {
     super();

--- a/components/observatory-comparison-table/element.js
+++ b/components/observatory-comparison-table/element.js
@@ -7,9 +7,11 @@ import { formatMinus } from "../observatory/utils.js";
 import styles from "./element.css?lit";
 
 export class MDNObservatoryComparisonTable extends LitElement {
-  static properties = {
-    result: { type: Object },
-  };
+  static get properties() {
+    return {
+      result: { type: Object },
+    };
+  }
 
   static styles = styles;
 

--- a/components/observatory-comparison-table/element.js
+++ b/components/observatory-comparison-table/element.js
@@ -207,7 +207,6 @@ function GradeSVG({ gradeDistribution, result }) {
             const barHeight =
               (height - bottomSpace - topSpace) * (item.count / yTickMax);
             return svg` <g
-              key="you-are-here"
               class="you-are-here"
               transform="translate(${xTickOffset + index * xTickIncr}, ${
                 height - bottomSpace - barHeight - 50

--- a/components/observatory-form/element.js
+++ b/components/observatory-form/element.js
@@ -15,11 +15,13 @@ const ERROR_MAP = {
 export class MDNObservatoryForm extends LitElement {
   static styles = styles;
 
-  static properties = {
-    _queryRunning: { type: Boolean, state: true },
-    _hostname: { type: String, state: true },
-    _errorMessage: { type: String, state: true },
-  };
+  static get properties() {
+    return {
+      _queryRunning: { type: Boolean, state: true },
+      _hostname: { type: String, state: true },
+      _errorMessage: { type: String, state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/observatory-form/element.js
+++ b/components/observatory-form/element.js
@@ -97,7 +97,7 @@ export class MDNObservatoryForm extends LitElement {
       : html`
           <form @submit=${this._handleSubmit} class="observatory-form">
             <div class="observatory-form__input-group">
-              <label htmlFor="host" class="visually-hidden">
+              <label for="host" class="visually-hidden">
                 Domain name or URL
               </label>
               <input

--- a/components/observatory-header-link/element.js
+++ b/components/observatory-header-link/element.js
@@ -8,12 +8,14 @@ import styles from "./element.css?lit";
 export class MDNObservatoryHeaderLink extends LitElement {
   static styles = styles;
 
-  static properties = {
-    header: { type: String },
-    _headerExists: { type: Boolean, state: true },
-    _isChecking: { type: Boolean, state: true },
-    _hasChecked: { type: Boolean, state: true },
-  };
+  static get properties() {
+    return {
+      header: { type: String },
+      _headerExists: { type: Boolean, state: true },
+      _isChecking: { type: Boolean, state: true },
+      _hasChecked: { type: Boolean, state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/observatory-human-duration/element.js
+++ b/components/observatory-human-duration/element.js
@@ -11,7 +11,7 @@ export class MDNObservatoryHumanDuration extends LitElement {
   static styles = styles;
   static get properties() {
     return {
-      date: { type: Date },
+      date: { attribute: false },
       _text: { state: true },
     };
   }

--- a/components/observatory-human-duration/element.js
+++ b/components/observatory-human-duration/element.js
@@ -9,10 +9,12 @@ import styles from "./element.css?lit";
 
 export class MDNObservatoryHumanDuration extends LitElement {
   static styles = styles;
-  static properties = {
-    date: { type: Date },
-    _text: { state: true },
-  };
+  static get properties() {
+    return {
+      date: { type: Date },
+      _text: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/observatory-rescan-button/element.js
+++ b/components/observatory-rescan-button/element.js
@@ -7,11 +7,13 @@ import styles from "./element.css?lit";
 
 export class MDNObservatoryRescanButton extends L10nMixin(LitElement) {
   static styles = styles;
-  static properties = {
-    from: { type: Object }, // Date object
-    duration: { type: Number },
-    _remainingTime: { state: true },
-  };
+  static get properties() {
+    return {
+      from: { type: Object }, // Date object
+      duration: { type: Number },
+      _remainingTime: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/observatory-results/element.js
+++ b/components/observatory-results/element.js
@@ -30,11 +30,13 @@ export class MDNObservatoryResults extends LitElement {
   /**
    * @type { import("@lit").PropertyDeclarations }
    */
-  static properties = {
-    host: { type: String },
-    selectedTab: { state: true, type: Number },
-    _usePostInApi: { state: true, type: Boolean },
-  };
+  static get properties() {
+    return {
+      host: { type: String },
+      selectedTab: { state: true, type: Number },
+      _usePostInApi: { state: true, type: Boolean },
+    };
+  }
 
   _apiTask = new Task(this, {
     args: () => [this.host],

--- a/components/placement-sidebar/element.js
+++ b/components/placement-sidebar/element.js
@@ -16,9 +16,11 @@ import styles from "./element.css?lit";
 export class MDNPlacementSidebar extends PlacementMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    horizontal: { type: Boolean },
-  };
+  static get properties() {
+    return {
+      horizontal: { type: Boolean },
+    };
+  }
 
   constructor() {
     super();

--- a/components/play-console/element.js
+++ b/components/play-console/element.js
@@ -87,9 +87,11 @@ class VirtualConsole {
 }
 
 export class MDNPlayConsole extends LitElement {
-  static properties = {
-    _messages: { state: true },
-  };
+  static get properties() {
+    return {
+      _messages: { state: true },
+    };
+  }
 
   static styles = styles;
 

--- a/components/play-controller/element.js
+++ b/components/play-controller/element.js
@@ -3,11 +3,13 @@ import { LitElement, css, html } from "lit";
 /** @import { VConsole } from "../play-console/types.js" */
 
 export class MDNPlayController extends LitElement {
-  static properties = {
-    runOnStart: { type: Boolean, attribute: "run-on-start" },
-    runOnChange: { type: Boolean, attribute: "run-on-change" },
-    srcPrefix: { attribute: false },
-  };
+  static get properties() {
+    return {
+      runOnStart: { type: Boolean, attribute: "run-on-start" },
+      runOnChange: { type: Boolean, attribute: "run-on-change" },
+      srcPrefix: { attribute: false },
+    };
+  }
 
   static styles = css`
     :host {

--- a/components/play-editor/element.js
+++ b/components/play-editor/element.js
@@ -25,12 +25,14 @@ import styles from "./element.css?lit";
 /** @import { PropertyValues } from "lit" */
 
 export class MDNPlayEditor extends LitElement {
-  static properties = {
-    language: { type: String },
-    minimal: { type: Boolean },
-    value: { attribute: false },
-    delay: { type: Number },
-  };
+  static get properties() {
+    return {
+      language: { type: String },
+      minimal: { type: Boolean },
+      value: { attribute: false },
+      delay: { type: Number },
+    };
+  }
 
   static styles = styles;
 

--- a/components/play-runner/element.js
+++ b/components/play-runner/element.js
@@ -24,15 +24,17 @@ import styles from "./element.css?lit";
 export class MDNPlayRunner extends LitElement {
   static ssr = false;
 
-  static properties = {
-    code: { type: Object },
-    defaults: { type: String },
-    srcPrefix: { type: String, attribute: "src-prefix" },
-    allow: { type: String },
-    sandbox: { type: String },
-    permalink: { type: Boolean },
-    _src: { state: true },
-  };
+  static get properties() {
+    return {
+      code: { type: Object },
+      defaults: { type: String },
+      srcPrefix: { type: String, attribute: "src-prefix" },
+      allow: { type: String },
+      sandbox: { type: String },
+      permalink: { type: Boolean },
+      _src: { state: true },
+    };
+  }
 
   static styles = styles;
 

--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -30,9 +30,11 @@ const SESSION_KEY = "playground-session-code";
 export class MDNPlayground extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    _gistID: { state: true },
-  };
+  static get properties() {
+    return {
+      _gistID: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/record-visit/element.js
+++ b/components/record-visit/element.js
@@ -7,9 +7,11 @@ import {
 
 export class MDNRecordVisit extends LitElement {
   static ssr = false;
-  static properties = {
-    pageTitle: { type: String, attribute: "page-title" },
-  };
+  static get properties() {
+    return {
+      pageTitle: { type: String, attribute: "page-title" },
+    };
+  }
 
   constructor() {
     super();

--- a/components/scrim-inline/element.js
+++ b/components/scrim-inline/element.js
@@ -15,13 +15,15 @@ export class MDNScrimInline extends L10nMixin(LitElement) {
 
   static ssr = false;
 
-  static properties = {
-    url: { type: String },
-    img: { type: String },
-    scrimTitle: { type: String, attribute: "scrimtitle" },
-    _fullscreen: { state: true },
-    _scrimLoaded: { state: true },
-  };
+  static get properties() {
+    return {
+      url: { type: String },
+      img: { type: String },
+      scrimTitle: { type: String, attribute: "scrimtitle" },
+      _fullscreen: { state: true },
+      _scrimLoaded: { state: true },
+    };
+  }
 
   /** @type {import("lit/directives/ref.js").Ref<HTMLElement>} */
   _bodyRef = createRef();

--- a/components/search-modal/element.js
+++ b/components/search-modal/element.js
@@ -16,12 +16,14 @@ export class MDNSearchModal extends L10nMixin(LitElement) {
   static ssr = false;
   static styles = styles;
 
-  static properties = {
-    _index: { state: true },
-    _query: { state: true },
-    _selected: { state: true },
-    _shiftFocus: { state: true },
-  };
+  static get properties() {
+    return {
+      _index: { state: true },
+      _query: { state: true },
+      _selected: { state: true },
+      _shiftFocus: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/sidebar-filter/element.js
+++ b/components/sidebar-filter/element.js
@@ -16,10 +16,12 @@ import "../button/element.js";
 class MDNSidebarFilter extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    query: { type: String },
-    matchCount: { state: true, type: Number },
-  };
+  static get properties() {
+    return {
+      query: { type: String },
+      matchCount: { state: true, type: Number },
+    };
+  }
 
   /**
    * Creates an instance of SidebarFilterElement.

--- a/components/sidebar-filter/element.js
+++ b/components/sidebar-filter/element.js
@@ -175,13 +175,13 @@ class MDNSidebarFilter extends L10nMixin(LitElement) {
       <mdn-button
         class="button"
         variant="plain"
-        label=${this.l10n(
-          "sidebar-filter-clear-filter-input",
-        )`Clear filter input`}
         .icon=${cancelIcon}
         icon-only
         @click=${this._clearFilter}
-      ></mdn-button>
+        >${this.l10n(
+          "sidebar-filter-clear-filter-input",
+        )`Clear filter input`}</mdn-button
+      >
     `;
   }
 }

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -44,11 +44,13 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
   static styles = styles;
   static ssr = false;
 
-  static properties = {
-    _inputValue: { state: true },
-    _query: { state: true },
-    _page: { state: true },
-  };
+  static get properties() {
+    return {
+      _inputValue: { state: true },
+      _query: { state: true },
+      _page: { state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/site-search/element.js
+++ b/components/site-search/element.js
@@ -171,7 +171,7 @@ export class MDNSiteSearch extends L10nMixin(LitElement) {
             @keydown=${this._handleKeyDown}
           />
           <mdn-button
-            icon-only="true"
+            icon-only
             .icon=${searchIcon}
             variant="plain"
             class="site-search-form__submit"

--- a/components/switch/element.js
+++ b/components/switch/element.js
@@ -5,11 +5,13 @@ import styles from "./element.css?lit";
 export class MDNSwitch extends LitElement {
   static styles = styles;
 
-  static properties = {
-    label: { type: String },
-    checked: { type: Boolean, reflect: true },
-    disabled: { type: Boolean },
-  };
+  static get properties() {
+    return {
+      label: { type: String },
+      checked: { type: Boolean, reflect: true },
+      disabled: { type: Boolean },
+    };
+  }
 
   constructor() {
     super();

--- a/components/themed-image/element.js
+++ b/components/themed-image/element.js
@@ -6,12 +6,14 @@ export class MDNThemedImage extends LitElement {
   static styles = styles;
   static ssr = false;
 
-  static properties = {
-    srcLight: { type: String, attribute: "src-light" },
-    srcDark: { type: String, attribute: "src-dark" },
-    alt: { type: String },
-    _theme: { type: String },
-  };
+  static get properties() {
+    return {
+      srcLight: { type: String, attribute: "src-light" },
+      srcDark: { type: String, attribute: "src-dark" },
+      alt: { type: String },
+      _theme: { type: String },
+    };
+  }
 
   constructor() {
     super();

--- a/components/toggle-sidebar/element.js
+++ b/components/toggle-sidebar/element.js
@@ -13,9 +13,11 @@ const MAIN_SIDEBAR_ID = "main-sidebar";
 export class MDNToggleSidebar extends L10nMixin(LitElement) {
   static styles = styles;
 
-  static properties = {
-    _canClose: { type: Boolean, state: true },
-  };
+  static get properties() {
+    return {
+      _canClose: { type: Boolean, state: true },
+    };
+  }
 
   constructor() {
     super();

--- a/components/writer-open-editor/element.js
+++ b/components/writer-open-editor/element.js
@@ -5,9 +5,11 @@ import { L10nMixin } from "../../l10n/mixin.js";
 import "../button/element.js";
 
 export class MDNWriterOpenEditor extends L10nMixin(LitElement) {
-  static properties = {
-    filepath: { type: String },
-  };
+  static get properties() {
+    return {
+      filepath: { type: String },
+    };
+  }
 
   constructor() {
     super();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,6 +89,15 @@ export default defineConfig([
       ],
       "lit/no-template-map": "off",
       "lit/prefer-query-decorators": "off",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "PropertyDefinition[static=true][key.name='properties'][value.type='ObjectExpression']",
+          message:
+            "Declare reactive properties with `static get properties()`, so lit-analyzer can detect the element's attributes.",
+        },
+      ],
       "n/no-missing-import": "off",
       "n/no-unsupported-features/node-builtins": ["off"],
       "n/no-unpublished-import": "off",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
           "no-missing-import": "error",
           "no-unknown-tag-name": "error",
           "no-incompatible-type-binding": "off",
-          "no-unknown-attribute": "off"
+          "no-unknown-attribute": "error"
         }
       }
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
           "no-missing-import": "error",
           "no-unknown-tag-name": "error",
           "no-incompatible-type-binding": "off",
+          "no-complex-attribute-binding": "off",
           "no-unknown-attribute": "error"
         },
         "customHtmlData": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,43 @@
           "no-unknown-tag-name": "error",
           "no-incompatible-type-binding": "off",
           "no-unknown-attribute": "error"
+        },
+        "customHtmlData": {
+          "version": 1.1,
+          "tags": [
+            {
+              "name": "dialog",
+              "attributes": [
+                {
+                  "name": "closedby",
+                  "description": "Controls which user actions can light-dismiss the dialog (any, closerequest, or none). [MDN reference](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/dialog#closedby)"
+                }
+              ]
+            },
+            {
+              "name": "link",
+              "attributes": [
+                {
+                  "name": "fetchpriority",
+                  "description": "Hints the relative priority for fetching the linked resource (high, low, or auto). [MDN reference](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/link#fetchpriority)"
+                }
+              ]
+            }
+          ],
+          "globalAttributes": [
+            {
+              "name": "vocab",
+              "description": "RDFa: default vocabulary IRI used to expand property and typeof values."
+            },
+            {
+              "name": "typeof",
+              "description": "RDFa: declares the RDF type(s) of the subject described by the current element."
+            },
+            {
+              "name": "property",
+              "description": "RDFa: declares a property relationship between the subject and its value."
+            }
+          ]
         }
       }
     ]


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1629:
- Enables the `no-unknown-attribute` rule we disabled in https://github.com/mdn/fred/pull/1631
- lit-analyzer couldn't parse attributes out of our `static properties` field, so adds an eslint rule to require, and converts to, `static get properties()`, which it can parse, and still works in lit
- declares some valid attributes lit-analyzer isn't aware of
- removes invalid react key attributes
- corrects remaining invalid attributes and properties
- disables the `no-complex-attribute-binding` as it can't deal with our manual json serialisation in server templates, and lit's automatic deserialisation

Manually tested components with modified attributes, commits are atomic for easier reviewing.