### PR TITLE
fix(search): only relabel top-level Web/API as 'Web APIs'

### DIFF
--- a/test/unit/utils/mdn-url2breadcrumb.test.js
+++ b/test/unit/utils/mdn-url2breadcrumb.test.js
@@ -1,0 +1,24 @@
+import { strictEqual } from "node:assert";
+
+import { describe, it } from "node:test";
+
+import { mdnUrl2Breadcrumb } from "../../../utils/mdn-url2breadcrumb.js";
+
+describe("mdnUrl2Breadcrumb", () => {
+  it("relabels API to Web APIs for the correct paths", () => {
+    strictEqual(
+      mdnUrl2Breadcrumb(
+        "/en-US/docs/Web/API/History_API/Working_with_the_History_API",
+        "en-US",
+      ),
+      "Web APIs / History API",
+    );
+    strictEqual(
+      mdnUrl2Breadcrumb(
+        "/en-US/docs/Mozilla/Add-ons/WebExtensions/API/action/onClicked",
+        "en-US",
+      ),
+      "Mozilla / Add-ons / WebExtensions / API / action",
+    );
+  });
+});

--- a/utils/mdn-url2breadcrumb.js
+++ b/utils/mdn-url2breadcrumb.js
@@ -12,7 +12,9 @@ export function mdnUrl2Breadcrumb(url, locale) {
     .filter((p) => !["", locale, "docs"].includes(p));
 
   // Replace "API" for clarity.
-  parents = parents.map((p) => (p === "API" ? "Web APIs" : p));
+  if (parents.at(0) === "Web" && parents.at(1) === "API") {
+    parents[1] = "Web APIs";
+  }
 
   if (parents.length > 1 && parents.at(0) === "Web") {
     // Remove virtual "Web" path.


### PR DESCRIPTION
Fixes "Web APIs" showing in the breadcrumbs here:

<img width="812" height="579" alt="image" src="https://github.com/user-attachments/assets/986ffd7c-2019-42a5-9411-47704c72cb37" />
