### PR TITLE
chore(test): support filtering spec files

### DIFF
--- a/scripts/tests.js
+++ b/scripts/tests.js
@@ -58,6 +58,16 @@ await yargs(hideBin(process.argv))
           describe: "run fred and rari from this content repo",
           type: "string",
         })
+        .option("spec", {
+          describe: "only run these spec files",
+          type: "array",
+          string: true,
+        })
+        .option("exclude", {
+          describe: "exclude these spec files",
+          type: "array",
+          string: true,
+        })
         .check((argv) => {
           if (argv.content && (argv.rari || argv.fred)) {
             throw new Error("--content cannot be used with --rari or --fred");
@@ -65,10 +75,17 @@ await yargs(hideBin(process.argv))
           return true;
         }),
     async (argv) => {
+      const wdioArgs = [
+        ...(argv.spec?.map((file) => ["spec", file]) || []),
+        ...(argv.exclude?.map((file) => ["exclude", file]) || []),
+      ]
+        .map(([option, file]) => ` --${option} ${JSON.stringify(file)}`)
+        .join("");
+
       /** @type {import("concurrently").ConcurrentlyCommandInput[]} */
       const jobs = [
         {
-          command: `npx --package=@wdio/cli wdio run wdio.conf.js`,
+          command: `npx --package=@wdio/cli wdio run wdio.conf.js${wdioArgs}`,
           name: "wdio",
           prefixColor: "green",
         },

--- a/test/README.md
+++ b/test/README.md
@@ -25,3 +25,15 @@ To run e2e tests and bring up a fred dev server and rari server:
 ```
 npm test -- e2e --fred dev --rari
 ```
+
+To run only some files:
+
+```
+npm test -- e2e --spec test/specs/playground.e2e.js
+```
+
+To exclude files:
+
+```
+npm test -- e2e --exclude test/specs/layout.e2e.js
+```


### PR DESCRIPTION
Relates to my yak shaving for https://github.com/mdn/fred/issues/1507

Very useful to be able to only run certain spec files, or filter the annoyingly long-running ones out (looking at you, `layout.e2e.js`).