### PR TITLE
build(sandbox): add per-component preview routes

### DIFF
--- a/components/baseline-indicator/sandbox.js
+++ b/components/baseline-indicator/sandbox.js
@@ -194,18 +194,18 @@ const CASES = [
 
 export class BaselineIndicatorSandbox extends SandboxComponent {
   /**
-   * @param {import("@fred").Context} context
+   * @param {import("@fred").SandboxContext} context
    */
   render(context) {
     return html`
       <style>
-        #BaselineIndicator .baseline-indicator {
+        #host .baseline-indicator {
           max-width: var(--layout-content-max);
         }
       </style>
       ${CASES.map((testCase) => {
         const docContext =
-          /** @type {import("@fred").Context<import("@rari").DocPage>} */ ({
+          /** @type {import("./types.js").BaselineContext} */ ({
             ...context,
             doc: {
               status: { baseline: testCase.status },

--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -59,7 +59,7 @@ export class BaselineIndicator extends ServerComponent {
   }
 
   /**
-   * @param {import("@fred").Context<import("@rari").DocPage>} context
+   * @param {import("./types.js").BaselineContext} context
    * @param {boolean} [simple]
    */
   normalizeData(context, simple = false) {
@@ -204,7 +204,7 @@ export class BaselineIndicator extends ServerComponent {
   }
 
   /**
-   * @param {import("@fred").Context<import("@rari").DocPage>} context
+   * @param {import("./types.js").BaselineContext} context
    */
   render(context) {
     const data = this.normalizeData(context);
@@ -379,7 +379,7 @@ export class BaselineIndicator extends ServerComponent {
   }
 
   /**
-   * @param {import("@fred").Context<import("@rari").DocPage>} context
+   * @param {import("./types.js").BaselineContext} context
    */
   renderSimplified(context) {
     const data = this.normalizeData(context, true);

--- a/components/baseline-indicator/types.d.ts
+++ b/components/baseline-indicator/types.d.ts
@@ -1,4 +1,9 @@
-import { Support } from "@mdn/rari";
+import { Doc, Support } from "@mdn/rari";
+import { L10nContext } from "@fred";
+
+export type BaselineContext = L10nContext & {
+  doc: Pick<Doc, "baseline" | "status">;
+};
 
 export type BrowserIdentifier = keyof Support;
 export interface BrowserGroup {

--- a/components/button/sandbox.js
+++ b/components/button/sandbox.js
@@ -22,7 +22,7 @@ export class ButtonSandbox extends SandboxComponent {
 
     return html`
       <style>
-        #Button {
+        #host {
           section {
             display: flex;
             flex-wrap: wrap;

--- a/components/outer-layout/server.js
+++ b/components/outer-layout/server.js
@@ -24,7 +24,7 @@ const DEFAULT_LOCALE = "en-US";
 
 export class OuterLayout extends ServerComponent {
   /**
-   * @param {import("@fred").Context} context
+   * @param {import("@fred").RenderContext} context
    * @param {import("lit-html").TemplateResult | import("lit").nothing} markup
    */
   render(context, markup) {
@@ -163,7 +163,7 @@ export class OuterLayout extends ServerComponent {
   }
 
   /**
-   * @param {import("@fred").Context} context
+   * @param {import("@fred").RenderContext} context
    */
   _renderMeta(context) {
     const noIndexing =

--- a/components/sandbox/class.js
+++ b/components/sandbox/class.js
@@ -2,7 +2,7 @@ export class SandboxComponent {
   /**
    * @template {typeof SandboxComponent} T
    * @this {T}
-   * @param {import("@fred").Context} context
+   * @param {import("@fred").SandboxContext} context
    * @returns {ReturnType<InstanceType<T>["render"]>}
    */
   static render(context) {
@@ -12,7 +12,7 @@ export class SandboxComponent {
   /* eslint-disable jsdoc/reject-any-type -- abstract render is overridden by subclasses (needs a supertype) yet consumed via generic `ReturnType<...>` (needs `any`); neither `unknown` nor `never` satisfies both */
   /**
    * @abstract
-   * @param {import("@fred").Context} _context
+   * @param {import("@fred").SandboxContext} _context
    * @returns {any}
    */
   /* eslint-enable jsdoc/reject-any-type */

--- a/components/sandbox/server.css
+++ b/components/sandbox/server.css
@@ -18,18 +18,6 @@
   }
 }
 
-.sandbox__section {
-  display: none;
-
-  &:target {
-    display: block;
-  }
-}
-
-.sandbox__list {
-  padding: 0;
-
-  > li {
-    margin-block: 1rem;
-  }
+#host {
+  padding: 1rem;
 }

--- a/components/sandbox/server.js
+++ b/components/sandbox/server.js
@@ -4,50 +4,63 @@ import { ServerComponent } from "../server/index.js";
 
 import { SandboxComponent } from "./class.js";
 
+/**
+ * @param {unknown} value
+ * @returns {value is typeof SandboxComponent}
+ */
+function isSandboxComponent(value) {
+  return Object.getPrototypeOf(value) === SandboxComponent;
+}
+
 export class Sandbox extends ServerComponent {
   /**
-   * @param {import("@fred").Context} context
+   * @param {import("@fred").SandboxContext} context
    */
   render(context) {
-    // @ts-expect-error
-    const modulesContext = import.meta.webpackContext("../", {
-      recursive: true,
-      regExp: /\/sandbox\.js$/,
-    });
-    // @ts-expect-error
-    const modules = modulesContext.keys().map((key) => modulesContext(key));
+    const modules = /** @type {Record<string, Record<string, unknown>>} */ (
+      import.meta.glob("../**/sandbox.js", { eager: true })
+    );
+    const componentMap = new Map(
+      Object.entries(modules).flatMap(([key, module]) => {
+        const component = Object.values(module).find(isSandboxComponent);
+        const name = key.split("/").at(-2);
+        return name && component ? [[name, component]] : [];
+      }),
+    );
 
-    /** @type {(typeof SandboxComponent)[]} */
-    // @ts-expect-error
-    const components = modules.flatMap((module) =>
-      Object.values(module).filter(
-        (exported) => Object.getPrototypeOf(exported) === SandboxComponent,
-      ),
-    );
-    const componentMap = Object.fromEntries(
-      components.map((component) => [
-        component.name.replace(/Sandbox$/, ""),
-        component,
-      ]),
-    );
+    const componentNames = [...componentMap.keys()].toSorted();
+    const selectedName = context.sandbox.component;
+    const selectedComponent = selectedName
+      ? componentMap.get(selectedName)
+      : undefined;
 
     return html`
       <body class="sandbox">
         <div class="sandbox__sidebar">
           <mdn-color-theme></mdn-color-theme>
           <ul>
-            ${Object.keys(componentMap).map(
-              (name) => html`<li><a href=${`#${name}`}>${name}</a></li>`,
+            ${componentNames.map(
+              (name) =>
+                html`<li>
+                  <a href=${`/${context.locale}/sandbox/${name}`}>${name}</a>
+                </li>`,
             )}
           </ul>
         </div>
-        ${Object.entries(componentMap).map(
-          ([name, component]) =>
-            html`<section class="sandbox__section" id=${name}>
-              <h1>${name}</h1>
-              ${component.render(context)}
-            </section>`,
-        )}
+        <main id="host">
+          ${
+            selectedComponent
+              ? html`<h1>${selectedName}</h1>
+                  ${selectedComponent.render(context)}`
+              : selectedName
+                ? html`<h1>Sandbox not found</h1>
+                    <p>
+                      No sandbox named <code>${selectedName}</code> exists.
+                    </p>`
+                : html`<h1>Fred sandbox</h1>
+                    <p>Select a component to render its sandbox.</p>`
+          }
+        </main>
       </body>
     `;
   }

--- a/entry.ssr.js
+++ b/entry.ssr.js
@@ -48,6 +48,7 @@ for (const [name, def] of customElements.__definitions) {
 export async function render(path, partialContext, compilationStats) {
   const locale = path.split("/", 2)[1] || "en-US";
 
+  /** @type {import("@fred").RenderContext} */
   const context = {
     path,
     ...(await addFluent(locale)),
@@ -117,7 +118,6 @@ export async function render(path, partialContext, compilationStats) {
               `Unknown Spa Page title=${context.pageTitle}, slug=${context.slug}`,
             );
           }
-          // @ts-expect-error
           case "Sandbox":
             return Sandbox.render(context);
           case "SpaNotFound":
@@ -136,6 +136,7 @@ export async function render(path, partialContext, compilationStats) {
  */
 export async function renderSimplified(path, partialContext) {
   const locale = path.split("/", 2)[1] || "en-US";
+  /** @type {import("@fred").RenderContext} */
   const context = {
     path,
     ...(await addFluent(locale)),

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ if (process.env.NODE_ENV === "production") {
 /**
  * @param {Request} req
  * @param {Response} res
- * @param {import("@rari").BuiltPage} page
+ * @param {import("@fred").RenderPage} page
  */
 async function serverRenderMiddleware(req, res, page) {
   try {
@@ -234,6 +234,26 @@ export async function startServer() {
     next();
   });
 
+  app.get("/sandbox", (_req, res) => {
+    res.redirect(302, "/en-US/sandbox");
+  });
+
+  app.get(
+    ["/:locale/sandbox", "/:locale/sandbox/:component"],
+    async (req, res) => {
+      const { component } = req.params;
+
+      await serverRenderMiddleware(req, res, {
+        renderer: "Sandbox",
+        pageTitle: component ? `${component} sandbox` : "Fred sandbox",
+        url: req.path,
+        sandbox: {
+          component,
+        },
+      });
+    },
+  );
+
   app.use(
     createProxyMiddleware({
       target: RARI_URL,
@@ -257,14 +277,6 @@ export async function startServer() {
         proxyRes: async (proxyRes, req, res) => {
           const contentType = proxyRes.headers["content-type"] || "";
           const statusCode = proxyRes.statusCode || 500;
-
-          if (req.path === "/sandbox") {
-            return serverRenderMiddleware(req, res, {
-              // @ts-expect-error
-              renderer: "Sandbox",
-              pageTitle: "Fred sandbox",
-            });
-          }
 
           if (
             (!contentType || contentType.includes("text/plain")) &&

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "target": "esnext",
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "types": ["@wdio/globals/types", "mocha"],
+    "types": ["@rspack/core/module", "@wdio/globals/types", "mocha"],
     // fix for badly-formed types in dependencies:
     "skipLibCheck": true,
     // alias for imports:

--- a/types/fred.ts
+++ b/types/fred.ts
@@ -8,9 +8,21 @@ export type Context<T = BuiltPage> = PartialContext<T> &
     path: string;
   };
 
-export type PartialContext<T = BuiltPage> = T & {
+export type SandboxPage = {
+  renderer: "Sandbox";
+  pageTitle: string;
+  url: string;
+  sandbox: {
+    component?: string;
+  };
+};
+
+export type RenderPage = BuiltPage | SandboxPage;
+export type PartialContext<T = RenderPage> = T & {
   localServer?: boolean;
 };
+export type RenderContext = Context<RenderPage>;
+export type SandboxContext = Context<SandboxPage>;
 
 export type L10nContext = {
   locale: string;


### PR DESCRIPTION
Relates to https://github.com/mdn/fred/issues/1507 - I wanted to write some regression e2e tests before opening the PR to fix that, and this turned into a bit of a yak shaving exercise :)

Moves the "everything in one page" sandbox approach to one where each component gets its own route: this is useful for testing - e2e tests can run against these sandboxes instead of the already-overloaded Kitchensink route. Also makes the sandboxes a little nicer for us while developing components.