### PR TITLE
fix(icons): space on index sections

### DIFF
--- a/components/baseline-indicator/icon.css
+++ b/components/baseline-indicator/icon.css
@@ -8,7 +8,6 @@
 
     /* align with optical middle: */
     margin-top: -0.1em;
-    margin-left: 0.5ch;
 
     vertical-align: middle;
 

--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -399,6 +399,10 @@
     li {
       break-inside: avoid;
     }
+
+    .icon {
+      margin-left: 0.5ch;
+    }
   }
 
   /* Article footer */


### PR DESCRIPTION
Remove spacing on all baseline icons (inline icons created by the deprecated_inline macro in https://github.com/mdn/rari/pull/832 don't need it, otherwise they become very padded), and instead add a margin to all icons on index pages like https://developer.mozilla.org/en-US/docs/Web/API:

Before:

<img width="1152" height="241" alt="image" src="https://github.com/user-attachments/assets/0df0dffc-9ba6-4d86-b3e9-d097999228b6" />

After:

<img width="1152" height="241" alt="image" src="https://github.com/user-attachments/assets/6f5c84dd-baf7-4c35-af77-6e4582fe1fcf" />
