### PR TITLE
ci(dependabot): exclude @mdn packages from cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      exclude:
+        - "@mdn/*"
     groups:
       npm-prod:
         dependency-type: production


### PR DESCRIPTION
Part of https://github.com/mdn/fred/issues/1770