### PR TITLE
fix(button): make disabled state more obvious

### DIFF
--- a/components/button/element.js
+++ b/components/button/element.js
@@ -46,7 +46,7 @@ export class MDNButton extends LitElement {
    * @param {MouseEvent} event
    */
   #click(event) {
-    if (this.disabled && this.disabledReason) {
+    if (!this.href && this.disabled && this.disabledReason) {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
@@ -64,7 +64,9 @@ export class MDNButton extends LitElement {
 
   render() {
     const title =
-      this.disabled && this.disabledReason ? this.disabledReason : undefined;
+      !this.href && this.disabled && this.disabledReason
+        ? this.disabledReason
+        : undefined;
     return Button({
       label: html`<slot></slot>`,
       disabled: this.disabledReason ? false : this.disabled,

--- a/components/button/element.js
+++ b/components/button/element.js
@@ -9,6 +9,7 @@ export class MDNButton extends LitElement {
   static get properties() {
     return {
       disabled: { type: Boolean },
+      disabledReason: { type: String, attribute: "disabled-reason" },
       variant: { type: String },
       action: { type: String },
       icon: { state: true },
@@ -23,6 +24,7 @@ export class MDNButton extends LitElement {
   constructor() {
     super();
     this.disabled = false;
+    this.disabledReason = "";
     /** @type {import("@lit").TemplateResult | undefined} */
     this.icon = undefined;
     this.iconOnly = false;
@@ -40,10 +42,35 @@ export class MDNButton extends LitElement {
     this.rel = undefined;
   }
 
+  /**
+   * @param {MouseEvent} event
+   */
+  #click(event) {
+    if (this.disabled && this.disabledReason) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener("click", this.#click, { capture: true });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener("click", this.#click, { capture: true });
+  }
+
   render() {
+    const title =
+      this.disabled && this.disabledReason ? this.disabledReason : undefined;
     return Button({
       label: html`<slot></slot>`,
-      disabled: this.disabled,
+      disabled: this.disabledReason ? false : this.disabled,
+      ariaDisabled: this.disabledReason ? this.disabled : undefined,
+      ariaDescription: title,
+      title,
       icon: this.icon,
       iconOnly: this.iconOnly,
       iconPosition: this.iconPosition,

--- a/components/button/pure.js
+++ b/components/button/pure.js
@@ -10,6 +10,9 @@ import { randomIdString } from "../utils/index.js";
  * @param {boolean} [options.iconOnly]
  * @param {import("./types.js").ButtonIconPositions} [options.iconPosition]
  * @param {boolean} [options.disabled]
+ * @param {boolean} [options.ariaDisabled]
+ * @param {string} [options.ariaDescription]
+ * @param {string} [options.title]
  * @param {string} [options.href]
  * @param {string} [options.target]
  * @param {string} [options.rel]
@@ -22,6 +25,9 @@ export default function Button({
   iconOnly,
   iconPosition,
   disabled = false,
+  ariaDisabled = false,
+  ariaDescription,
+  title,
   href,
   target,
   rel,
@@ -51,6 +57,8 @@ export default function Button({
           target=${ifDefined(target)}
           rel=${ifDefined(rel)}
           aria-labelledby=${labelId}
+          aria-description=${ifDefined(ariaDescription)}
+          title=${ifDefined(title)}
           data-variant=${ifDefined(variant)}
           data-action=${ifDefined(action)}
           part="button"
@@ -63,6 +71,9 @@ export default function Button({
           class="button"
           aria-labelledby=${labelId}
           ?disabled=${disabled}
+          aria-disabled=${ariaDisabled ? "true" : nothing}
+          aria-description=${ifDefined(ariaDescription)}
+          title=${ifDefined(title)}
           data-variant=${ifDefined(variant)}
           data-action=${ifDefined(action)}
           part="button"

--- a/components/button/server.css
+++ b/components/button/server.css
@@ -123,10 +123,11 @@
 
   /* Disabled */
 
-  &[disabled] {
+  &[disabled],
+  &[aria-disabled="true"] {
     color: light-dark(var(--color-gray-40), var(--color-gray-60)) !important;
 
-    cursor: default;
+    cursor: not-allowed;
 
     background-color: light-dark(
       var(--color-gray-80),

--- a/components/interactive-example/with-choices.js
+++ b/components/interactive-example/with-choices.js
@@ -128,6 +128,7 @@ export const InteractiveExampleWithChoices = (Base) =>
               @click=${this._reset}
               variant="secondary"
               .disabled=${!this.__choiceUpdated}
+              disabled-reason=${this.l10n("interactive-example-reset-disabled")`Reset is disabled until you edit the example`}
               >${this.l10n("interactive-example-reset")`Reset`}</mdn-button
             >
           </header>

--- a/l10n/template.ftl
+++ b/l10n/template.ftl
@@ -227,6 +227,7 @@ homepage-contributor-spotlight-contributor-spotlight = Contributor Spotlight
 homepage-contributor-spotlight-get-involved = Get involved
 homepage-search-search-the-site = Search the site
 homepage-search-search = Search
+interactive-example-reset-disabled = Reset is disabled until you edit the example
 interactive-example-reset = Reset
 interactive-example-value-select = Value select
 interactive-example-the-current-value-is-not-support = The current value is not supported by your browser.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,10 @@
           ],
           "globalAttributes": [
             {
+              "name": "aria-description",
+              "description": "Defines a string value that describes or annotates the current element. [MDN reference](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description)"
+            },
+            {
               "name": "vocab",
               "description": "RDFa: default vocabulary IRI used to expand property and typeof values."
             },


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1469

We can't reduce contrast without making the button inaccessible, but I have adjusted the icon to show a prohibited cursor, and added a reason which appears in the title and a11y tree.

Been working on a proper tooltip component which will work on mobile as well as some Friday fun, but it's not quite ready yet.