### PR TITLE
chore(sandbox): pass context to sandbox components

### DIFF
--- a/components/sandbox/class.js
+++ b/components/sandbox/class.js
@@ -2,19 +2,21 @@ export class SandboxComponent {
   /**
    * @template {typeof SandboxComponent} T
    * @this {T}
+   * @param {import("@fred").Context} context
    * @returns {ReturnType<InstanceType<T>["render"]>}
    */
-  static render() {
-    return new this().render();
+  static render(context) {
+    return new this().render(context);
   }
 
   /* eslint-disable jsdoc/reject-any-type -- abstract render is overridden by subclasses (needs a supertype) yet consumed via generic `ReturnType<...>` (needs `any`); neither `unknown` nor `never` satisfies both */
   /**
    * @abstract
+   * @param {import("@fred").Context} _context
    * @returns {any}
    */
   /* eslint-enable jsdoc/reject-any-type */
-  render() {
+  render(_context) {
     throw new Error("Must be implemented by subclass");
   }
 }

--- a/components/sandbox/server.js
+++ b/components/sandbox/server.js
@@ -5,7 +5,10 @@ import { ServerComponent } from "../server/index.js";
 import { SandboxComponent } from "./class.js";
 
 export class Sandbox extends ServerComponent {
-  render() {
+  /**
+   * @param {import("@fred").Context} context
+   */
+  render(context) {
     // @ts-expect-error
     const modulesContext = import.meta.webpackContext("../", {
       recursive: true,
@@ -42,7 +45,7 @@ export class Sandbox extends ServerComponent {
           ([name, component]) =>
             html`<section class="sandbox__section" id=${name}>
               <h1>${name}</h1>
-              ${component.render()}
+              ${component.render(context)}
             </section>`,
         )}
       </body>

--- a/entry.ssr.js
+++ b/entry.ssr.js
@@ -119,7 +119,7 @@ export async function render(path, partialContext, compilationStats) {
           }
           // @ts-expect-error
           case "Sandbox":
-            return Sandbox.render();
+            return Sandbox.render(context);
           case "SpaNotFound":
           default:
             return NotFound.render(context);


### PR DESCRIPTION
Pass the `context` to sandbox components, most useful for being able to use the `context.l10n` helpers - which a number of components depend on to render, so currently are un-renderable in the sandbox.