### PR TITLE
ci(pr-review): drop `--comments` from `gh pr view --json comments`

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Comment in PR
         run: |
-          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --comments --json comments \
+          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json comments \
             --jq ".comments | sort_by(.createdAt) | map(select(.author.login == \"github-actions\")) | .[0].id")
           if [ -n "$COMMENT_ID" ]; then
             gh api graphql -f query='


### PR DESCRIPTION
### Description

Drop the redundant `--comments` flag from the `gh pr view ... --json comments` call in the "Comment in PR" step of the PR review companion workflow.

### Motivation

Prevent the step from failing on the ubuntu-24.04 runner image, which ships GitHub CLI 2.99.0. This version rejects combining `--comments` with `--json`:

```
specify only one of --comments or --json
```

### Additional details

`--json comments` already returns the comments, so the `--comments` flag was a no-op on older `gh` versions. See cli/cli#14215.

### Related issues and pull requests

Part of mdn/fred#1873.