### PR TITLE
chore(eslint): disable jsdoc/multiline-blocks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ export default defineConfig([
         "error",
         { definedTags: ["element", "attr", "slot"] },
       ],
+      "jsdoc/multiline-blocks": "off",
       "lit/no-template-map": "off",
       "lit/prefer-query-decorators": "off",
       "no-restricted-syntax": [


### PR DESCRIPTION
Follow up to https://github.com/mdn/fred/pull/1895#discussion_r3987795713

Ignoring this rule is necessary for autofixing with a new unicorn version, because it was reformatting nice lines like:

```
/** @type {HTMLDialogElement} */
```

into:

```
/**
@type {HTMLDialogElement}
*/
```

And even if the reformatting wasn't broken, I don't think there's anything wrong with single line jsdoc comments - especially when we use them for type hinting so often as we do.