### PR TITLE
fix(baseline): update copy to reference 'browser support'

### DIFF
--- a/l10n/locales/en-US.ftl
+++ b/l10n/locales/en-US.ftl
@@ -14,7 +14,7 @@ baseline-not-extra = This feature is not Baseline because it does not work in so
 baseline-supported-in = Supported in { $browsers }
 baseline-unsupported-in = Not widely supported in { $browsers }
 baseline-supported-and-unsupported-in = Supported in { $supported }, but not widely supported in { $unsupported }
-baseline-signals = Want more support for this feature? <a data-l10n-name="link">Tell us why.</a>
+baseline-signals = Want more browser support for this feature? <a data-l10n-name="link">Tell us why.</a>
 
 homepage-hero-title = Resources for Developers,<br> by Developers
 

--- a/l10n/template.ftl
+++ b/l10n/template.ftl
@@ -10,7 +10,7 @@ baseline-not-extra = This feature is not Baseline because it does not work in so
 baseline-supported-in = Supported in { $browsers }
 baseline-unsupported-in = Not widely supported in { $browsers }
 baseline-supported-and-unsupported-in = Supported in { $supported }, but not widely supported in { $unsupported }
-baseline-signals = Want more support for this feature? <a data-l10n-name="link">Tell us why.</a>
+baseline-signals = Want more browser support for this feature? <a data-l10n-name="link">Tell us why.</a>
 homepage-hero-title = Resources for Developers,<br> by Developers
 playground-user-shared-warning = This is a user-shared playground.<br>Always inspect the code before running it.
 homepage-hero-description = Documenting <a data-l10n-name="css">CSS</a>, <a data-l10n-name="html">HTML</a>, and <a data-l10n-name="js">JavaScript</a>, since 2005.


### PR DESCRIPTION
Requested by Kadir and approved by @Rumyra in the same meeting.

There was some confusion from users about the string asking "want more support?", like it was asking if they needed support understanding the feature. "want more browser support?" clarifies it's about compatibility.

No localised versions of this string exist yet, so I haven't changed the ID.

Can be seen on a page like http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal