### PR TITLE
fix(search): rename modal ID to `mdn-search`

### DIFF
--- a/components/a11y-menu/server.js
+++ b/components/a11y-menu/server.js
@@ -16,7 +16,7 @@ export class A11yMenu extends ServerComponent {
         >
       </li>
       <li>
-        <a href="#search" data-glean-id="a11y_menu: click #search"
+        <a href="#mdn-search" data-glean-id="a11y_menu: click #search"
           >${context.l10n("a11y-menu-skip-to-search")`Skip to search`}</a
         >
       </li>

--- a/components/homepage-search/element.js
+++ b/components/homepage-search/element.js
@@ -9,7 +9,7 @@ export class MDNHomepageSearch extends L10nMixin(LitElement) {
   static styles = styles;
 
   _showModal() {
-    const search = document.querySelector("#search");
+    const search = document.querySelector("#mdn-search");
     if (search instanceof MDNSearchModal) {
       search.showModal();
     } else {

--- a/components/navigation/server.js
+++ b/components/navigation/server.js
@@ -41,7 +41,7 @@ export class Navigation extends ServerComponent {
           ${WRITER_MODE ? nothing : html`<mdn-user-menu></mdn-user-menu>`}
         </div>
       </nav>
-      <mdn-search-modal id="search"></mdn-search-modal>
+      <mdn-search-modal id="mdn-search"></mdn-search-modal>
     `;
   }
 }

--- a/components/search-button/element.js
+++ b/components/search-button/element.js
@@ -10,7 +10,7 @@ export class MDNSearchButton extends L10nMixin(LitElement) {
   static styles = styles;
 
   _showModal() {
-    const search = document.querySelector("#search");
+    const search = document.querySelector("#mdn-search");
     if (search instanceof MDNSearchModal) {
       search.showModal();
     } else {

--- a/hooks/skip-to-search.js
+++ b/hooks/skip-to-search.js
@@ -1,9 +1,9 @@
 import { MDNSearchModal } from "../components/search-modal/element.js";
 
-const skipToSearch = document.querySelector(`.a11y-menu a[href="#search"]`);
+const skipToSearch = document.querySelector(`.a11y-menu a[href="#mdn-search"]`);
 
 if (skipToSearch instanceof HTMLAnchorElement) {
-  const search = document.querySelector("#search");
+  const search = document.querySelector("#mdn-search");
 
   if (search instanceof MDNSearchModal) {
     skipToSearch.addEventListener("click", (event) => {


### PR DESCRIPTION
### Description

Update the site search modal ID to `mdn-search` and adjust search buttons, the accessibility link, and the skip-to-search handler.

### Motivation

Prevent collisions with article anchors named `search`, such as the definition on the HTML `rel` reference page.

### Additional details

ESLint, Prettier, Lit analyzer, and `git diff --check` pass. Browser testing remains.

### Related issues and pull requests

Fixes #1891.
