### PR TITLE
refactor(playground): port logging + refined runner errors

### DIFF
--- a/vendor/yari/libs/play/index.js
+++ b/vendor/yari/libs/play/index.js
@@ -640,10 +640,9 @@ function playSubdomain(hostname) {
 }
 
 /**
- * @param {URL} referer
+ * @param {string} hostname
  */
-function isMDNReferer(referer) {
-  const { hostname } = referer;
+function isMDNHost(hostname) {
   return (
     hostname === ORIGIN_MAIN ||
     // Review Companion (old/new).
@@ -672,19 +671,45 @@ export async function handleRunner(req, res) {
     "https://example.com",
   );
   const stateParam = url.searchParams.get("state");
+
+  if (!stateParam) {
+    console.warn("[runner] Missing state parameter");
+    return res.status(400).end();
+  }
+
   const { state, hash } = await decompressFromBase64(stateParam);
 
-  const isLocalhost = req.hostname === "localhost";
-  const hasMatchingHash = playSubdomain(req.hostname) === hash;
-  const isIframeOnMDN =
-    isMDNReferer(referer) && req.headers["sec-fetch-dest"] === "iframe";
-
-  if (
-    !stateParam ||
-    !state ||
-    (!isLocalhost && !hasMatchingHash && !isIframeOnMDN)
-  ) {
+  if (!state) {
+    console.warn("[runner] Invalid state value");
     return res.status(404).end();
+  }
+
+  if (req.hostname !== "localhost") {
+    // For security reasons, we only allow the runner:
+    // 1. on localhost (without any restrictions),
+    // 2. if the subdomain matches the hash (for embedded direct links), or
+    // 3. in iframes on MDN.
+    const subdomain = playSubdomain(req.hostname);
+
+    if (subdomain !== hash) {
+      const secFetchDest = req.headers["sec-fetch-dest"];
+
+      if (secFetchDest !== "iframe") {
+        console.warn(
+          `[runner] Disallowed Sec-Fetch-Dest (expected "iframe", was ${JSON.stringify(secFetchDest)})`,
+        );
+        return res.status(403).end();
+      }
+
+      const { hostname } = referer;
+
+      if (!isMDNHost(hostname)) {
+        console.warn(
+          `[runner] Disallowed Referer (expected MDN host, was ${JSON.stringify(hostname)})`,
+        );
+        return res.status(403).end();
+      }
+    }
   }
 
   const json = JSON.parse(state);


### PR DESCRIPTION
### Description

Port logging + refined runner errors for the Playground runner in `vendor/yari/libs/play/index.js` from mdn/yari#12645 (`enhance(libs/play): add logging + refine runner errors`). Add logging and distinguish runner responses, instead of overloading HTTP `404`. Fred's vendored copy predates that change; dex's mirror (`cloud-function/src/internal/play/index.js`) already carries it, so this converges all three.

- Split the catch-all `404` into distinct, logged cases: missing `state` -> `400`, invalid `state` -> `404`, and non-localhost/non-hash requests requiring `sec-fetch-dest: iframe` and an MDN `Referer` (else `403`), logging the offending value.
- Rename `isMDNReferer(referer)` -> `isMDNHost(hostname)`.

### Motivation

Upstream observed a significant amount of HTTP `404` responses from the Playground runner without knowing exactly why; distinguishing responses and adding logging makes the cause diagnosable and the runner harder to misconfigure, and keeps the vendored copy in sync with upstream yari/dex. The accept/reject decision is unchanged (same requests admitted as before); only response codes and logging differ, so this is a refactor.

### Additional details

Scope limited to `handleRunner` and the helper. Fred-only bits preserved: `uuid` postMessage isolation, `@import` typedefs, swallowed-`<script>` detection, and the `DecompressionStream` `eslint-disable` comments.

The change originated in yari (mdn/yari#12645, merged 2025-06-30) and reached dex via its initial bootstrap import from yari, not a separate dex PR. Prior-art check: `git log -S handleRunner` on fred's file shows only the original vendoring commit; no PR/issue records a decision to keep fred's runner minimal. Open issue #919 (`403`s on `mdnplay.dev` for a privacy-extension user whose `Referer` is likely stripped) is a rough edge of this same logic, which this PR only mirrors.

### Related issues and pull requests

Relates to mdn/yari#12645 (the upstream logging + refined runner errors this ports).

<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->