### PR TITLE
fix(external-link): glue the icon to the last word

### DIFF
--- a/components/external-link/global.css
+++ b/components/external-link/global.css
@@ -1,21 +1,25 @@
-.external::after {
-  display: inline-block;
+.external {
+  padding-right: 1.125em;
 
-  width: 1em;
-  height: 1em;
+  &::after {
+    position: absolute;
 
-  margin-left: 0.25em;
+    width: 1em;
+    height: 1em;
 
-  vertical-align: text-top;
+    margin-left: 0.125em;
 
-  /*
-    Unicode zero width space as `<content replacement>` to expose the alt text in the a11y tree.
-    See: https://bugzilla.mozilla.org/show_bug.cgi?id=1976574
-  */
-  content: "\200b" / " (external)";
+    /*
+      Unicode zero width space as `<content replacement>` to expose the alt text in the a11y tree.
+      See: https://bugzilla.mozilla.org/show_bug.cgi?id=1976574
+    */
+    content: "\200b" / " (external)";
 
-  background-color: currentcolor;
+    background-color: currentcolor;
 
-  mask-image: url("../icon/external-link.svg");
-  mask-size: cover;
+    mask-image: url("../icon/external-link.svg");
+    mask-size: cover;
+
+    transform: translateY(calc(1lh / 2 - 0.5em));
+  }
 }


### PR DESCRIPTION
### Description

- Glues the icon to the last word by reserving the space using padding
- Better vertically align the icon

### Motivation

To avoid the icon being wrapped to the next line.

### Additional details

Before/after

<img width="446" height="436" alt="image" src="https://github.com/user-attachments/assets/5a99b8e9-6691-48f7-8670-9cd8c1008a05" />

[See the CodePen demo](https://codepen.io/editor/pepelsbey/pen/019e88ad-b90d-71d6-9ec4-798d80d97a33)
