### PR TITLE
fix(a11y-menu): add scroll margin to main content skip link target

### DIFF
--- a/components/global/global.css
+++ b/components/global/global.css
@@ -30,3 +30,7 @@ a {
 [hidden] {
   display: none !important;
 }
+
+#content {
+  scroll-margin-block-start: var(--sticky-header-height);
+}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This adds some scroll margin to the “Skip to main content” target globally (i.e. `#content`), so that the target’s content does not scroll beneath the sticky header.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

Relevant visible content is obscured when following the skip link and what’s visible is still important for keyboard users and even screen reader users.

<details><summary>Before video</summary>

Description: in Firefox a user navigates to the MDN homepage and tabs to the “Skip to main content” link, upon activation the hero content scrolls beneath the sticky header causing some of the target content to be obscured. 

https://github.com/user-attachments/assets/88652a30-c62b-4dee-b3f1-5290bd091304 

</details>

<details><summary>After video</summary>

Description: in Firefox a user navigates to the MDN homepage and tabs to the “Skip to main content” link, upon activation the page scrolls slightly so that the ad is out of view, but the target content is not obscured at all.

https://github.com/user-attachments/assets/ce9e5d45-625d-4776-bd87-fc7365002baf

</details>

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

~~As far as I can tell, this isn’t a problem on other pages.~~ This is now applied globally.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Looked, but couldn’t find any.

