### PR TITLE
chore(baseline): hide baseline icon in sidebar

### DIFF
--- a/components/baseline-indicator/icon.css
+++ b/components/baseline-indicator/icon.css
@@ -1,0 +1,6 @@
+.left-sidebar,
+.content-section {
+  .icon.icon-baseline {
+    display: none;
+  }
+}

--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -2,6 +2,7 @@
 @import url("../prev-next/index.css");
 @import url("../notecard/index.css");
 @import url("../code-example/prism.css");
+@import url("../baseline-indicator/icon.css");
 
 .content-section {
   line-height: var(--font-line-content);

--- a/components/left-sidebar/server.css
+++ b/components/left-sidebar/server.css
@@ -1,3 +1,5 @@
+@import url("../baseline-indicator/icon.css");
+
 .left-sidebar {
   padding-bottom: 3rem;
   overflow-wrap: anywhere;


### PR DESCRIPTION
Allows us to merge and release https://github.com/mdn/rari/pull/816 without any UI changes. This is necessary to fix the type checking on https://github.com/mdn/fred/pull/1759 and above.