### PR TITLE
fix(server): 404 unmatched `/static/*` before rari proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -147,6 +147,13 @@ export async function startServer() {
 
   app.use("/", express.static(FRED_BUILD_ROOT));
 
+  // Anything under /static/* not found on disk (e.g. before the dev compiler
+  // finishes, or a stale hashed chunk name) shouldn't fall through to the
+  // rari proxy below, which logs "invalid locale: static" errors for it.
+  app.use("/static/*_", (_req, res) => {
+    res.writeHead(404).end();
+  });
+
   app.get("/", async (_req, res, _next) => {
     res.writeHead(302, {
       Location: "/en-US/",


### PR DESCRIPTION
### Description

Add a terminal 404 handler for `/static/*` right after `express.static(FRED_BUILD_ROOT)` (and the dev middleware), before the rari catch-all proxy.

### Motivation

Requests for `/static/*` not found on disk (e.g. before the dev compiler finishes, or a stale hashed chunk name) fell through past `express.static` to the catch-all rari proxy, which logged `invalid locale: static` errors for them.

### Additional details

The playground (`play`) app doesn't need the same guard: it has no `express.static` and never serves anything under `/static`, so its catch-all proxy to rari for live-sample assets is unaffected.

### Related issues and pull requests

Related to mdn/rari#932.