### PR TITLE
fix(baseline): add `<code>` styling to discouraged reason

### DIFF
--- a/components/baseline-indicator/sandbox.js
+++ b/components/baseline-indicator/sandbox.js
@@ -46,7 +46,7 @@ const ALTERNATIVES = [
 ];
 
 const REASON_HTML =
-  "It was replaced by a standardised equivalent that browsers implement consistently.";
+  "This reason comes from upstream and can include <code>&lt;code&gt;</code> blocks.";
 
 /**
  * @param {Partial<import("@rari").FeatureData>} [overrides]

--- a/components/baseline-indicator/server.css
+++ b/components/baseline-indicator/server.css
@@ -34,7 +34,7 @@
     var(--baseline-color-gray-90),
     var(--baseline-color-gray-10)
   );
-  --baseline-engine-bg: light-dark(
+  --baseline-bg-secondary: light-dark(
     oklch(0% 0 0deg / 6%),
     oklch(100% 0 0deg / 6%)
   );
@@ -239,7 +239,7 @@
 
         padding: 0.5rem 0.625rem;
 
-        background: var(--baseline-engine-bg);
+        background: var(--baseline-bg-secondary);
         border-radius: 2rem;
 
         .browser {
@@ -324,9 +324,18 @@
       font-weight: 500;
     }
 
-    p {
+    > p {
       margin-top: 0;
       margin-bottom: 1rem;
+
+      code {
+        padding: 0.125em 0.25em;
+
+        font-family: var(--font-family-code);
+
+        background: var(--baseline-bg-secondary);
+        border-radius: var(--radius-normal);
+      }
     }
 
     .asterisk-note {


### PR DESCRIPTION
Follow up: https://github.com/mdn/fred/pull/1821#issuecomment-5527963058

From http://localhost:3000/en-US/sandbox/baseline-indicator:

<img width="768" height="178" alt="Screen Shot 2026-09-03 at 16 48 10" src="https://github.com/user-attachments/assets/ade11824-0adb-4110-925d-2f82a550256a" />
<img width="768" height="178" alt="Screen Shot 2026-09-03 at 16 47 58" src="https://github.com/user-attachments/assets/4bb55c40-2cd7-4ab6-b326-2c3ea05d4ec3" />
