### PR TITLE
feat(cli): add single `fred` entrypoint with subcommands

### DIFF
--- a/.github/workflows/npm-publish-simulation.yml
+++ b/.github/workflows/npm-publish-simulation.yml
@@ -101,7 +101,7 @@ jobs:
       - name: (mdn/content) Render (Linux)
         if: runner.os == 'Linux'
         working-directory: mdn/content
-        run: npx fred-ssr
+        run: npx @mdn/fred ssr
 
       - name: (mdn/fred) Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/bin/fred-server.js
+++ b/bin/fred-server.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+console.warn(
+  "`fred-server` is deprecated and will be removed in a future major; use `fred server` (e.g. `npx @mdn/fred server`) instead.",
+);
+await import("../scripts/server.js");

--- a/bin/fred-ssr.js
+++ b/bin/fred-ssr.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+console.warn(
+  "`fred-ssr` is deprecated and will be removed in a future major; use `fred ssr` (e.g. `npx @mdn/fred ssr`) instead.",
+);
+await import("../build/ssr.js");

--- a/bin/fred.js
+++ b/bin/fred.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Drop the subcommand so the remaining arguments are exposed to the
+// delegated script as if it had been invoked directly.
+const [command] = process.argv.splice(2, 1);
+
+const usage = "Usage: fred <server|ssr>";
+
+switch (command) {
+  case "server":
+    await import("../scripts/server.js");
+    break;
+  case "ssr":
+    await import("../build/ssr.js");
+    break;
+  case "--help":
+  case "-h":
+    console.log(usage);
+    break;
+  default:
+    console.error(
+      command
+        ? `fred: unknown command ${JSON.stringify(command)}`
+        : "fred: missing command",
+    );
+    console.error(usage);
+    process.exitCode = 1;
+}

--- a/build/ssr.js
+++ b/build/ssr.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { readFile, writeFile } from "node:fs/promises";
 
 import { RARI_BUILD_ROOT } from "./env.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,9 @@
         "source-map-support": "^0.5.21"
       },
       "bin": {
-        "fred-server": "scripts/server.js",
-        "fred-ssr": "build/ssr.js"
+        "fred": "bin/fred.js",
+        "fred-server": "bin/fred-server.js",
+        "fred-ssr": "bin/fred-ssr.js"
       },
       "devDependencies": {
         "@codemirror/autocomplete": "^6.20.3",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "author": "MDN Web Docs",
   "type": "module",
   "bin": {
-    "fred-server": "scripts/server.js",
-    "fred-ssr": "build/ssr.js"
+    "fred": "bin/fred.js",
+    "fred-server": "bin/fred-server.js",
+    "fred-ssr": "bin/fred-ssr.js"
   },
   "scripts": {
     "start": "node --env-file=.env scripts/server.js",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { fileURLToPath } from "node:url";
 
 import { rariBin } from "@mdn/rari";


### PR DESCRIPTION
### Description

Add a single `fred` binary that dispatches `server`/`ssr` subcommands, so `@mdn/fred` can be run as `npx @mdn/fred ssr`. The existing `fred-server`/`fred-ssr` binaries are kept as deprecated shims (which print a warning and delegate) for backward compatibility, and the publish-simulation workflow now uses `npx @mdn/fred ssr`.

- Add `bin/fred.js` dispatcher (`fred <server|ssr>`).
- Convert `fred-server`/`fred-ssr` bins to deprecation shims in `bin/`.
- Point `bin` entries in `package.json`/`package-lock.json` at the new wrappers.
- Drop the now-dead shebangs from `scripts/server.js` and `build/ssr.js` (no longer `bin` entries).
- Switch the publish-simulation workflow to `npx @mdn/fred ssr`.

### Motivation

Prevent the risk of bare `npx fred-server`/`npx fred-ssr` resolving to squatted registry packages when `@mdn/fred` is not installed locally, by steering consumers to the unambiguous `npx @mdn/fred <command>` (and `npx --package=@mdn/fred fred-ssr` during the deprecation window).

### Additional details

Both target invocations are verified to work: `npx @mdn/fred ssr` produces byte-identical output to running `build/ssr.js` directly, and `npx --package=@mdn/fred fred-ssr` continues to work via the shim. The two standalone bins remain only as a temporary bridge and can be dropped in a future major.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.