### PR TITLE
ci(tests): retry failed specs in windows

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -10,11 +10,14 @@ const READY_TIMEOUT = 60_000;
 const READY_INTERVAL = 1000;
 const READY_URL = `${baseUrl}en-US/docs/MDN/Kitchensink`;
 
+const windowsCI = process.env.CI && process.platform === "win32";
+
 /** @type {WebdriverIO.Config} */
 export const config = {
   runner: "local",
   specs: ["./test/specs/**/*.js"],
   maxInstances: 10,
+  specFileRetries: windowsCI ? 1 : 0,
   capabilities: [
     {
       browserName: "firefox",


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1777

Conditionally sets [`specFileRetries`](https://webdriver.io/docs/configuration/#specfileretries) to 1 on Windows in CI. As can be seen in https://github.com/mdn/fred/actions/runs/31490956717/job/93808952557?pr=1789#step:12:43, even though we hit the BiDi timeout, we don't after the spec auto-reruns.