### PR TITLE
ci(dependabot): make our ignores explicit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      # matches .nvmrc
+      - dependency-name: "@types/node"
+        versions: [">=25"]
+      # https://github.com/mdn/fred/issues/1704
+      - dependency-name: "typescript"
+        versions: [">=7"]
+      # need to fix lint breakage before updating
+      - dependency-name: "eslint-plugin-unicorn"
+        versions: [">65.0.1"]
     cooldown:
       exclude:
         - "@mdn/*"


### PR DESCRIPTION
At least one security alert wasn't automatically closed by a dependency bump because we had a stale `@rsdoctor/rspack-plugin` ignore condition hanging around.

I've gone through and removed all the comment-based ignore conditions which no longer seem necessary, so with our latest run [we had](https://github.com/mdn/fred/actions/runs/34581613076/job/103206231941#step:3:34):

`ignore-conditions":[{"dependency-name":"@types/node","version-requirement":">= 25.a, < 26","update-types":null,"source":"@dependabot ignore command","updated-at":"2025-12-11T08:38:29.000Z"},{"dependency-name":"@types/node","version-requirement":">= 26.a, < 27","update-types":null,"source":"@dependabot ignore command","updated-at":"2026-06-24T14:17:30.000Z"},{"dependency-name":"eslint-plugin-unicorn","version-requirement":"> 65.0.1","update-types":null,"source":"@dependabot ignore command","updated-at":"2026-07-03T11:45:53.000Z"},{"dependency-name":"eslint-plugin-unicorn","version-requirement":">= 69.a, < 70","update-types":null,"source":"@dependabot ignore command","updated-at":"2026-06-30T14:43:40.000Z"},{"dependency-name":"typescript","version-requirement":">= 7.a, < 8","update-types":null,"source":"@dependabot ignore command","updated-at":"2026-07-09T11:16:40.000Z"}]`

This makes these more visible by adding them to `dependabot.yml` - and I'd suggest we have a soft policy going forward of only temporarily adding comment-based ignores (e.g. to allow a grouped update to proceed if there's one misbehaving dependency) and then immediately un-ignoring them. Anything longer-running (like ensuring our node types match our node version) should be immortalised in `dependabot.yml`

Once merged I'll remove all those comment-based ignore conditions.