### PR TITLE
style: resolve all ESLint warnings

### DIFF
--- a/components/color-theme/controller.js
+++ b/components/color-theme/controller.js
@@ -31,7 +31,7 @@ export class ThemeController {
   }
 
   /**
-   * @param {any} value
+   * @param {unknown} value
    * @returns {"light" | "dark" | undefined}
    */
   _lightOrDark(value) {

--- a/components/compat-table/utils.js
+++ b/components/compat-table/utils.js
@@ -25,7 +25,7 @@ export const SHOW_BROWSERS = [
 /**
  * Gets the first element of an array or returns the value itself.
  * @template T
- * @param {T | [T?, ...any[]]} a
+ * @param {T | [T?, ...unknown[]]} a
  * @returns {T | undefined}
  */
 export function getFirst(a) {

--- a/components/interactive-example/with-choices.js
+++ b/components/interactive-example/with-choices.js
@@ -17,10 +17,12 @@ import "../play-runner/element.js";
  * @import { InteractiveExampleBase } from "./element.js";
  */
 
+/* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
 /**
  * @template {new (...args: any[]) => InteractiveExampleBase} TBase
  * @param {TBase} Base
  */
+/* eslint-enable jsdoc/reject-any-type */
 export const InteractiveExampleWithChoices = (Base) =>
   class extends L10nMixin(Base) {
     static get properties() {
@@ -31,6 +33,7 @@ export const InteractiveExampleWithChoices = (Base) =>
       };
     }
 
+    // eslint-disable-next-line jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545)
     /** @param {any[]} _args  */
     constructor(..._args) {
       super();

--- a/components/interactive-example/with-console.js
+++ b/components/interactive-example/with-console.js
@@ -18,10 +18,12 @@ import { randomIdString } from "../utils/index.js";
  * @import { InteractiveExampleBase } from "./element.js";
  */
 
+/* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
 /**
  * @template {new (...args: any[]) => InteractiveExampleBase} TBase
  * @param {TBase} Base
  */
+/* eslint-enable jsdoc/reject-any-type */
 export const InteractiveExampleWithConsole = (Base) =>
   class extends L10nMixin(Base) {
     #render() {

--- a/components/interactive-example/with-tabs.js
+++ b/components/interactive-example/with-tabs.js
@@ -16,10 +16,12 @@ import { randomIdString } from "../utils/index.js";
  * @import { InteractiveExampleBase } from "./element.js";
  */
 
+/* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
 /**
  * @template {new (...args: any[]) => InteractiveExampleBase} TBase
  * @param {TBase} Base
  */
+/* eslint-enable jsdoc/reject-any-type */
 export const InteractiveExampleWithTabs = (Base) =>
   class extends L10nMixin(Base) {
     #render() {

--- a/components/observatory-results/rating.js
+++ b/components/observatory-results/rating.js
@@ -11,7 +11,7 @@ import "../dropdown/element.js";
 
 /**
  *
- * @param {{result: import("@observatory").Result, host: string, rescan: Function}} props
+ * @param {{result: import("@observatory").Result, host: string, rescan: (event: Event) => void}} props
  * @returns {import("@lit").TemplateResult}
  */
 export function Rating({ result, host, rescan }) {

--- a/components/placement/mixin.js
+++ b/components/placement/mixin.js
@@ -14,10 +14,12 @@ import "../placement-no/element.js";
  * @import * as Placements from "./types.js";
  */
 
+/* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
 /**
  * @template {new (...args: any[]) => LitElement} TBase
  * @param {TBase} Base
  */
+/* eslint-enable jsdoc/reject-any-type */
 export const PlacementMixin = (Base) =>
   class PlacementElement extends Base {
     static ssr = false;
@@ -30,10 +32,12 @@ export const PlacementMixin = (Base) =>
       },
     });
 
+    /* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
     /**
      *
      * @param  {...any} args
      */
+    /* eslint-enable jsdoc/reject-any-type */
     constructor(...args) {
       super(...args);
       /**

--- a/components/play-console/element.js
+++ b/components/play-console/element.js
@@ -18,22 +18,22 @@ class VirtualConsole {
     this.#host._messages = [];
   }
 
-  /** @param {...any} args */
+  /** @param {...unknown} args */
   debug(...args) {
     return this.log(...args);
   }
 
-  /** @param {...any} args */
+  /** @param {...unknown} args */
   error(...args) {
     return this.log(...args);
   }
 
-  /** @param {...any} args */
+  /** @param {...unknown} args */
   info(...args) {
     return this.log(...args);
   }
 
-  /** @param {...any} args */
+  /** @param {...unknown} args */
   log(...args) {
     if (args.length > 1 && typeof args[0] === "string") {
       // https://developer.mozilla.org/en-US/docs/Web/API/console#using_string_substitutions
@@ -49,18 +49,20 @@ class VirtualConsole {
             }
             case "d":
             case "i": {
-              const i = args.splice(1, 1)[0];
+              const i = /** @type {number} */ (args.splice(1, 1)[0]);
               return Math.trunc(i).toFixed(0).padStart(formatArg, "0");
             }
             case "s": {
-              const s = args.splice(1, 1)[0];
+              const s = /** @type {string} */ (args.splice(1, 1)[0]);
               return s.toString();
             }
             case "f": {
               const f = args.splice(1, 1)[0];
-              return (typeof f === "number" ? f : Number.parseFloat(f)).toFixed(
-                formatArg ?? 6,
-              );
+              return (
+                typeof f === "number"
+                  ? f
+                  : Number.parseFloat(/** @type {string} */ (f))
+              ).toFixed(formatArg ?? 6);
             }
             case "c":
               // TODO: Not implemented yet, so just remove the argument
@@ -80,7 +82,7 @@ class VirtualConsole {
     ];
   }
 
-  /** @param {...any} args */
+  /** @param {...unknown} args */
   warn(...args) {
     return this.log(...args);
   }

--- a/components/play-console/utils.js
+++ b/components/play-console/utils.js
@@ -6,7 +6,7 @@
  * - adds commas appropriately (with spacing)
  * - identifies empty slots
  * designed to be used recursively
- * @param {any} input - The output to log.
+ * @param {unknown[]} input - The output to log.
  * @returns Formatted output as a string.
  */
 export function formatArray(input) {
@@ -16,7 +16,7 @@ export function formatArray(input) {
       output += '"' + input[i] + '"';
     } else if (Array.isArray(input[i])) {
       output += "Array [";
-      output += formatArray(input[i]);
+      output += formatArray(/** @type {unknown[]} */ (input[i]));
       output += "]";
     } else if (Object.prototype.hasOwnProperty.call(input, i)) {
       output += formatOutput(input[i]);
@@ -37,6 +37,7 @@ export function formatArray(input) {
   return output;
 }
 
+/* eslint-disable jsdoc/reject-any-type -- formats arbitrary console values via dynamic member access (`.constructor`, `for...in`, indexing); vendored from mdn/bob */
 /**
  * Formats objects:
  * ArrayBuffer, DataView, SharedArrayBuffer,
@@ -47,6 +48,7 @@ export function formatArray(input) {
  * @param {any} input - The output to log.
  * @returns Formatted output as a string.
  */
+/* eslint-enable jsdoc/reject-any-type */
 export function formatObject(input) {
   const bufferDataViewRegExp = /^(ArrayBuffer|SharedArrayBuffer|DataView)$/;
   const complexArrayRegExp =
@@ -126,7 +128,7 @@ export function formatObject(input) {
  * - square brackets around arrays
  * (also copes with arrays of arrays)
  * does NOT detect Int32Array etc
- * @param {any} input - The output to log.
+ * @param {unknown} input - The output to log.
  * @returns Formatted output as a string.
  */
 export function formatOutput(input) {

--- a/components/play-runner/element.js
+++ b/components/play-runner/element.js
@@ -139,7 +139,7 @@ export class MDNPlayRunner extends LitElement {
     window.addEventListener("message", this._onMessage);
   }
 
-  /** @param {any} message */
+  /** @param {unknown} message */
   async postMessage(message) {
     await this.ready;
     this._iframe.value?.contentWindow?.postMessage(message, "*");

--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -536,7 +536,7 @@ ${"```"}`,
 customElements.define("mdn-playground", MDNPlayground);
 
 /**
- * @param {import("./types.js").PlaygroundStateParam | import("./types.js").PlaygroundSession | {}} stateOrSession
+ * @param {import("./types.js").PlaygroundStateParam | import("./types.js").PlaygroundSession} stateOrSession
  * @returns {import("./types.js").PlaygroundSession}
  */
 function stateToSession(stateOrSession) {

--- a/components/sandbox/class.js
+++ b/components/sandbox/class.js
@@ -8,10 +8,12 @@ export class SandboxComponent {
     return new this().render();
   }
 
+  /* eslint-disable jsdoc/reject-any-type -- abstract render is overridden by subclasses (needs a supertype) yet consumed via generic `ReturnType<...>` (needs `any`); neither `unknown` nor `never` satisfies both */
   /**
    * @abstract
    * @returns {any}
    */
+  /* eslint-enable jsdoc/reject-any-type */
   render() {
     throw new Error("Must be implemented by subclass");
   }

--- a/components/server/index.js
+++ b/components/server/index.js
@@ -76,19 +76,23 @@ export class ServerComponent {
     return res;
   }
 
+  /* eslint-disable jsdoc/reject-any-type -- abstract render is overridden by subclasses (needs a supertype) yet consumed via generic `ReturnType<...>` (needs `any`); neither `unknown` nor `never` satisfies both */
   /**
    * @abstract
    * @param {...any} _args
    * @returns {any}
    */
+  /* eslint-enable jsdoc/reject-any-type */
   render(..._args) {
     throw new Error("Must be implemented by subclass");
   }
 
+  /* eslint-disable jsdoc/reject-any-type -- abstract render is overridden by subclasses (needs a supertype) yet consumed via generic `ReturnType<...>` (needs `any`); neither `unknown` nor `never` satisfies both */
   /**
    * @param {...any} args
    * @returns {any}
    */
+  /* eslint-enable jsdoc/reject-any-type */
   renderSimplified(...args) {
     return this.render(...args);
   }

--- a/components/sidebar-filter/element.js
+++ b/components/sidebar-filter/element.js
@@ -89,7 +89,7 @@ class MDNSidebarFilter extends L10nMixin(LitElement) {
   /**
    * Lit lifecycle method called after properties are updated.
    * Triggers telemetry events and applies filtering logic when properties change.
-   * @param {Map<string, any>} changedProperties
+   * @param {import("lit").PropertyValues<this>} changedProperties
    */
   updated(changedProperties) {
     if (changedProperties.has("query")) {

--- a/components/viewed-controller/viewed-controller.js
+++ b/components/viewed-controller/viewed-controller.js
@@ -13,7 +13,7 @@ export class ViewedController {
   /**
    * @param {LitElement} host
    * @param {Ref<Element>} target
-   * @param {Function} callback
+   * @param {() => void} callback
    * @param {IntersectionObserverInit} [observerOptions]
    */
   constructor(host, target, callback, observerOptions) {

--- a/components/viewed-controller/viewed-observer.js
+++ b/components/viewed-controller/viewed-observer.js
@@ -17,7 +17,7 @@ export class ViewedObserver {
 
   /**
    * @param {Element} element
-   * @param {Function} callback
+   * @param {() => void} callback
    * @param {IntersectionObserverInit} [options]
    */
   constructor(element, callback, options = OPTIONS) {

--- a/l10n/mixin.js
+++ b/l10n/mixin.js
@@ -6,15 +6,19 @@ import getFluentContext from "./fluent.js";
  * @import { LitElement } from "lit";
  */
 
+/* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
 /**
  * @template {new (...args: any[]) => LitElement} TBase
  * @param {TBase} Base
  */
+/* eslint-enable jsdoc/reject-any-type */
 export const L10nMixin = (Base) =>
   class LocalizedElement extends Base {
+    /* eslint-disable jsdoc/reject-any-type -- TS mixin constructors require `any[]` (error TS2545) */
     /**
      * @param  {...any} args
      */
+    /* eslint-enable jsdoc/reject-any-type */
     constructor(...args) {
       super(...args);
       const context = getSymmetricContext();

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -65,7 +65,7 @@ const postcssLoaders = (lit = false) => [
               mixins: {
                 "light-dark":
                   /**
-                   * @param {any} _mixin
+                   * @param {unknown} _mixin
                    * @param {string} property
                    * @param {string} light
                    * @param {string} dark

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -13,7 +13,7 @@ export default {
     "no-descending-specificity": null,
     "no-duplicate-selectors": null,
     "order/properties-order": [
-      propertyGroups.map((/** @type {any} */ group) => ({
+      propertyGroups.map((/** @type {Record<string, unknown>} */ group) => ({
         ...group,
         emptyLineBefore: "threshold",
         noEmptyLineBetween: true,


### PR DESCRIPTION
### Description

Fix all 31 ESLint warnings (`jsdoc/reject-any-type`, `jsdoc/reject-function-type`, `jsdoc/ts-no-empty-object-type`).

- Replace `Function` with concrete callback signatures (`() => void`, `(event: Event) => void`).
- Replace genuine `any` with precise types or `unknown` (`[T?, ...unknown[]]`, `PropertyValues<this>`, …).
- Drop a redundant `{}` union member in `stateToSession` (all callers pass `any`).
- Type play-console console-emulation args as `unknown`, casting at the `%d`/`%s`/`%f` substitution sites.
- Add scoped `eslint-disable` comments only where `any` is genuinely required: TS mixin constructors, abstract `render`/`renderSimplified` (overridden by subclasses yet consumed via generic `ReturnType<…>`), and `formatObject`'s dynamic member access.

### Motivation

Ensure `npx eslint .` passes with zero warnings, improving type precision across JSDoc annotations.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

Both `npx eslint .` (0 warnings) and `npm run tsc` (no regressions) pass.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
