### PR TITLE
fix(playground): handle malformed HTML + warn when JS cannot run

### DIFF
--- a/test/unit/play/runner.test.js
+++ b/test/unit/play/runner.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { renderHtml } from "../../../vendor/yari/libs/play/index.js";
+
+describe("play renderHtml", () => {
+  it("tags the runner script with an id for swallow detection", () => {
+    const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
+    assert.ok(out.includes('id="mdn-play-js"'));
+    // Detection matches the <script> tag specifically, so a user element
+    // reusing the id cannot cause a false "did not run" warning.
+    assert.ok(out.includes('querySelector("script#mdn-play-js")'));
+  });
+});

--- a/test/unit/play/runner.test.js
+++ b/test/unit/play/runner.test.js
@@ -3,7 +3,61 @@ import { describe, it } from "node:test";
 
 import { renderHtml } from "../../../vendor/yari/libs/play/index.js";
 
+// The runner assembles the document as a string, interpolating user CSS/JS
+// into `<style>`/`<script>` elements. These tests exercise the breakout
+// escaping via the emitted document, slicing out the region between an
+// element's opening `>` and its first real closing tag.
+
+/**
+ * @param {string} out
+ * @param {string} marker
+ * @param {string} close
+ */
+function region(out, marker, close) {
+  const start = out.indexOf(marker);
+  const open = out.indexOf(">", start) + 1;
+  return out.slice(open, out.indexOf(close, open));
+}
+
+/** @param {string} out */
+const scriptRegion = (out) => region(out, 'id="mdn-play-js"', "</script>");
+/** @param {string} out */
+const styleRegion = (out) => region(out, 'id="css-output"', "</style>");
+
 describe("play renderHtml", () => {
+  it("escapes a </script sequence so user JS cannot break out", () => {
+    const js = `console.log("</script><img src=x onerror=alert(1)>");`;
+    const code = scriptRegion(renderHtml({ html: "", css: "", js }));
+    // The backslash stops the HTML parser from ending the element early...
+    assert.ok(code.includes("<\\/script"), "sequence should be escaped");
+    assert.ok(!code.includes("</script"), "raw </script must not survive");
+    // ...while `\/` resolves to `/`, so the source round-trips unchanged.
+    assert.equal(code.replaceAll("<\\/", "</").trim(), `${js};`);
+  });
+
+  it("escapes a </style sequence so user CSS cannot break out", () => {
+    const css = `body::before { content: "</style><img src=x>"; }`;
+    const code = styleRegion(renderHtml({ html: "", css, js: "1;" }));
+    assert.ok(code.includes("<\\/style"), "sequence should be escaped");
+    assert.ok(!code.includes("</style"), "raw </style must not survive");
+    assert.equal(code.replaceAll("<\\/", "</").trim(), css);
+  });
+
+  it("preserves case when escaping (</SCRIPT stays uppercase)", () => {
+    const js = `x = "</SCRIPT>";`;
+    const code = scriptRegion(renderHtml({ html: "", css: "", js }));
+    assert.ok(code.includes("<\\/SCRIPT"));
+  });
+
+  it("leaves the <!--<script> double-escape unaddressed (known limitation)", () => {
+    // Documented in `escapeScriptText`: the escaping only neutralizes
+    // `</script`, so a `<!--` … `<script` sequence still reaches the parser
+    // intact. Pinned here so a future fix is a deliberate, visible change.
+    const js = `console.log("<!--<script>");`;
+    const code = scriptRegion(renderHtml({ html: "", css: "", js }));
+    assert.ok(code.includes("<!--<script>"), "sequence is not neutralized");
+  });
+
   it("tags the runner script with an id for swallow detection", () => {
     const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
     assert.ok(out.includes('id="mdn-play-js"'));

--- a/test/unit/play/runner.test.js
+++ b/test/unit/play/runner.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { renderHtml } from "../../../vendor/yari/libs/play/index.js";
+
+describe("play renderHtml", () => {
+  it("marks the runner script and its end for swallow detection", () => {
+    const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
+    for (const marker of ['id="mdn-play-js"', 'id="mdn-play-js-end"']) {
+      assert.ok(out.includes(marker), `missing ${marker}`);
+    }
+  });
+
+  it("runs the swallow detection from the head, after DOMContentLoaded", () => {
+    const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
+    const head = out.slice(0, out.indexOf("</head>"));
+    assert.ok(head.includes('querySelector("script#mdn-play-js")'));
+    assert.ok(head.includes('addEventListener("DOMContentLoaded"'));
+  });
+});

--- a/test/unit/play/runner.test.js
+++ b/test/unit/play/runner.test.js
@@ -4,17 +4,51 @@ import { describe, it } from "node:test";
 import { renderHtml } from "../../../vendor/yari/libs/play/index.js";
 
 describe("play renderHtml", () => {
-  it("marks the runner script and its end for swallow detection", () => {
-    const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
-    for (const marker of ['id="mdn-play-js"', 'id="mdn-play-js-end"']) {
-      assert.ok(out.includes(marker), `missing ${marker}`);
-    }
-  });
+  const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
+  const body = out.slice(out.indexOf("<body>"));
+  const head = out.slice(0, out.indexOf("</head>"));
 
-  it("runs the swallow detection from the head, after DOMContentLoaded", () => {
-    const out = renderHtml({ html: "<p>ok</p>", css: "", js: "1;" });
-    const head = out.slice(0, out.indexOf("</head>"));
-    assert.ok(head.includes('querySelector("script#mdn-play-js")'));
-    assert.ok(head.includes('addEventListener("DOMContentLoaded"'));
+  const cases = [
+    {
+      name: "closes unclosed tags, attribute values, and comments",
+      haystack: body,
+      needle: `<!-- "" '' -->`,
+    },
+    {
+      name: "records that the runner script was reached",
+      haystack: body,
+      needle: "window.__mdnPlayJsStarted = true;",
+    },
+    {
+      name: "records that the runner script ended",
+      haystack: body,
+      needle: "window.__mdnPlayJsEnded = true;",
+    },
+    {
+      name: "checks the flags from the head",
+      haystack: head,
+      needle: "window.__mdnPlayJsStarted && window.__mdnPlayJsEnded",
+    },
+    {
+      name: "checks the flags after DOMContentLoaded",
+      haystack: head,
+      needle: 'addEventListener("DOMContentLoaded"',
+    },
+  ];
+
+  for (const { name, haystack, needle } of cases) {
+    it(name, () => {
+      assert.ok(haystack.includes(needle), `missing ${needle}`);
+    });
+  }
+
+  it("places the closer and flag script between the HTML and the runner", () => {
+    const html = body.indexOf("<p>ok</p>");
+    const closer = body.indexOf(`<!-- "" '' -->`);
+    const started = body.indexOf("__mdnPlayJsStarted = true");
+    const runner = body.indexOf('id="mdn-play-js"');
+    const ended = body.indexOf("__mdnPlayJsEnded = true");
+    assert.ok(html < closer && closer < started && started < runner);
+    assert.ok(runner < ended);
   });
 });

--- a/vendor/yari/libs/play/index.js
+++ b/vendor/yari/libs/play/index.js
@@ -86,6 +86,39 @@ function html(strings, ...args) {
 }
 
 /**
+ * Prevent user CSS from breaking out of the `<style>` element via a literal
+ * `</style` sequence. Inserting a backslash (`<\/style`) stops the HTML parser
+ * from ending the element while remaining equivalent inside CSS strings, where
+ * `\/` resolves to `/`.
+ * @param {string} css
+ */
+function escapeStyleText(css) {
+  return css.replace(/<\/(style)/gi, String.raw`<\/$1`);
+}
+
+/**
+ * Prevent user JS from breaking out of the `<script>` element via a literal
+ * `</script` sequence. Inserting a backslash (`<\/script`) stops the HTML
+ * parser from ending the element while remaining equivalent inside JS strings,
+ * template literals, and regexes, where `\/` resolves to `/`. The equivalence
+ * holds within literal *contents*; the pathological `x</script/` — a `<`
+ * operator immediately followed by a regex literal beginning with `script`
+ * (i.e. `x < /script/`) — would not round-trip, but such code is vanishingly
+ * rare.
+ *
+ * Known limitation: this does not neutralize a `<!--` … `<script` sequence,
+ * which pushes the parser into the script-data-double-escaped state where the
+ * runner's own closing `</script>` no longer closes the element (swallowing
+ * everything after it, including the swallow-detection warning). No backslash
+ * escape fixes this without changing behavior — `<\!--` is an invalid escape in
+ * `/u` regexes — so such input still corrupts the runner.
+ * @param {string} js
+ */
+function escapeScriptText(js) {
+  return js.replace(/<\/(script)/gi, String.raw`<\/$1`);
+}
+
+/**
  * @param {State | null} state
  * @param {string} hrefWithCode
  * @param {string} searchWithState
@@ -428,7 +461,7 @@ export function renderHtml(state = null) {
             : ""
         }
         <style id="css-output">
-          ${css}
+          ${escapeStyleText(css)}
         </style>
         <script>
           const consoleProxy = new Proxy(console, {
@@ -527,7 +560,7 @@ export function renderHtml(state = null) {
       <body>
         ${htmlCode}
         <script id="mdn-play-js" type=${defaults === "ix-wat" ? "module" : ""}>
-          ${js};
+          ${escapeScriptText(js)};
         </script>
         <script>
           try {

--- a/vendor/yari/libs/play/index.js
+++ b/vendor/yari/libs/play/index.js
@@ -526,11 +526,26 @@ export function renderHtml(state = null) {
       </head>
       <body>
         ${htmlCode}
-        <script type=${defaults === "ix-wat" ? "module" : ""}>
+        <script id="mdn-play-js" type=${defaults === "ix-wat" ? "module" : ""}>
           ${js};
         </script>
         <script>
           try {
+            // Post-rendering check: an unclosed or malformed tag in the HTML
+            // input can swallow the following <script> element (its markup is
+            // parsed as attributes of the open tag), leaving the JavaScript
+            // source visible as text content. Detect that and warn the user.
+            // Match the <script> tag with our id specifically, so a user
+            // element that happens to reuse the id cannot trigger a false
+            // warning when the real script did run.
+            const jsScript = document.querySelector("script#mdn-play-js");
+            if (!(jsScript instanceof HTMLScriptElement)) {
+              console.warn(
+                "[Playground] The JavaScript did not run because the HTML input " +
+                  'contains an unclosed or malformed tag (for example "<o"). ' +
+                  "Close the tag to run your code.",
+              );
+            }
             const uuid =
               new URLSearchParams(location.search).get("uuid") || undefined;
             window.parent.postMessage({ uuid, typ: "ready" }, "*");

--- a/vendor/yari/libs/play/index.js
+++ b/vendor/yari/libs/play/index.js
@@ -488,6 +488,19 @@ export function renderHtml(state = null) {
           window.console = consoleProxy;
           window.addEventListener("error", (e) => console.log(e.error));
         </script>
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            const start = document.querySelector("script#mdn-play-js");
+            const end = document.querySelector("script#mdn-play-js-end");
+            if (!(start instanceof HTMLScriptElement) || !end) {
+              console.warn(
+                "[Playground] Could not verify that the JavaScript ran. This " +
+                  "usually means the HTML input contains an unclosed or " +
+                  "malformed tag.",
+              );
+            }
+          });
+        </script>
         ${
           defaults === "ix-tabbed"
             ? html`<script>
@@ -530,10 +543,10 @@ export function renderHtml(state = null) {
       </head>
       <body>
         ${htmlCode}
-        <script type=${defaults === "ix-wat" ? "module" : ""}>
+        <script id="mdn-play-js" type=${defaults === "ix-wat" ? "module" : ""}>
           ${js};
         </script>
-        <script>
+        <script id="mdn-play-js-end">
           try {
             const uuid =
               new URLSearchParams(location.search).get("uuid") || undefined;

--- a/vendor/yari/libs/play/index.js
+++ b/vendor/yari/libs/play/index.js
@@ -490,13 +490,10 @@ export function renderHtml(state = null) {
         </script>
         <script>
           document.addEventListener("DOMContentLoaded", () => {
-            const start = document.querySelector("script#mdn-play-js");
-            const end = document.querySelector("script#mdn-play-js-end");
-            if (!(start instanceof HTMLScriptElement) || !end) {
+            if (!(window.__mdnPlayJsStarted && window.__mdnPlayJsEnded)) {
               console.warn(
-                "[Playground] Could not verify that the JavaScript ran. This " +
-                  "usually means the HTML input contains an unclosed or " +
-                  "malformed tag.",
+                "[Playground] The JavaScript did not run. This usually means " +
+                  "the HTML input contains an unclosed or malformed tag.",
               );
             }
           });
@@ -543,10 +540,15 @@ export function renderHtml(state = null) {
       </head>
       <body>
         ${htmlCode}
+        <!-- "" '' -->
+        <script>
+          window.__mdnPlayJsStarted = true;
+        </script>
         <script id="mdn-play-js" type=${defaults === "ix-wat" ? "module" : ""}>
           ${js};
         </script>
         <script id="mdn-play-js-end">
+          window.__mdnPlayJsEnded = true;
           try {
             const uuid =
               new URLSearchParams(location.search).get("uuid") || undefined;


### PR DESCRIPTION
(⚠️ Mirrored to https://github.com/mdn/dex/pull/435. ⚠️ )

### Description

Fix the Playground runner (`vendor/yari/libs/play/index.js`) so malformed HTML no longer swallows the user's JS, and warn when it still does:

- Insert `<!-- "" '' -->` after the HTML, which closes an unclosed tag, attribute value, or comment before the runner script.
- Add a sacrificial `<script></script>` so an unterminated user script does not swallow the start flag and trigger a false warning.
- Set `window.__mdnPlayJsStarted` in a script before the runner and `window.__mdnPlayJsEnded` in the script after it.
- Add a `<head>` check on `DOMContentLoaded` that warns via `console.warn` if either flag is missing.
- Add a unit test (`test/unit/play/runner.test.js`).

### Motivation

Ensure a typo like `<o` in the HTML no longer renders the JS as text, and that users get a hint in the remaining cases (e.g. an unclosed `<textarea>`), where the JS silently does not run.

### Additional details

Flags instead of marker elements: user JS that replaces the body's children (e.g. `document.body.innerHTML = ...`, as several live samples do) removes the script elements but not the flags.

Verified with headless Chrome:

| HTML | JS runs | Warning |
| --- | --- | --- |
| `<p>ok</p>` | yes | no |
| `annn <o jwj`, `<div class="`, unclosed `<!--` | yes | no |
| JS replacing `document.body` children | yes | no |
| unclosed `<textarea>`, `<template>`, `<math>` | no | yes |

The file is mirrored in `mdn/dex` (`cloud-function/src/internal/play/index.js`), which serves the runner in deployed environments, so the fix only takes effect there once mdn/dex#435 lands.

### Related issues and pull requests

Fixes #1440.
