### PR TITLE
feat(observatory): show COEP and COOP results in scoring

### DIFF
--- a/components/observatory/constants.js
+++ b/components/observatory/constants.js
@@ -32,6 +32,8 @@ const TEST_NAMES_IN_ORDER = [
   "subresource-integrity",
   "x-content-type-options",
   "x-frame-options",
+  "cross-origin-embedder-policy",
+  "cross-origin-opener-policy",
   "cross-origin-resource-policy",
 ];
 


### PR DESCRIPTION
### Description

Update Observatory scoring table to include the Cross-Origin-Embedder-Policy (COEP) and Cross-Origin-Opener-Policy (COOP) tests, by adding `cross-origin-embedder-policy` and `cross-origin-opener-policy` to `TEST_NAMES_IN_ORDER`.

### Motivation

Ensure COEP and COOP results returned by the scanner are shown to users. `Scoring` only renders tests listed in `TEST_NAMES_IN_ORDER`, so these two results were silently dropped.

### Additional details

Both are placed next to `cross-origin-resource-policy` to keep the cross-origin tests grouped.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->