### PR TITLE
test(playground): move data-url test from e2e to unit

### DIFF
--- a/components/playground/element.js
+++ b/components/playground/element.js
@@ -9,7 +9,7 @@ import warningIcon from "../icon/triangle-alert.svg?lit";
 import { globalUser } from "../user/context.js";
 
 import styles from "./element.css?lit";
-import { decompressFromBase64 } from "./utils.js";
+import { codeToDataUrl, decompressFromBase64 } from "./utils.js";
 
 import "../play-controller/element.js";
 import "../button/element.js";
@@ -135,18 +135,7 @@ ${"```"}`,
     const controller = this._controller.value;
     if (controller) {
       const { css, html, js } = controller.code;
-      let code = `<!doctype html><body>`;
-      if (css) code += `<style>${css}</style>`;
-      if (html) code += html;
-      if (js) code += `<script>${js}</script>`;
-      code += `</body>`;
-      // allowlist for characters we know not to be problematic in data urls
-      code = code.replaceAll(/[^ <>/{}=:;]+/g, (str) =>
-        encodeURIComponent(str),
-      );
-      await navigator.clipboard.writeText(
-        `data:text/html;charset=utf-8,${code}`,
-      );
+      await navigator.clipboard.writeText(codeToDataUrl({ css, html, js }));
     }
   }
 

--- a/components/playground/utils.js
+++ b/components/playground/utils.js
@@ -132,3 +132,21 @@ export async function decompressFromBase64(base64String) {
   const state = new TextDecoder().decode(await decompressedStream);
   return { state, hash };
 }
+
+/**
+ * @param {{ css?: string, html?: string, js?: string }} code
+ */
+export function codeToDataUrl({ css, html, js }) {
+  let document = "<!doctype html><body>";
+  if (css) document += `<style>${css}</style>`;
+  if (html) document += html;
+  if (js) document += `<script>${js}</script>`;
+  document += "</body>";
+
+  // Allowlist characters we know not to be problematic in data URLs.
+  document = document.replaceAll(/[^ <>/{}=:;]+/g, (text) =>
+    encodeURIComponent(text),
+  );
+
+  return `data:text/html;charset=utf-8,${document}`;
+}

--- a/test/specs/playground.e2e.js
+++ b/test/specs/playground.e2e.js
@@ -40,25 +40,5 @@ describe("Playground", () => {
         expect.stringContaining("js-contents"),
       );
     });
-
-    it("should only uri-encode characters outside the allowlist", async () => {
-      await $(`mdn-play-editor[language="html"]`).click();
-      await browser.keys("@\n@ @%20 @");
-      await $(`mdn-play-editor[language="css"]`).click();
-      await browser.keys("body {\n  font-size: 5em;\n}");
-
-      await $(`[data-id="share"]:not([disabled])`).click();
-      await $(`[data-glean-id="playground: share-data-url"]`).click();
-
-      // will cause a webdriver error about permissions, but we've set them in firefox through about:config
-      await expect(browser).toHaveClipboardText(
-        expect.stringContaining("%40%0A%40 %40%2520 %40"),
-      );
-      await expect(browser).toHaveClipboardText(
-        expect.stringContaining(
-          "<style>body {%0A  font-size: 5em;%0A}</style>",
-        ),
-      );
-    });
   });
 });

--- a/test/unit/components/playground.test.js
+++ b/test/unit/components/playground.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+
+import { describe, it } from "node:test";
+
+import { codeToDataUrl } from "../../../components/playground/utils.js";
+
+describe("playground", () => {
+  describe("codeToDataUrl", () => {
+    it("only URI-encodes characters outside the allowlist", () => {
+      const dataUrl = codeToDataUrl({
+        html: "@\n@ @%20 @",
+        css: "body {\n  font-size: 5em;\n}",
+        js: "",
+      });
+
+      assert.equal(
+        dataUrl,
+        "data:text/html;charset=utf-8," +
+          "<!doctype html><body>" +
+          "<style>body {%0A  font-size: 5em;%0A}</style>" +
+          "%40%0A%40 %40%2520 %40" +
+          "</body>",
+      );
+    });
+  });
+});


### PR DESCRIPTION
This is something I said I'd do as a follow up to a PR review too long ago :)

Doing now because I want to update the playground tests a bit for https://github.com/mdn/fred/issues/1507, and there's no need/point in having this hang around in there.