### PR TITLE
chore(content-section): remove no-op @ts-nocheck

### DIFF
--- a/components/content-section/server.js
+++ b/components/content-section/server.js
@@ -33,7 +33,6 @@ export class ContentSection extends ServerComponent {
  */
 function Prose({ id, title, content, isH3 }) {
   const level = isH3 ? 3 : 2;
-  // @ts-nocheck
   return html`<section
     class="content-section"
     aria-labelledby=${ifDefined(id ?? undefined)}


### PR DESCRIPTION
## Description

removes a `// @ts-nocheck` inside `Prose()` in `components/content-section/server.js`. its sitting mid function (between two statements). Typescript's `@ts-nocheck` only applies when placed on the first line of a file, so it currently suppresses nothing and treated as a plain comment.
