### PR TITLE
feat(index): style index navigation links

### DIFF
--- a/components/content-section/server.css
+++ b/components/content-section/server.css
@@ -391,7 +391,26 @@
 
   /* Alphabetical/grouped indexes (rari `CSS_Ref`, `ListGroups`, `APIListAlpha`, `css_ref_list`) */
   .index {
-    ul {
+    .index-nav ul {
+      display: grid;
+
+      grid-template-columns: repeat(auto-fit, minmax(1.75rem, 1fr));
+
+      padding: 0;
+
+      list-style: none;
+
+      li {
+        margin: 0;
+        text-align: center;
+      }
+
+      a {
+        display: block;
+      }
+    }
+
+    > ul {
       columns: 18rem;
       column-gap: 2rem;
     }


### PR DESCRIPTION
Part of https://github.com/mdn/rari/issues/842

Adds styling for https://github.com/mdn/rari/pull/851

<img width="768" height="529" alt="image" src="https://github.com/user-attachments/assets/106cecde-4bbb-4216-96c5-c79c6835278a" />
