### PR TITLE
fix(search): relabel breadcrumbs cross-locale

### DIFF
--- a/test/unit/utils/mdn-url2breadcrumb.test.js
+++ b/test/unit/utils/mdn-url2breadcrumb.test.js
@@ -5,6 +5,19 @@ import { describe, it } from "node:test";
 import { mdnUrl2Breadcrumb } from "../../../utils/mdn-url2breadcrumb.js";
 
 describe("mdnUrl2Breadcrumb", () => {
+  it("strips Web segment when unnecessary", () => {
+    strictEqual(mdnUrl2Breadcrumb("/en-US/docs/Web/HTML", "en-US"), "HTML");
+    strictEqual(mdnUrl2Breadcrumb("/en-US/docs/Web", "en-US"), "Web");
+  });
+
+  it("strips Web segment cross-locale", () => {
+    strictEqual(
+      mdnUrl2Breadcrumb("/en-US/docs/Web/HTML", "fr"),
+      "en-US / HTML",
+    );
+    strictEqual(mdnUrl2Breadcrumb("/en-US/docs/Web", "fr"), "en-US / Web");
+  });
+
   it("relabels API to Web APIs for the correct paths", () => {
     strictEqual(
       mdnUrl2Breadcrumb(
@@ -19,6 +32,16 @@ describe("mdnUrl2Breadcrumb", () => {
         "en-US",
       ),
       "Mozilla / Add-ons / WebExtensions / API / action",
+    );
+  });
+
+  it("relabels API to Web APIs cross-locale", () => {
+    strictEqual(
+      mdnUrl2Breadcrumb(
+        "/en-US/docs/Web/API/History_API/Working_with_the_History_API",
+        "fr",
+      ),
+      "en-US / Web APIs / History API",
     );
   });
 });

--- a/utils/mdn-url2breadcrumb.js
+++ b/utils/mdn-url2breadcrumb.js
@@ -9,7 +9,10 @@ export function mdnUrl2Breadcrumb(url, locale) {
   let parents = url
     .replaceAll("_", " ")
     .split("/")
-    .filter((p) => !["", locale, "docs"].includes(p));
+    .filter((p) => !["", "docs"].includes(p));
+
+  const urlLocale = parents.shift();
+  const prefix = urlLocale === locale ? [] : [urlLocale];
 
   // Replace "API" for clarity.
   if (parents.at(0) === "Web" && parents.at(1) === "API") {
@@ -26,5 +29,5 @@ export function mdnUrl2Breadcrumb(url, locale) {
     parents.splice(-1, 1);
   }
 
-  return parents.join(" / ");
+  return [...prefix, ...parents].join(" / ");
 }


### PR DESCRIPTION
Fixes breadcrumb re-labelling rules not applying cross-locale, like here:

<img width="802" height="201" alt="image" src="https://github.com/user-attachments/assets/35c3a1b4-2520-456c-b766-785bc1ad691a" />


