### PR TITLE
build(stylelint): ignore `@mixin` in `at-rule-prelude-no-invalid`

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -26,5 +26,6 @@ export default {
     "selector-id-pattern": null,
     "font-family-name-quotes": "always-unless-keyword",
     "at-rule-no-unknown": [true, { ignoreAtRules: ["mixin"] }],
+    "at-rule-prelude-no-invalid": [true, { ignoreAtRules: ["media", "mixin"] }],
   },
 };


### PR DESCRIPTION
### Description

Update the stylelint config to add `mixin` to `ignoreAtRules` for `at-rule-prelude-no-invalid`, mirroring the existing `at-rule-no-unknown` entry.

### Motivation

Prevent 34 false-positive stylelint errors that appear as soon as stylelint is bumped to 17.15.0.

stylelint 17.15.0 bumps `@csstools/css-syntax-patches-for-csstree` from `^1.1.6` to `^1.1.9`, and 1.1.9 added a prelude grammar for the native CSS `@mixin` at-rule:

```json
"mixin": { "prelude": "[ <function-token> <function-parameter>#? ) | <ident-token> ]" }
```

1.1.6 had no `mixin` entry, so the rule skipped the at-rule entirely. Now that a grammar exists, every `@mixin` gets validated against it.

Our `@mixin` is not the native one, it comes from [`postcss-mixins`](https://github.com/postcss/postcss-mixins), whose call syntax is `@mixin <name> <arg>, <arg>`. That matches neither branch of the native grammar, and `postcss-mixins` has no function-call form to switch to. All 34 errors are the single `light-dark` mixin defined in `rspack.config.js`.

### Additional details

Note that `ignoreAtRules` replaces rather than extends, so `media` is repeated to preserve the default from `stylelint-config-recommended`.

Verified the full lint suite passes both with stylelint 17.14.1 (current `main`) and 17.15.0.

### Related issues and pull requests

Relates to #1858.