### PR TITLE
fix(baseline): add lang attribute to discouraged reason

### DIFF
--- a/components/baseline-indicator/server.js
+++ b/components/baseline-indicator/server.js
@@ -129,6 +129,7 @@ export class BaselineIndicator extends ServerComponent {
       }
     }
     if (isDiscouraged) {
+      const reason = feature?.discouraged?.reason_html;
       extraText.push(
         html`${
           status === "removing"
@@ -139,7 +140,7 @@ export class BaselineIndicator extends ServerComponent {
                 "baseline-indicator-avoid-using",
               )`Avoid using this feature in new projects.`
         }
-        ${unsafeHTML(feature?.discouraged?.reason_html || nothing)}
+        ${reason ? html`<span lang="en-US">${unsafeHTML(reason)}</span>` : nothing}
         ${
           status === "removing"
             ? nothing


### PR DESCRIPTION
Follow up: https://github.com/mdn/fred/pull/1821#issuecomment-5527790107

Until we add a pipeline for localising these strings, they'll always appear in english.