### PR TITLE
fix(playground): render italic text as slanted in Safari

### DIFF
--- a/vendor/yari/libs/play/index.js
+++ b/vendor/yari/libs/play/index.js
@@ -347,6 +347,12 @@ export function renderHtml(state = null) {
                 body math {
                   font-size: 1.5rem;
                 }
+
+                /* Safari won't drive Inter's slnt variable axis from
+                 font-style: italic alone, so set the slant explicitly. */
+                :is(i, em, cite, dfn, var, address) {
+                  font-variation-settings: "slnt" -10;
+                }
               </style>`
             : ""
         }
@@ -389,6 +395,12 @@ export function renderHtml(state = null) {
                   padding: 1rem;
                   margin: 0;
                   box-sizing: border-box;
+                }
+
+                /* Safari won't drive Inter's slnt variable axis from
+                 font-style: italic alone, so set the slant explicitly. */
+                :is(i, em, cite, dfn, var, address) {
+                  font-variation-settings: "slnt" -10;
                 }
 
                 section {


### PR DESCRIPTION
🚧 Needs companion PR in mdn/dex 🚧  

### Description

Fix `<em>` and other italics rendering upright in interactive-example runners on Safari, by explicitly driving Inter's `slnt` variable-font axis for italic elements in the `ix-tabbed` and `ix-choice` runners.

### Motivation

The runners load Inter as a single variable `@font-face` from `Inter.var.woff2`, which exposes a `slnt` axis (`-10` to `0`) but no `ital` axis, declared as `font-style: oblique 0deg 20deg`. Safari trusts that declaration and neither drives the slant axis from `font-style: italic` nor synthesizes an oblique, so italics render upright. Chrome and Firefox slant them regardless.

### Additional details

- Confirmed by inspecting the font: `/shared-assets/fonts/Inter.var.woff2` has axes `wght 100–900` and `slnt -10 → 0` only.
- MDN content itself is unaffected because [`components/font/inter.css`](https://github.com/mdn/fred/blob/main/components/font/inter.css) ships separate real `normal`/`italic` faces; the runner can't reuse those (shared-assets only hosts the single variable file).
- Same class of bug and fix as mdn/yari#10828.

### Related issues and pull requests

Fixes #1269.