### PR TITLE
chore(placement): instrument pong fetch requests and errors

### DIFF
--- a/components/placement/context.js
+++ b/components/placement/context.js
@@ -78,20 +78,28 @@ export function globalPlacementContext() {
  * @returns {Promise<Placements.PlacementContextData>}
  */
 async function fetchPlacementData() {
-  const response = await fetch("/pong/get", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      keywords: [],
-      pongs: placementTypes(
-        globalThis.document.documentElement.dataset.renderer || "Unknown",
-      ),
-    }),
-  });
-
-  gleanClick(`pong: pong->fetched ${response.status}`);
+  let response;
+  try {
+    gleanClick(`pong: pong->requested`);
+    response = await fetch("/pong/get", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        keywords: [],
+        pongs: placementTypes(
+          globalThis.document.documentElement.dataset.renderer || "Unknown",
+        ),
+      }),
+    });
+    gleanClick(`pong: pong->fetched ${response.status}`);
+  } catch (error) {
+    gleanClick(
+      `pong: pong->error ${error instanceof Error ? error.name : "unknown"}`,
+    );
+    throw error;
+  }
 
   if (!response.ok) {
     throw new Error(response.statusText);


### PR DESCRIPTION
### Description

Instrument the placement (pong) fetch in `components/placement/context.js`:

- Emit `pong: pong->requested` immediately before each `/pong/get` request.
- Wrap the request in `try/catch`, emitting `pong: pong->error <name>` when it throws, and re-throw so the failure is no longer silently swallowed ahead of the `response.ok` check.

### Motivation

Make it easier to explain the mismatch between page views and the (lower) number of pong fetch requests. Today only `pong->fetched <status>` is recorded, which fires *after* a response arrives — so any drop-off before that point is invisible. Adding `pong->requested` (attempts) and `pong->error` (network/other failures) lets us line up page views → requested → fetched and see exactly where the count falls off.

### Additional details

Event funnel after this change:

- `pong->requested` — a fetch was attempted
- `pong->error <name>` — the fetch threw (e.g. `TypeError` for a network error)
- `pong->fetched <status>` — a response was received

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->