### PR TITLE
feat(eslint): add `fred/no-external-link-whitespace` rule

### DIFF
--- a/build/eslint-fred.js
+++ b/build/eslint-fred.js
@@ -116,6 +116,53 @@ export default {
         };
       },
     },
+    "no-external-link-whitespace": {
+      meta: {
+        type: "problem",
+        fixable: "whitespace",
+        docs: {
+          description:
+            "disallow leading/trailing whitespace inside external links, so the icon stays attached to the last word",
+        },
+      },
+      create(context) {
+        return {
+          /**
+           * @param {import("estree").TaggedTemplateExpression} node
+           */
+          TaggedTemplateExpression(node) {
+            if (node.tag.type !== "Identifier" || node.tag.name !== "html") {
+              return;
+            }
+
+            const { quasis, expressions } = node.quasi;
+            const { source, segments } = flattenTemplate(quasis);
+            const sourceCode = /** @type {import("eslint").SourceCode} */ (
+              context.sourceCode
+            );
+
+            for (const anchor of findExternalAnchors(source, (index) =>
+              sourceCode.getText(expressions[index]),
+            )) {
+              const ranges = anchor.whitespace.map((range) =>
+                toSourceRange(segments, range),
+              );
+              const [start, end] = toSourceRange(segments, anchor.span);
+              context.report({
+                node,
+                loc: {
+                  start: sourceCode.getLocFromIndex(start),
+                  end: sourceCode.getLocFromIndex(end),
+                },
+                message:
+                  "External links must not start or end with whitespace, otherwise the icon wraps onto its own line.",
+                fix: (fixer) => ranges.map((range) => fixer.removeRange(range)),
+              });
+            }
+          },
+        };
+      },
+    },
     "server-html-import": {
       meta: {
         type: "problem",
@@ -161,4 +208,118 @@ function getClassNames(node) {
     node.id?.name || "",
     node.superClass?.type === "Identifier" ? node.superClass.name : undefined,
   ];
+}
+
+const PLACEHOLDER = "$__fred_expr_";
+const PLACEHOLDER_RE = new RegExp(`\\${PLACEHOLDER}(\\d+)__`, "g");
+
+/**
+ * Joins the raw template chunks into one HTML string, replacing each
+ * `${}` with a placeholder that contains neither whitespace nor `>`.
+ * @param {import("estree").TemplateElement[]} quasis
+ * @returns {{ source: string, segments: Array<[number, number, number]> }}
+ * `segments` maps `[startInSource, endInSource, startInFile]` per chunk.
+ */
+function flattenTemplate(quasis) {
+  let source = "";
+  /** @type {Array<[number, number, number]>} */
+  const segments = [];
+  for (const [index, quasi] of quasis.entries()) {
+    const raw = quasi.value.raw;
+    // `range` excludes the backtick / `${` / `}` delimiters.
+    const fileStart = /** @type {[number, number]} */ (quasi.range)[0] + 1;
+    segments.push([source.length, source.length + raw.length, fileStart]);
+    source += raw;
+    if (index < quasis.length - 1) {
+      source += `${PLACEHOLDER}${index}__`;
+    }
+  }
+  return { source, segments };
+}
+
+/**
+ * @param {Array<[number, number, number]>} segments
+ * @param {[number, number]} range
+ * @returns {[number, number]}
+ */
+function toSourceRange(segments, [start, end]) {
+  return [toSourceOffset(segments, start), toSourceOffset(segments, end)];
+}
+
+/**
+ * @param {Array<[number, number, number]>} segments
+ * @param {number} offset
+ */
+function toSourceOffset(segments, offset) {
+  const segment = segments.find(
+    ([start, end]) => offset >= start && offset <= end,
+  );
+  if (!segment) {
+    throw new Error(`Offset ${offset} is inside a template expression`);
+  }
+  return segment[2] + (offset - segment[0]);
+}
+
+const ANCHOR_RE = /<a\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/a\s*>/g;
+const CLASS_RE = /\bclass\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+))/;
+
+/**
+ * @typedef {object} ExternalAnchor
+ * @property {Array<[number, number]>} whitespace offsets (in `source`) of the
+ * leading and/or trailing whitespace of an offending external anchor
+ * @property {[number, number]} span covers all `whitespace` ranges, for reporting
+ */
+
+/**
+ * @param {string} source
+ * @param {(index: number) => string} getExpressionText
+ * @returns {ExternalAnchor[]}
+ */
+function findExternalAnchors(source, getExpressionText) {
+  /** @type {ExternalAnchor[]} */
+  const anchors = [];
+  for (const match of source.matchAll(ANCHOR_RE)) {
+    const attributes = match[1] ?? "";
+    const body = match[2] ?? "";
+    if (!isExternal(attributes, getExpressionText)) {
+      continue;
+    }
+    const bodyStart =
+      match.index + "<a".length + attributes.length + ">".length;
+    const bodyEnd = bodyStart + body.length;
+    const leading = /^\s+/.exec(body);
+    const trailing = /\s+$/.exec(body);
+    /** @type {Array<[number, number]>} */
+    const whitespace = [];
+    if (leading) {
+      whitespace.push([bodyStart, bodyStart + leading[0].length]);
+    }
+    if (trailing && !(leading && leading[0].length === body.length)) {
+      whitespace.push([bodyEnd - trailing[0].length, bodyEnd]);
+    }
+    const first = whitespace[0];
+    const last = whitespace.at(-1);
+    if (first && last) {
+      anchors.push({ whitespace, span: [first[0], last[1]] });
+    }
+  }
+  return anchors;
+}
+
+/**
+ * An anchor is external when its class contains the `external` token,
+ * either literally or in the source of an interpolated expression.
+ * @param {string} attributes
+ * @param {(index: number) => string} getExpressionText
+ */
+function isExternal(attributes, getExpressionText) {
+  const match = CLASS_RE.exec(attributes);
+  if (!match) {
+    return false;
+  }
+  const value = match[1] ?? match[2] ?? match[3] ?? "";
+  const expanded = value.replaceAll(PLACEHOLDER_RE, (_, index) =>
+    getExpressionText(Number(index)),
+  );
+  return /\bexternal\b/.test(expanded);
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,7 @@ export default defineConfig([
       "fred/server-component-name": "error",
       "fred/sandbox-component-name": "error",
       "fred/server-html-import": "error",
+      "fred/no-external-link-whitespace": "warn",
     },
   },
   {

--- a/test/unit/build/eslint-fred.test.js
+++ b/test/unit/build/eslint-fred.test.js
@@ -1,0 +1,133 @@
+import { describe, it } from "node:test";
+
+import { RuleTester } from "eslint";
+
+import fred from "../../../build/eslint-fred.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+});
+
+const rule = fred.rules?.["no-external-link-whitespace"];
+if (!rule) {
+  throw new Error("Rule `no-external-link-whitespace` is not registered");
+}
+
+const message =
+  "External links must not start or end with whitespace, otherwise the icon wraps onto its own line.";
+
+ruleTester.run("no-external-link-whitespace", rule, {
+  valid: [
+    {
+      name: "static class without whitespace",
+      code: 'html`<a class="external" href="https://example.com">Link</a>`;',
+    },
+    {
+      name: "expression body without whitespace",
+      code: 'html`<a class="external" href=${href}>${text}</a>`;',
+    },
+    {
+      name: "prettier-style formatting without inner whitespace",
+      code: `html\`<a
+        class="external"
+        href=\${href}
+        >\${text}</a
+      >\`;`,
+    },
+    {
+      name: "non-external anchor with whitespace",
+      code: 'html`<a href="/foo"> Link </a>`;',
+    },
+    {
+      name: "class that merely contains the substring",
+      code: 'html`<a class="externalize"> Link </a>`;',
+    },
+    {
+      name: "class expression that does not mention external",
+      code: "html`<a class=${className} href=${href}> Link </a>`;",
+    },
+    {
+      name: "non-html template tag",
+      code: 'css`<a class="external"> Link </a>`;',
+    },
+    {
+      name: "nested content without whitespace",
+      code: 'html`<a class="external"><span>Link</span><i></i></a>`;',
+    },
+  ],
+  invalid: [
+    {
+      name: "trailing newline (static class)",
+      code: 'html`<a class="external" href="https://example.com">Link\n</a>`;',
+      output: 'html`<a class="external" href="https://example.com">Link</a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "leading space",
+      code: 'html`<a class="external"> Link</a>`;',
+      output: 'html`<a class="external">Link</a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "leading and trailing whitespace around an expression",
+      code: 'html`<a class="external" href=${href}>\n  ${text}\n</a>`;',
+      output: 'html`<a class="external" href=${href}>${text}</a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "conditional class expression",
+      code: 'html`<a class=${link.external ? "external" : ""}>\n  ${link.text}\n</a>`;',
+      output:
+        'html`<a class=${link.external ? "external" : ""}>${link.text}</a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "class with literal and expression",
+      code: 'html`<a class="external ${className}"> ${content} </a>`;',
+      output: 'html`<a class="external ${className}">${content}</a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "multiple classes",
+      code: 'html`<a class="bc-github-link external external-icon">\n  ${text}\n</a>`;',
+      output:
+        'html`<a class="bc-github-link external external-icon">${text}</a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "whitespace-only body",
+      code: 'html`<a class="external"> </a>`;',
+      output: 'html`<a class="external"></a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "nested elements",
+      code: 'html`<a class="external">\n  <div class="x"></div>\n  <span>${text}</span>\n</a>`;',
+      output:
+        'html`<a class="external"><div class="x"></div>\n  <span>${text}</span></a>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "closing tag split across lines",
+      code: 'html`<a class="external">Link </a\n>`;',
+      output: 'html`<a class="external">Link</a\n>`;',
+      errors: [{ message }],
+    },
+    {
+      name: "two anchors in one template",
+      code: 'html`<a class="external">A </a><a class="external"> B</a>`;',
+      output: 'html`<a class="external">A</a><a class="external">B</a>`;',
+      errors: [{ message }, { message }],
+    },
+    {
+      name: "attribute value containing a closing angle bracket",
+      code: 'html`<a class="external" data-glean-id=${`footer: link -> ${href}`}>\n  ${text}\n</a>`;',
+      output:
+        'html`<a class="external" data-glean-id=${`footer: link -> ${href}`}>${text}</a>`;',
+      errors: [{ message }],
+    },
+  ],
+});


### PR DESCRIPTION
### Description

Add a custom ESLint rule `fred/no-external-link-whitespace` that flags `<a>` elements with the `external` class inside `html` templates whose content starts or ends with whitespace, with an autofix that strips it.

- Rule + `RuleTester` unit tests in `build/eslint-fred.js` and `test/unit/build/eslint-fred.test.js`.
- Enable the rule in `eslint.config.js` as `warn`, so it can land before the 14 existing violations are fixed.

### Motivation

Ensure the external-link icon stays attached to the last word of the link. Whitespace before `</a>` renders as a space, so when the link text wraps, the icon drops onto its own line. Prettier introduces this whitespace whenever it wraps the link text onto its own line, so a lint rule is needed to keep it out.

### Additional details

Prettier does not reintroduce the whitespace once removed: it formats a whitespace-free anchor as `>${text}</a\n>`, so the rule and the formatter are stable together.

Rari does not add whitespace to external links, and a scan of a fresh en-US content build found only one external link out of about 30k with trailing whitespace, so the templates in this repo are the main source.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
